### PR TITLE
feat(processor): improve adaptive filter tuning with speech metrics and noise-aware thresholds

### DIFF
--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -295,8 +295,8 @@ func DefaultFilterConfig() *FilterChainConfig {
 		NoiseRemovePatchSec:         0.006,   // 6ms patch (fast-compand validated)
 		NoiseRemoveResearchSec:      0.0058,  // 5.8ms research (fast-compand validated)
 		NoiseRemoveSmooth:           11.0,    // Default smoothing
-		NoiseRemoveCompandThreshold: -50.0,   // Overridden by adaptive tuning
-		NoiseRemoveCompandExpansion: 10.0,    // Overridden by adaptive tuning
+		NoiseRemoveCompandThreshold: -55.0,   // Overridden by adaptive tuning
+		NoiseRemoveCompandExpansion: 6.0,     // Overridden by adaptive tuning
 		NoiseRemoveCompandAttack:    0.005,   // 5ms - fixed, empirically validated for speech
 		NoiseRemoveCompandDecay:     0.100,   // 100ms - fixed, empirically validated for speech
 		NoiseRemoveCompandKnee:      6.0,     // 6dB - fixed, soft knee for transparency
@@ -330,7 +330,7 @@ func DefaultFilterConfig() *FilterChainConfig {
 		LA2AMix:       1.0, // 100% wet (true LA-2A has no parallel compression)
 
 		// De-esser - automatic sibilance reduction
-		DeessEnabled:   false,
+		DeessEnabled:   true,
 		DeessIntensity: 0.0, // 0.0 = disabled by default, will be set adaptively if enabled
 		DeessAmount:    0.5, // 50% ducking on treble (moderate reduction)
 		DeessFreq:      0.5, // Keep 50% of original frequency content (balanced)


### PR DESCRIPTION
## Summary

This PR enhances the adaptive filter tuning system to use more accurate measurements for filter parameter selection:

- **NoiseRemove adaptive thresholding**: Replace fixed compand parameters with values derived from measured noise floor during silence analysis. Threshold scales to `noise_floor + 5dB` (clamped to `[-70dB, -40dB]`) and expansion scales from 4-12dB based on noise severity across 4 tiers.

- **Speech-specific spectral metrics**: Filters that process speech content now prefer metrics from `SpeechProfile` (speech-only regions) over full-file measurements. This provides more accurate tuning for `tuneDeesserFull`, `tuneLA2ARatio`, `tuneLA2ARelease`, and `tuneDC1Declick`.

- **Fallback handling**: Both improvements gracefully fall back to previous behavior when noise profile or speech metrics are unavailable.

## Problem Solved

Previous adaptive tuning used full-file spectral measurements diluted by silence periods and fixed noise reduction parameters regardless of actual recording characteristics. This caused:
- Clean recordings received no adaptive benefit
- Noisy recordings could have speech unnecessarily affected
- Filter parameters were not optimally tuned to actual content

## Changes

- `internal/processor/adaptive.go`: Core adaptive logic with `preferSpeechMetric()` helper and updated `tuneNoiseRemove()`
- `internal/processor/adaptive_test.go`: 12 new test cases for metric preference and expansion scaling
- `internal/processor/filters.go`: Updated default NoiseRemove config values
- `internal/logging/report.go`: Enhanced rationale logging for adaptive decisions

## Testing

- `just test` passes with all new and existing tests
- Tests cover edge cases: zero values, negative values, unavailable metrics, and all expansion tiers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves adaptive filter tuning with speech-aware metrics and noise-aware compand thresholds for more transparent, consistent processing. Speech filters now use measurements from speech regions, and noise reduction adjusts to the actual noise floor.

- **New Features**
  - NoiseRemove compand: threshold = noise floor + 5 dB (clamped to [-70, -40]); expansion scales 4–12 dB by noise severity; falls back to -55 dB/6 dB without a noise profile.
  - Prefer SpeechProfile metrics for speech filters: de-esser (centroid, rolloff), LA‑2A ratio (kurtosis), LA‑2A release (flux), DC‑1 declick (centroid).
  - Logging shows measurement sources and adaptive rationale for decisions.
  - Defaults updated: de-esser enabled; compand defaults set to -55 dB threshold and 6 dB expansion.

<sup>Written for commit 7183b892be3e7a6d7f26fbc2b272b5cc2bc7d869. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

