### PR TITLE
feat(processor): add breath reduction enhancement to DS201 gate filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,15 @@ Processing goroutine communicates via typed messages:
 Filter parameters adapt based on Pass 1 measurements (see `adaptive.go`):
 
 - **Highpass frequency:** 60-120Hz based on spectral centroid and LUFS gap
-- **NoiseRemove compand:** Threshold and expansion derived from measured noise floor
-- **De-esser intensity:** 0.0-0.6 based on spectral centroid + rolloff
-- **Gate threshold:** Derived from measured noise floor
+- **NoiseRemove compand:** Adaptive thresholding (noise floor + 5 dB, clamped [-70, -40]), expansion scales 4-12 dB based on noise severity
+- **De-esser intensity:** 0.0-0.6 based on spectral centroid + rolloff (prefers `SpeechProfile` metrics when available)
+- **Gate threshold:** Derived from measured noise floor; with breath reduction enabled, positioned at 60% of gap between noise floor and quiet speech level (`SpeechProfile.RMSLevel - CrestFactor`), using firmer ratio (1.5x, clamped 2.0-4.0) and deeper range (+6 dB)
+- **LA-2A ratio/release:** Adapts based on kurtosis and flux from `SpeechProfile` when available
+- **DC-1 declick:** Uses spectral centroid from `SpeechProfile` when available
+
+**Speech-aware metrics:** Filters processing speech content prefer `SpeechProfile` measurements (speech-only regions) over full-file analysis. Graceful fallback when speech metrics unavailable.
+
+**Breath reduction:** Enabled by default (`--breath-reduction` / `--no-breath-reduction`). Requires `SpeechProfile` to calculate quiet speech level for adaptive gate threshold.
 
 ## Release workflow
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -22,10 +22,11 @@ var version = "dev"
 
 // CLI defines the command-line interface
 type CLI struct {
-	Version bool     `short:"v" help:"Show version information"`
-	Debug   bool     `short:"d" help:"Enable debug logging to jivetalking-debug.log"`
-	Logs    bool     `help:"Save detailed analysis logs"`
-	Files   []string `arg:"" name:"files" help:"Audio files to process" type:"existingfile" optional:""`
+	Version         bool     `short:"v" help:"Show version information"`
+	Debug           bool     `short:"d" help:"Enable debug logging to jivetalking-debug.log"`
+	Logs            bool     `help:"Save detailed analysis logs"`
+	BreathReduction bool     `help:"Enable breath reduction in gate" default:"true" negatable:""`
+	Files           []string `arg:"" name:"files" help:"Audio files to process" type:"existingfile" optional:""`
 }
 
 func main() {
@@ -59,6 +60,7 @@ func main() {
 
 	// Create default filter configuration
 	config := processor.DefaultFilterConfig()
+	config.BreathReductionEnabled = cliArgs.BreathReduction
 
 	// Open debug log file if --debug flag is set
 	var debugLog *os.File

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -803,6 +803,20 @@ func formatDS201GateFilter(f *os.File, cfg *processor.FilterChainConfig, m *proc
 			fmt.Fprintf(f, "        Rationale: %s\n", strings.Join(rationale, ", "))
 		}
 	}
+
+	// Breath reduction status and threshold derivation
+	if cfg.BreathReductionEnabled {
+		if m != nil && m.SpeechProfile != nil {
+			quietSpeechDB := m.SpeechProfile.RMSLevel - m.SpeechProfile.CrestFactor
+			fmt.Fprintf(f, "        breath reduction: ACTIVE\n")
+			fmt.Fprintf(f, "        quiet speech level: %.1f dBFS (RMS %.1f - crest %.1f)\n",
+				quietSpeechDB, m.SpeechProfile.RMSLevel, m.SpeechProfile.CrestFactor)
+			fmt.Fprintf(f, "        threshold targets breath band between noise (%.1f) and speech (%.1f)\n",
+				m.NoiseFloor, quietSpeechDB)
+		} else {
+			fmt.Fprintf(f, "        breath reduction: INACTIVE (no speech profile)\n")
+		}
+	}
 }
 
 // formatLA2ACompressorFilter outputs LA-2A Compressor filter details

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -101,6 +101,13 @@ const (
 	dc1CentroidFast  = 3000.0 // Hz - above: use shorter window
 	dc1CentroidSlow  = 1500.0 // Hz - below: consider longer window
 
+	// Breath-aware gate threshold tuning
+	breathThresholdPosition = 0.6 // Position in noise-to-speech gap (0.0=noise, 1.0=speech)
+	breathRatioMultiplier   = 1.5 // Ratio increase for breath reduction mode
+	breathRatioMin          = 2.0 // Minimum ratio when breath reduction active
+	breathRatioMax          = 4.0 // Maximum ratio when breath reduction active
+	breathRangeDeepening    = 6.0 // Additional range (dB) for breath attenuation
+
 	// DS201 Gate tuning constants
 	// Threshold calculation: ensures sufficient gap above noise for effective soft expansion
 	ds201GateThresholdMinDB       = -50.0 // dB - minimum threshold (quiet speech floor)
@@ -927,6 +934,33 @@ func tuneDS201Gate(config *FilterChainConfig, measurements *AudioMeasurements) {
 		lufsGap,
 	)
 
+	// Breath-aware threshold override when enabled and speech profile available
+	if config.BreathReductionEnabled && measurements.SpeechProfile != nil {
+		breathThreshold := calculateBreathAwareThreshold(
+			measurements.NoiseFloor,
+			measurements.SpeechProfile.RMSLevel,
+			measurements.SpeechProfile.CrestFactor,
+		)
+
+		// Use breath threshold if more aggressive (higher) than noise-based threshold
+		existingThresholdDB := LinearToDb(config.DS201GateThreshold)
+		if breathThreshold > existingThresholdDB {
+			config.DS201GateThreshold = DbToLinear(breathThreshold)
+		}
+
+		// Increase ratio for breath reduction (firmer expansion)
+		config.DS201GateRatio = clamp(
+			config.DS201GateRatio*breathRatioMultiplier,
+			breathRatioMin,
+			breathRatioMax,
+		)
+
+		// Deepen range for stronger breath attenuation
+		rangeDB := LinearToDb(config.DS201GateRange)
+		rangeDB = clamp(rangeDB-breathRangeDeepening, float64(ds201GateRangeMinDB)-6.0, float64(ds201GateRangeMaxDB))
+		config.DS201GateRange = DbToLinear(rangeDB)
+	}
+
 	// 3. Attack: based on MaxDifference, SpectralFlux, and SpectralCrest
 	// DS201-inspired: supports sub-millisecond attack for transient preservation
 	config.DS201GateAttack = calculateDS201GateAttack(
@@ -1025,6 +1059,15 @@ func calculateDS201GateThreshold(noiseFloorDB, silencePeakDB, silenceCrestDB, ra
 	thresholdDB = clamp(thresholdDB, ds201GateThresholdMinDB, ds201GateThresholdMaxDB)
 
 	return DbToLinear(thresholdDB)
+}
+
+// calculateBreathAwareThreshold derives a gate threshold targeting the breath amplitude band.
+// Breaths occupy the space between noise floor and quiet speech level.
+// Position 0.6 = 60% of the way from noise to speech (biased toward catching breaths).
+func calculateBreathAwareThreshold(noiseFloorDB, speechRMS, speechCrest float64) float64 {
+	quietSpeechDB := speechRMS - speechCrest
+	breathThresholdDB := noiseFloorDB + breathThresholdPosition*(quietSpeechDB-noiseFloorDB)
+	return clamp(breathThresholdDB, noiseFloorDB+3.0, quietSpeechDB-3.0)
 }
 
 // calculateDS201GateRatio determines ratio based on LRA (loudness range).

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -2248,6 +2248,254 @@ func TestScaleExpansion(t *testing.T) {
 	}
 }
 
+func TestCalculateBreathAwareThreshold(t *testing.T) {
+	// Tests the breath-aware threshold calculation which positions the gate threshold
+	// in the amplitude band where breaths typically occur (between noise floor and
+	// quiet speech level).
+	//
+	// Formula: threshold = noiseFloor + breathThresholdPosition * (quietSpeech - noiseFloor)
+	// where quietSpeech = speechRMS - speechCrest
+	// breathThresholdPosition = 0.6 (60% of the way from noise to quiet speech)
+	//
+	// Result is clamped to [noiseFloor+3, quietSpeech-3] for safety margins.
+
+	tests := []struct {
+		name        string
+		noiseFloor  float64 // dB
+		speechRMS   float64 // dB
+		speechCrest float64 // dB (peak - RMS)
+		wantMin     float64 // expected threshold minimum
+		wantMax     float64 // expected threshold maximum
+		desc        string
+	}{
+		{
+			name:        "typical podcast recording",
+			noiseFloor:  -55.0,
+			speechRMS:   -20.0,
+			speechCrest: 15.0, // quietSpeech = -20 - 15 = -35 dB
+			// gap = -35 - (-55) = 20 dB
+			// threshold = -55 + 0.6 * 20 = -55 + 12 = -43 dB
+			wantMin: -44.0,
+			wantMax: -42.0,
+			desc:    "60% of gap from -55 to -35 = -43 dB",
+		},
+		{
+			name:        "noisy recording",
+			noiseFloor:  -40.0,
+			speechRMS:   -18.0,
+			speechCrest: 12.0, // quietSpeech = -18 - 12 = -30 dB
+			// gap = -30 - (-40) = 10 dB
+			// threshold = -40 + 0.6 * 10 = -40 + 6 = -34 dB
+			wantMin: -35.0,
+			wantMax: -33.0,
+			desc:    "60% of gap from -40 to -30 = -34 dB",
+		},
+		{
+			name:        "clean studio recording",
+			noiseFloor:  -70.0,
+			speechRMS:   -22.0,
+			speechCrest: 18.0, // quietSpeech = -22 - 18 = -40 dB
+			// gap = -40 - (-70) = 30 dB
+			// threshold = -70 + 0.6 * 30 = -70 + 18 = -52 dB
+			wantMin: -53.0,
+			wantMax: -51.0,
+			desc:    "60% of gap from -70 to -40 = -52 dB",
+		},
+		{
+			name:        "narrow gap - clamp to minimum margin",
+			noiseFloor:  -35.0,
+			speechRMS:   -25.0,
+			speechCrest: 5.0, // quietSpeech = -25 - 5 = -30 dB
+			// gap = -30 - (-35) = 5 dB
+			// unclamped = -35 + 0.6 * 5 = -35 + 3 = -32 dB
+			// but must be >= noiseFloor + 3 = -32 and <= quietSpeech - 3 = -33
+			// clamp range: [-32, -33] is inverted, so result depends on clamp order
+			wantMin: -33.0, // clamped to quietSpeech - 3
+			wantMax: -32.0, // or noiseFloor + 3
+			desc:    "very narrow gap forces clamping",
+		},
+		{
+			name:        "very quiet speech with high crest",
+			noiseFloor:  -60.0,
+			speechRMS:   -30.0,
+			speechCrest: 20.0, // quietSpeech = -30 - 20 = -50 dB
+			// gap = -50 - (-60) = 10 dB
+			// threshold = -60 + 0.6 * 10 = -60 + 6 = -54 dB
+			wantMin: -55.0,
+			wantMax: -53.0,
+			desc:    "high crest factor compresses the gap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateBreathAwareThreshold(tt.noiseFloor, tt.speechRMS, tt.speechCrest)
+
+			if got < tt.wantMin || got > tt.wantMax {
+				t.Errorf("calculateBreathAwareThreshold(%.1f, %.1f, %.1f) = %.1f dB, want %.1f-%.1f dB [%s]",
+					tt.noiseFloor, tt.speechRMS, tt.speechCrest, got, tt.wantMin, tt.wantMax, tt.desc)
+			}
+		})
+	}
+}
+
+func TestTuneDS201GateBreathReduction(t *testing.T) {
+	// Tests breath reduction mode in tuneDS201Gate()
+	// When enabled with valid SpeechProfile, should:
+	// 1. Calculate breath-aware threshold and use if more aggressive
+	// 2. Increase ratio by breathRatioMultiplier (1.5x), clamped to [2.0, 4.0]
+	// 3. Deepen range by breathRangeDeepening (6 dB)
+
+	t.Run("breath reduction enabled with speech profile", func(t *testing.T) {
+		config := newTestConfig()
+		config.DS201GateEnabled = true
+		config.BreathReductionEnabled = true
+		config.TargetI = -18.0
+
+		measurements := &AudioMeasurements{
+			NoiseFloor: -55.0,
+			InputLRA:   12.0, // Moderate LRA → base ratio 2.0
+			NoiseProfile: &NoiseProfile{
+				PeakLevel:   -50.0,
+				CrestFactor: 10.0,
+				Entropy:     0.5,
+			},
+			SpeechProfile: &SpeechCandidateMetrics{
+				RMSLevel:    -20.0,
+				CrestFactor: 15.0, // quietSpeech = -35 dB
+			},
+		}
+
+		tuneDS201Gate(config, measurements)
+
+		// Check ratio was increased (base 2.0 * 1.5 = 3.0)
+		if config.DS201GateRatio < 2.9 || config.DS201GateRatio > 3.1 {
+			t.Errorf("DS201GateRatio = %.1f, want ~3.0 (base 2.0 * 1.5 multiplier)", config.DS201GateRatio)
+		}
+
+		// Check range was deepened
+		rangeDB := linearToDB(config.DS201GateRange)
+		// Base range depends on entropy, but should be deepened by 6 dB
+		if rangeDB > -20.0 {
+			t.Errorf("DS201GateRange = %.1f dB, want < -20 dB (deepened for breath reduction)", rangeDB)
+		}
+	})
+
+	t.Run("nil speech profile uses standard tuning", func(t *testing.T) {
+		config := newTestConfig()
+		config.DS201GateEnabled = true
+		config.BreathReductionEnabled = true
+		config.TargetI = -18.0
+
+		measurements := &AudioMeasurements{
+			NoiseFloor:    -55.0,
+			InputLRA:      12.0, // Moderate LRA → base ratio 2.0
+			SpeechProfile: nil,  // No speech profile available
+			NoiseProfile: &NoiseProfile{
+				PeakLevel:   -50.0,
+				CrestFactor: 10.0,
+				Entropy:     0.5,
+			},
+		}
+
+		tuneDS201Gate(config, measurements)
+
+		// Ratio should be standard (2.0 for moderate LRA), not multiplied
+		if config.DS201GateRatio != 2.0 {
+			t.Errorf("DS201GateRatio = %.1f, want 2.0 (standard tuning without speech profile)", config.DS201GateRatio)
+		}
+	})
+
+	t.Run("breath reduction disabled uses standard tuning", func(t *testing.T) {
+		config := newTestConfig()
+		config.DS201GateEnabled = true
+		config.BreathReductionEnabled = false // Explicitly disabled
+		config.TargetI = -18.0
+
+		measurements := &AudioMeasurements{
+			NoiseFloor: -55.0,
+			InputLRA:   12.0, // Moderate LRA → base ratio 2.0
+			SpeechProfile: &SpeechCandidateMetrics{
+				RMSLevel:    -20.0,
+				CrestFactor: 15.0,
+			},
+			NoiseProfile: &NoiseProfile{
+				PeakLevel:   -50.0,
+				CrestFactor: 10.0,
+				Entropy:     0.5,
+			},
+		}
+
+		tuneDS201Gate(config, measurements)
+
+		// Ratio should be standard (2.0 for moderate LRA), not multiplied
+		if config.DS201GateRatio != 2.0 {
+			t.Errorf("DS201GateRatio = %.1f, want 2.0 (breath reduction disabled)", config.DS201GateRatio)
+		}
+	})
+
+	t.Run("ratio clamped to breath limits", func(t *testing.T) {
+		config := newTestConfig()
+		config.DS201GateEnabled = true
+		config.BreathReductionEnabled = true
+		config.TargetI = -18.0
+
+		measurements := &AudioMeasurements{
+			NoiseFloor: -55.0,
+			InputLRA:   6.0, // Narrow LRA → base ratio 2.5, * 1.5 = 3.75 (within [2.0, 4.0])
+			SpeechProfile: &SpeechCandidateMetrics{
+				RMSLevel:    -20.0,
+				CrestFactor: 15.0,
+			},
+			NoiseProfile: &NoiseProfile{
+				PeakLevel:   -50.0,
+				CrestFactor: 10.0,
+				Entropy:     0.5,
+			},
+		}
+
+		tuneDS201Gate(config, measurements)
+
+		// Ratio = 2.5 * 1.5 = 3.75, within [2.0, 4.0]
+		if config.DS201GateRatio < 3.7 || config.DS201GateRatio > 3.8 {
+			t.Errorf("DS201GateRatio = %.2f, want ~3.75 (2.5 * 1.5)", config.DS201GateRatio)
+		}
+	})
+
+	t.Run("breath threshold only used if more aggressive", func(t *testing.T) {
+		// When noise-based threshold is already higher than breath threshold,
+		// the noise-based threshold should be kept
+		config := newTestConfig()
+		config.DS201GateEnabled = true
+		config.BreathReductionEnabled = true
+		config.TargetI = -18.0
+
+		measurements := &AudioMeasurements{
+			NoiseFloor: -35.0, // Very noisy - high threshold
+			InputLRA:   12.0,
+			SpeechProfile: &SpeechCandidateMetrics{
+				RMSLevel:    -20.0,
+				CrestFactor: 15.0, // quietSpeech = -35 dB
+				// breath threshold would be around -35 + 0.6*0 = -35, clamped
+			},
+			NoiseProfile: &NoiseProfile{
+				PeakLevel:   -32.0,
+				CrestFactor: 10.0,
+				Entropy:     0.5,
+			},
+		}
+
+		tuneDS201Gate(config, measurements)
+
+		// Threshold should be based on noisy floor, not breath calculation
+		thresholdDB := linearToDB(config.DS201GateThreshold)
+		// With noise floor at -35, threshold should be high (clamped at max -25 dB)
+		if thresholdDB < -30.0 {
+			t.Errorf("DS201GateThreshold = %.1f dB, expected higher (noise-based, not breath)", thresholdDB)
+		}
+	})
+}
+
 // containsString checks if substr exists in s
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -187,6 +187,9 @@ type FilterChainConfig struct {
 	DS201GateDetection  string  // Level detection mode: "rms" (default, smoother) or "peak" (tighter)
 	DS201GateGentleMode bool    // Gentle mode active - for extreme LUFS gap + low LRA recordings
 
+	// Breath reduction mode - adjusts gate threshold to target breath sounds
+	BreathReductionEnabled bool
+
 	// LA-2A Compressor - Teletronix LA-2A style optical compression
 	// The LA-2A is legendary for its gentle, program-dependent character from the T4 optical cell.
 	LA2AEnabled   bool    // Enable LA-2A compressor
@@ -312,6 +315,9 @@ func DefaultFilterConfig() *FilterChainConfig {
 		DS201GateKnee:      3.0,    // Soft knee (adaptive: based on spectral crest)
 		DS201GateMakeup:    1.0,    // Unity gain (loudnorm handles all level adjustment)
 		DS201GateDetection: "rms",  // RMS detection (adaptive: rms for bleed, peak for clean)
+
+		// Breath reduction mode - enabled by default
+		BreathReductionEnabled: true,
 
 		// LA-2A Compressor - Teletronix LA-2A style optical compressor emulation
 		// The Teletronix LA-2A is renowned for its gentle, program-dependent character:


### PR DESCRIPTION
Breath reduction enhances the DS201 gate to target breath sounds using adaptive threshold positioning at 60% of the noise-to-speech gap. When enabled, applies firmer ratio (1.5x multiplier, clamped 2.0-4.0) and deeper range (+6 dB) for stronger breath attenuation. This approach eliminates the need for additional processing passes by tuning the existing gate to specifically attenuate breath content while preserving speech.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a breath reduction mode to the DS201 gate to reliably attenuate breath sounds without extra processing passes. It targets the breath band between noise and quiet speech, with tighter ratio and deeper range to preserve speech.

- **New Features**
  - Gate threshold set at 60% of the noise-to-quiet speech gap (quiet speech = RMS − crest); falls back to standard tuning if no SpeechProfile.
  - Firmer ratio (1.5x, clamped 2.0–4.0) and deeper range (+6 dB) for stronger breath control.
  - CLI flag: --breath-reduction (negatable), enabled by default.
  - Debug logs show breath reduction status and threshold derivation.
  - Unit tests for threshold and tuning; AGENTS.md updated.

<sup>Written for commit fa1c8be42c7206dba6273c284cddbbf26e382517. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

