### PR TITLE
docs(readme): recommend 10-15s room tone at recording start

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Record → Process → Edit → Finalise
   └─ Each presenter records separately, exports FLAC
 ```
 
+**Start each recording with 10-15 seconds of silence.** Just sit quietly and let the room breathe. Jivetalking uses this room tone to build a noise profile, which drives the adaptive noise reduction in Pass 2. Without a clean quiet section near the start, the tool has nothing to calibrate against and denoising results will be noticeably worse.
+
 ---
 
 ## Development


### PR DESCRIPTION
- Instruct users to begin each recording with 10-15 seconds of silence.
- Explain that Jivetalking uses the initial room tone to build a noise profile for Pass 2 denoising; without a clean quiet section the adaptive noise reduction will be noticeably worse.

Closes #26