### PR TITLE
feat(logging): add recording tips to analysis output

### DIFF
--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -231,6 +231,19 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 	// Dynamics and disorder metrics
 	fmt.Fprintf(w, "  Entropy:        %.3f (%s)\n", measurements.SpectralEntropy, interpretEntropy(measurements.SpectralEntropy))
 	fmt.Fprintf(w, "  Flux:           %.4f (%s)\n", measurements.SpectralFlux, interpretFlux(measurements.SpectralFlux))
+
+	// Recording tips section
+	tips := GenerateRecordingTips(measurements, config)
+	fmt.Fprintln(w)
+	writeAnalysisSection(w, "RECORDING TIPS")
+	if len(tips) == 0 {
+		fmt.Fprintln(w, "  ✓ Your recording setup looks good. No issues detected.")
+	} else {
+		for _, tip := range tips {
+			wrapped := wrapText(tip.Message, 66, "    ")
+			fmt.Fprintf(w, "  ⚠ %s\n", wrapped)
+		}
+	}
 }
 
 // writeAnalysisSection writes a section header for analysis output.

--- a/internal/logging/recording_tips.go
+++ b/internal/logging/recording_tips.go
@@ -1,0 +1,323 @@
+package logging
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+// RecordingTip represents a single piece of actionable recording advice
+// derived from audio analysis measurements.
+type RecordingTip struct {
+	Priority int    // Higher = more important (1-10)
+	Message  string // Human-readable advice (1-2 sentences)
+	RuleID   string // Identifier for testing/logging (e.g., "level_too_quiet")
+}
+
+// MaxRecordingTips is the maximum number of tips to return.
+const MaxRecordingTips = 5
+
+// GenerateRecordingTips analyses audio measurements and returns prioritised
+// recording improvement suggestions.
+func GenerateRecordingTips(m *processor.AudioMeasurements, config *processor.FilterChainConfig) []RecordingTip {
+	if m == nil {
+		return nil
+	}
+
+	var tips []RecordingTip
+	firedRules := make(map[string]bool)
+
+	rules := []func(*processor.AudioMeasurements, *processor.FilterChainConfig) *RecordingTip{
+		tipLevelTooHot,
+		tipLevelTooQuiet,
+		tipLevelQuiet,
+		tipBackgroundNoise,
+		tipMainsHum,
+		tipTooFarFromMic,
+		tipProximityEffect,
+		tipSibilance,
+		tipDynamicRange,
+		tipOverCompressed,
+		tipPoorSNR,
+	}
+
+	for _, rule := range rules {
+		if tip := rule(m, config); tip != nil {
+			tips = append(tips, *tip)
+			firedRules[tip.RuleID] = true
+		}
+	}
+
+	// Apply mutual exclusion
+	tips = applyExclusions(tips, firedRules)
+
+	// Sort by priority (descending)
+	sort.Slice(tips, func(i, j int) bool {
+		return tips[i].Priority > tips[j].Priority
+	})
+
+	// Cap at maximum
+	if len(tips) > MaxRecordingTips {
+		tips = tips[:MaxRecordingTips]
+	}
+
+	return tips
+}
+
+// applyExclusions removes tips that are redundant when a more specific tip
+// has already fired. For example, "level_quiet" is suppressed when
+// "too_far_from_mic" fires because the latter already implies the former.
+func applyExclusions(tips []RecordingTip, fired map[string]bool) []RecordingTip {
+	var result []RecordingTip
+	for _, tip := range tips {
+		switch tip.RuleID {
+		case "level_quiet":
+			if fired["too_far_from_mic"] {
+				continue
+			}
+		case "poor_snr":
+			if fired["too_far_from_mic"] {
+				continue
+			}
+		}
+		result = append(result, tip)
+	}
+	return result
+}
+
+// wrapText wraps text at word boundaries to fit within maxWidth columns.
+// Continuation lines are prefixed with indent.
+func wrapText(text string, maxWidth int, indent string) string {
+	words := strings.Fields(text)
+	var lines []string
+	currentLine := ""
+
+	for _, word := range words {
+		if currentLine == "" {
+			currentLine = word
+		} else if len(currentLine)+1+len(word) <= maxWidth {
+			currentLine += " " + word
+		} else {
+			lines = append(lines, currentLine)
+			currentLine = word
+		}
+	}
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
+
+	return strings.Join(lines, "\n"+indent)
+}
+
+// tipLevelTooQuiet fires when input is very quiet (InputI < -30 LUFS).
+// At this level, 12+ dB of gain is needed to reach -18 LUFS target,
+// which raises the noise floor significantly.
+func tipLevelTooQuiet(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	if m.InputI >= -30.0 {
+		return nil
+	}
+	gainNeeded := -18.0 - m.InputI
+	return &RecordingTip{
+		Priority: 10,
+		RuleID:   "level_too_quiet",
+		Message:  fmt.Sprintf("Your microphone gain is too low - try increasing it by about %.0f dB.", gainNeeded),
+	}
+}
+
+// tipLevelQuiet fires when input is moderately quiet (InputI between -30 and -24 LUFS).
+// Still needs noticeable gain to reach target, worth mentioning but less urgent.
+func tipLevelQuiet(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	if m.InputI < -30.0 || m.InputI >= -24.0 {
+		return nil
+	}
+	gainNeeded := -18.0 - m.InputI
+	return &RecordingTip{
+		Priority: 8,
+		RuleID:   "level_quiet",
+		Message:  fmt.Sprintf("Your recording is a bit quiet - increasing your microphone gain by about %.0f dB would improve quality.", gainNeeded),
+	}
+}
+
+// tipLevelTooHot fires when true peak approaches or exceeds 0 dBTP.
+// InputTP > 0.0 means actual clipping; > -1.0 means dangerously close.
+func tipLevelTooHot(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	if m.InputTP <= -1.0 {
+		return nil
+	}
+	if m.InputTP > 0.0 {
+		return &RecordingTip{
+			Priority: 10,
+			RuleID:   "level_clipping",
+			Message:  "Your recording is clipping - turn your microphone gain down by 6-10 dB to prevent distortion.",
+		}
+	}
+	return &RecordingTip{
+		Priority: 9,
+		RuleID:   "level_near_clipping",
+		Message:  "Your recording is very close to clipping - turn your microphone gain down by 3-6 dB to give yourself some headroom.",
+	}
+}
+
+// tipBackgroundNoise fires when the noise floor is elevated.
+// Uses NoiseProfile.MeasuredNoiseFloor when available, falling back to AstatsNoiseFloor.
+// Thresholds align with adaptive.go: -45 dBFS (la2aNoiseFloorNoisy), -55 dBFS (midpoint).
+func tipBackgroundNoise(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	noiseFloor := m.AstatsNoiseFloor
+	if m.NoiseProfile != nil {
+		noiseFloor = m.NoiseProfile.MeasuredNoiseFloor
+	}
+
+	if noiseFloor > -45.0 {
+		return &RecordingTip{
+			Priority: 9,
+			RuleID:   "background_noise_high",
+			Message:  fmt.Sprintf("Background noise is high (%.0f dBFS) - try turning off fans, air conditioning, or other appliances before recording.", noiseFloor),
+		}
+	}
+	if noiseFloor > -55.0 {
+		return &RecordingTip{
+			Priority: 6,
+			RuleID:   "background_noise_moderate",
+			Message:  fmt.Sprintf("Background noise is slightly elevated (%.0f dBFS) - if possible, turn off any fans or appliances nearby.", noiseFloor),
+		}
+	}
+	return nil
+}
+
+// tipMainsHum fires when silence regions show tonal noise characteristics.
+// Requires NoiseProfile with low entropy (< 0.30, matching silenceEntropyTonal in adaptive.go),
+// low flatness (< 0.3, confirming tonal character), and audible noise (> -65 dBFS).
+func tipMainsHum(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	if m.NoiseProfile == nil {
+		return nil
+	}
+	np := m.NoiseProfile
+	if np.Entropy >= 0.30 || np.SpectralFlatness >= 0.3 || np.MeasuredNoiseFloor < -65.0 {
+		return nil
+	}
+	return &RecordingTip{
+		Priority: 7,
+		RuleID:   "mains_hum",
+		Message:  "There's a constant low-frequency hum in your recording - check for nearby power supplies, monitors, or chargers and move them further from your microphone.",
+	}
+}
+
+// tipTooFarFromMic fires when speech level is low and SNR is poor,
+// indicating the speaker is too far from the microphone.
+// Requires both SpeechProfile and NoiseProfile to be present.
+// Thresholds: NoiseReductionHeadroom < 15 dB (below minSNRMargin of 20 dB in analyzer.go)
+// AND SpeechProfile.RMSLevel < -30 dBFS.
+func tipTooFarFromMic(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	if m.SpeechProfile == nil || m.NoiseProfile == nil {
+		return nil
+	}
+	if m.NoiseReductionHeadroom >= 15.0 || m.SpeechProfile.RMSLevel >= -30.0 {
+		return nil
+	}
+	return &RecordingTip{
+		Priority: 8,
+		RuleID:   "too_far_from_mic",
+		Message:  "You sound quite far from your microphone. Try moving closer - about a hand's width (15-20cm) from the mic is ideal for most setups.",
+	}
+}
+
+// tipProximityEffect fires when spectral analysis indicates bass boost
+// from being too close to a directional microphone.
+// Thresholds from adaptive.go: spectralDecreaseVeryWarm = -0.10,
+// spectralDecreaseWarm = -0.05. Skewness > 2.5 is tip-specific (stricter
+// than adaptive.go's spectralSkewnessLFEmphasis = 1.0).
+func tipProximityEffect(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	veryWarm := m.SpectralDecrease < -0.10
+	warmWithSkew := m.SpectralDecrease < -0.05 && m.SpectralSkewness > 2.5
+
+	if !veryWarm && !warmWithSkew {
+		return nil
+	}
+	return &RecordingTip{
+		Priority: 5,
+		RuleID:   "proximity_effect",
+		Message:  "Your voice sounds quite boomy - you may be too close to the microphone. Try moving back slightly or angling the mic to one side.",
+	}
+}
+
+// tipSibilance fires when the adaptive de-esser was set to high intensity,
+// confirmed by bright speech spectral characteristics.
+// Checks FilterChainConfig.DeessIntensity > 0.5 (deessIntensityNormal in adaptive.go),
+// speech centroid > 4000 Hz (centroidBright), and speech rolloff > 10000 Hz.
+// Prefers SpeechProfile metrics when available, falling back to full-file metrics.
+func tipSibilance(m *processor.AudioMeasurements, config *processor.FilterChainConfig) *RecordingTip {
+	if config == nil || config.DeessIntensity <= 0.5 {
+		return nil
+	}
+
+	centroid := m.SpectralCentroid
+	rolloff := m.SpectralRolloff
+	if m.SpeechProfile != nil {
+		if m.SpeechProfile.SpectralCentroid > 0 {
+			centroid = m.SpeechProfile.SpectralCentroid
+		}
+		if m.SpeechProfile.SpectralRolloff > 0 {
+			rolloff = m.SpeechProfile.SpectralRolloff
+		}
+	}
+
+	if centroid <= 4000.0 || rolloff <= 10000.0 {
+		return nil
+	}
+	return &RecordingTip{
+		Priority: 4,
+		RuleID:   "sibilance",
+		Message:  "Your recording has noticeable sibilance (harsh 's' and 'sh' sounds). Try angling your microphone slightly off-axis - point it at your chin rather than directly at your mouth.",
+	}
+}
+
+// tipDynamicRange fires when the loudness range is very wide, indicating
+// inconsistent speaking volume or microphone distance.
+// Thresholds: InputLRA > 18 LU (very wide) or InputLRA > 14 LU with
+// CrestFactor > 18 dB (wide with extreme dynamics).
+// References: adaptive.go la2aLRAExpressive = 14.0 LU,
+// Spectral-Metrics-Reference.md crest > 18 dB = extreme dynamics.
+func tipDynamicRange(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	veryWide := m.InputLRA > 18.0
+	wideWithCrest := m.InputLRA > 14.0 && m.CrestFactor > 18.0
+
+	if !veryWide && !wideWithCrest {
+		return nil
+	}
+	return &RecordingTip{
+		Priority: 5,
+		RuleID:   "dynamic_range",
+		Message:  "Your speaking volume varies quite a lot. Try to maintain a consistent distance from your microphone and a steady speaking level.",
+	}
+}
+
+// tipOverCompressed fires when the crest factor is extremely low,
+// indicating aggressive AGC or prior processing has damaged the audio.
+// Threshold: CrestFactor < 6 dB (brickwalled per Spectral-Metrics-Reference.md).
+// CrestFactor == 0 is treated as unmeasured and skipped.
+func tipOverCompressed(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	if m.CrestFactor >= 6.0 || m.CrestFactor == 0 {
+		return nil
+	}
+	return &RecordingTip{
+		Priority: 6,
+		RuleID:   "over_compressed",
+		Message:  "Your recording sounds heavily compressed, possibly by automatic gain control. If your microphone software has an 'AGC' or 'auto-level' setting, try turning it off and setting the gain manually.",
+	}
+}
+
+// tipPoorSNR fires when the noise-to-speech gap is critically small.
+// Threshold: NoiseReductionHeadroom < 10 dB (half of minSNRMargin 20 dB).
+// NoiseReductionHeadroom == 0 is treated as unmeasured and skipped.
+func tipPoorSNR(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+	if m.NoiseReductionHeadroom >= 10.0 || m.NoiseReductionHeadroom == 0 {
+		return nil
+	}
+	return &RecordingTip{
+		Priority: 7,
+		RuleID:   "poor_snr",
+		Message:  "The gap between your voice and the background noise is very small. Move closer to your microphone and reduce background noise if possible.",
+	}
+}

--- a/internal/logging/recording_tips_test.go
+++ b/internal/logging/recording_tips_test.go
@@ -1,0 +1,725 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+func TestWrapText(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		maxWidth int
+		indent   string
+		want     string
+	}{
+		{
+			name:     "short_text_no_wrap",
+			text:     "Hello world",
+			maxWidth: 20,
+			indent:   "  ",
+			want:     "Hello world",
+		},
+		{
+			name:     "long_text_wraps",
+			text:     "Try moving closer to your microphone for better results",
+			maxWidth: 30,
+			indent:   "  ",
+			want:     "Try moving closer to your\n  microphone for better results",
+		},
+		{
+			name:     "single_long_word",
+			text:     "supercalifragilisticexpialidocious",
+			maxWidth: 10,
+			indent:   "  ",
+			want:     "supercalifragilisticexpialidocious",
+		},
+		{
+			name:     "empty_input",
+			text:     "",
+			maxWidth: 20,
+			indent:   "  ",
+			want:     "",
+		},
+		{
+			name:     "exact_fit",
+			text:     "exactly twenty chars",
+			maxWidth: 20,
+			indent:   "  ",
+			want:     "exactly twenty chars",
+		},
+		{
+			name:     "multiple_wraps",
+			text:     "one two three four five six seven eight nine ten",
+			maxWidth: 15,
+			indent:   "    ",
+			want:     "one two three\n    four five six\n    seven eight\n    nine ten",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapText(tt.text, tt.maxWidth, tt.indent)
+			if got != tt.want {
+				t.Errorf("wrapText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTipLevelTooQuiet(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputI     float64
+		wantTip    bool
+		wantRuleID string
+		wantGain   string // substring to check in message, empty to skip
+	}{
+		{"very quiet -35 LUFS", -35.0, true, "level_too_quiet", "17 dB"},
+		{"boundary -30 LUFS", -30.0, false, "", ""},
+		{"moderately quiet -28 LUFS", -28.0, false, "", ""},
+		{"normal -20 LUFS", -20.0, false, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.InputI = tt.inputI
+			tip := tipLevelTooQuiet(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipLevelTooQuiet() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil {
+				if tip.RuleID != tt.wantRuleID {
+					t.Errorf("RuleID = %q, want %q", tip.RuleID, tt.wantRuleID)
+				}
+				if tt.wantGain != "" && !strings.Contains(tip.Message, tt.wantGain) {
+					t.Errorf("Message %q should contain %q", tip.Message, tt.wantGain)
+				}
+			}
+		})
+	}
+}
+
+func TestTipLevelQuiet(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputI     float64
+		wantTip    bool
+		wantRuleID string
+		wantGain   string
+	}{
+		{"very quiet handled by too_quiet", -35.0, false, "", ""},
+		{"boundary -30 LUFS triggers quiet", -30.0, true, "level_quiet", "12 dB"},
+		{"moderately quiet -28 LUFS", -28.0, true, "level_quiet", "10 dB"},
+		{"boundary -24 LUFS no tip", -24.0, false, "", ""},
+		{"normal -20 LUFS", -20.0, false, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.InputI = tt.inputI
+			tip := tipLevelQuiet(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipLevelQuiet() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil {
+				if tip.RuleID != tt.wantRuleID {
+					t.Errorf("RuleID = %q, want %q", tip.RuleID, tt.wantRuleID)
+				}
+				if tt.wantGain != "" && !strings.Contains(tip.Message, tt.wantGain) {
+					t.Errorf("Message %q should contain %q", tip.Message, tt.wantGain)
+				}
+			}
+		})
+	}
+}
+
+func TestTipLevelTooHot(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputTP    float64
+		wantTip    bool
+		wantRuleID string
+	}{
+		{"clipping +0.5 dBTP", 0.5, true, "level_clipping"},
+		{"boundary 0.0 dBTP near clipping", 0.0, true, "level_near_clipping"},
+		{"near clipping -0.5 dBTP", -0.5, true, "level_near_clipping"},
+		{"boundary -1.0 dBTP no tip", -1.0, false, ""},
+		{"safe -3.0 dBTP", -3.0, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.InputTP = tt.inputTP
+			tip := tipLevelTooHot(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipLevelTooHot() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil {
+				if tip.RuleID != tt.wantRuleID {
+					t.Errorf("RuleID = %q, want %q", tip.RuleID, tt.wantRuleID)
+				}
+			}
+		})
+	}
+}
+
+func TestTipBackgroundNoise(t *testing.T) {
+	tests := []struct {
+		name             string
+		astatsNoiseFloor float64
+		noiseProfile     *processor.NoiseProfile // nil to test fallback
+		wantTip          bool
+		wantRuleID       string
+	}{
+		{
+			name:             "high noise with NoiseProfile",
+			astatsNoiseFloor: -50.0,
+			noiseProfile:     &processor.NoiseProfile{MeasuredNoiseFloor: -42.0},
+			wantTip:          true,
+			wantRuleID:       "background_noise_high",
+		},
+		{
+			name:             "moderate noise with NoiseProfile",
+			astatsNoiseFloor: -60.0,
+			noiseProfile:     &processor.NoiseProfile{MeasuredNoiseFloor: -52.0},
+			wantTip:          true,
+			wantRuleID:       "background_noise_moderate",
+		},
+		{
+			name:             "clean with NoiseProfile",
+			astatsNoiseFloor: -50.0,
+			noiseProfile:     &processor.NoiseProfile{MeasuredNoiseFloor: -68.0},
+			wantTip:          false,
+			wantRuleID:       "",
+		},
+		{
+			name:             "nil NoiseProfile fallback to astats high",
+			astatsNoiseFloor: -42.0,
+			noiseProfile:     nil,
+			wantTip:          true,
+			wantRuleID:       "background_noise_high",
+		},
+		{
+			name:             "nil NoiseProfile fallback to astats clean",
+			astatsNoiseFloor: -68.0,
+			noiseProfile:     nil,
+			wantTip:          false,
+			wantRuleID:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.AstatsNoiseFloor = tt.astatsNoiseFloor
+			m.NoiseProfile = tt.noiseProfile
+			tip := tipBackgroundNoise(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipBackgroundNoise() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != tt.wantRuleID {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, tt.wantRuleID)
+			}
+		})
+	}
+}
+
+func TestTipMainsHum(t *testing.T) {
+	tests := []struct {
+		name         string
+		noiseProfile *processor.NoiseProfile
+		wantTip      bool
+	}{
+		{
+			name: "tonal noise detected",
+			noiseProfile: &processor.NoiseProfile{
+				MeasuredNoiseFloor: -55.0,
+				Entropy:            0.15,
+				SpectralFlatness:   0.10,
+			},
+			wantTip: true,
+		},
+		{
+			name: "high entropy no hum",
+			noiseProfile: &processor.NoiseProfile{
+				MeasuredNoiseFloor: -55.0,
+				Entropy:            0.50,
+				SpectralFlatness:   0.10,
+			},
+			wantTip: false,
+		},
+		{
+			name: "high flatness no hum",
+			noiseProfile: &processor.NoiseProfile{
+				MeasuredNoiseFloor: -55.0,
+				Entropy:            0.15,
+				SpectralFlatness:   0.50,
+			},
+			wantTip: false,
+		},
+		{
+			name: "noise at audibility boundary fires",
+			noiseProfile: &processor.NoiseProfile{
+				MeasuredNoiseFloor: -65.0,
+				Entropy:            0.15,
+				SpectralFlatness:   0.10,
+			},
+			wantTip: true,
+		},
+		{
+			name: "noise below audibility gate suppressed",
+			noiseProfile: &processor.NoiseProfile{
+				MeasuredNoiseFloor: -68.0,
+				Entropy:            0.15,
+				SpectralFlatness:   0.10,
+			},
+			wantTip: false,
+		},
+		{
+			name:         "nil NoiseProfile",
+			noiseProfile: nil,
+			wantTip:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.NoiseProfile = tt.noiseProfile
+			tip := tipMainsHum(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipMainsHum() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != "mains_hum" {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, "mains_hum")
+			}
+		})
+	}
+}
+
+func TestTipTooFarFromMic(t *testing.T) {
+	tests := []struct {
+		name          string
+		speechProfile *processor.SpeechCandidateMetrics
+		noiseProfile  *processor.NoiseProfile
+		headroom      float64
+		wantTip       bool
+	}{
+		{
+			name:          "too far low headroom and quiet speech",
+			speechProfile: &processor.SpeechCandidateMetrics{RMSLevel: -35.0},
+			noiseProfile:  &processor.NoiseProfile{MeasuredNoiseFloor: -50.0},
+			headroom:      12.0,
+			wantTip:       true,
+		},
+		{
+			name:          "good headroom",
+			speechProfile: &processor.SpeechCandidateMetrics{RMSLevel: -35.0},
+			noiseProfile:  &processor.NoiseProfile{MeasuredNoiseFloor: -60.0},
+			headroom:      20.0,
+			wantTip:       false,
+		},
+		{
+			name:          "loud speech",
+			speechProfile: &processor.SpeechCandidateMetrics{RMSLevel: -22.0},
+			noiseProfile:  &processor.NoiseProfile{MeasuredNoiseFloor: -50.0},
+			headroom:      12.0,
+			wantTip:       false,
+		},
+		{
+			name:          "nil SpeechProfile",
+			speechProfile: nil,
+			noiseProfile:  &processor.NoiseProfile{MeasuredNoiseFloor: -50.0},
+			headroom:      12.0,
+			wantTip:       false,
+		},
+		{
+			name:          "nil NoiseProfile",
+			speechProfile: &processor.SpeechCandidateMetrics{RMSLevel: -35.0},
+			noiseProfile:  nil,
+			headroom:      12.0,
+			wantTip:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.SpeechProfile = tt.speechProfile
+			m.NoiseProfile = tt.noiseProfile
+			m.NoiseReductionHeadroom = tt.headroom
+			tip := tipTooFarFromMic(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipTooFarFromMic() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != "too_far_from_mic" {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, "too_far_from_mic")
+			}
+		})
+	}
+}
+
+func TestTipProximityEffect(t *testing.T) {
+	tests := []struct {
+		name             string
+		spectralDecrease float64
+		spectralSkewness float64
+		wantTip          bool
+	}{
+		{"very warm spectral decrease", -0.15, 1.0, true},
+		{"warm with high skewness", -0.07, 3.0, true},
+		{"warm without skewness", -0.07, 1.5, false},
+		{"normal spectral decrease", -0.03, 1.0, false},
+		{"boundary decrease -0.10 fires", -0.101, 0.0, true},
+		{"boundary decrease -0.05 with skew", -0.051, 2.6, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.SpectralDecrease = tt.spectralDecrease
+			m.SpectralSkewness = tt.spectralSkewness
+			tip := tipProximityEffect(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipProximityEffect() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != "proximity_effect" {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, "proximity_effect")
+			}
+		})
+	}
+}
+
+func TestTipSibilance(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *processor.FilterChainConfig
+		centroid      float64
+		rolloff       float64
+		speechProfile *processor.SpeechCandidateMetrics
+		wantTip       bool
+	}{
+		{
+			name:     "high de-esser bright speech",
+			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			centroid: 4500.0,
+			rolloff:  11000.0,
+			wantTip:  true,
+		},
+		{
+			name:     "low de-esser",
+			config:   &processor.FilterChainConfig{DeessIntensity: 0.3},
+			centroid: 4500.0,
+			rolloff:  11000.0,
+			wantTip:  false,
+		},
+		{
+			name:     "de-esser at boundary no tip",
+			config:   &processor.FilterChainConfig{DeessIntensity: 0.5},
+			centroid: 4500.0,
+			rolloff:  11000.0,
+			wantTip:  false,
+		},
+		{
+			name:     "nil config",
+			config:   nil,
+			centroid: 4500.0,
+			rolloff:  11000.0,
+			wantTip:  false,
+		},
+		{
+			name:     "dark voice no sibilance",
+			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			centroid: 3000.0,
+			rolloff:  11000.0,
+			wantTip:  false,
+		},
+		{
+			name:     "low rolloff no sibilance",
+			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			centroid: 4500.0,
+			rolloff:  9000.0,
+			wantTip:  false,
+		},
+		{
+			name:     "speech profile overrides full-file",
+			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			centroid: 3000.0,
+			rolloff:  9000.0,
+			speechProfile: &processor.SpeechCandidateMetrics{
+				SpectralCentroid: 4500.0,
+				SpectralRolloff:  11000.0,
+			},
+			wantTip: true,
+		},
+		{
+			name:     "speech profile zero values use full-file",
+			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			centroid: 4500.0,
+			rolloff:  11000.0,
+			speechProfile: &processor.SpeechCandidateMetrics{
+				SpectralCentroid: 0,
+				SpectralRolloff:  0,
+			},
+			wantTip: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.SpectralCentroid = tt.centroid
+			m.SpectralRolloff = tt.rolloff
+			m.SpeechProfile = tt.speechProfile
+			tip := tipSibilance(m, tt.config)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipSibilance() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != "sibilance" {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, "sibilance")
+			}
+		})
+	}
+}
+
+func TestTipDynamicRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputLRA    float64
+		crestFactor float64
+		wantTip     bool
+	}{
+		{"very wide LRA", 20.0, 12.0, true},
+		{"wide LRA with high crest", 15.0, 20.0, true},
+		{"wide LRA with normal crest", 15.0, 12.0, false},
+		{"normal LRA", 10.0, 12.0, false},
+		{"boundary LRA 18 no tip", 18.0, 12.0, false},
+		{"boundary LRA 14 with crest 18 no tip", 14.0, 18.0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.InputLRA = tt.inputLRA
+			m.CrestFactor = tt.crestFactor
+			tip := tipDynamicRange(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipDynamicRange() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != "dynamic_range" {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, "dynamic_range")
+			}
+		})
+	}
+}
+
+func TestTipOverCompressed(t *testing.T) {
+	tests := []struct {
+		name        string
+		crestFactor float64
+		wantTip     bool
+	}{
+		{"heavily compressed", 4.0, true},
+		{"boundary crest 6 no tip", 6.0, false},
+		{"crest zero unmeasured", 0, false},
+		{"normal crest", 12.0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.CrestFactor = tt.crestFactor
+			tip := tipOverCompressed(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipOverCompressed() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != "over_compressed" {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, "over_compressed")
+			}
+		})
+	}
+}
+
+func TestTipPoorSNR(t *testing.T) {
+	tests := []struct {
+		name     string
+		headroom float64
+		wantTip  bool
+	}{
+		{"poor SNR", 8.0, true},
+		{"boundary headroom 10 no tip", 10.0, false},
+		{"headroom zero unmeasured", 0, false},
+		{"good headroom", 25.0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &processor.AudioMeasurements{}
+			m.NoiseReductionHeadroom = tt.headroom
+			tip := tipPoorSNR(m, nil)
+			if (tip != nil) != tt.wantTip {
+				t.Errorf("tipPoorSNR() returned tip=%v, want tip=%v", tip != nil, tt.wantTip)
+			}
+			if tip != nil && tip.RuleID != "poor_snr" {
+				t.Errorf("RuleID = %q, want %q", tip.RuleID, "poor_snr")
+			}
+		})
+	}
+}
+
+// hasRuleID checks whether any tip in the slice has the given RuleID.
+func hasRuleID(tips []RecordingTip, ruleID string) bool {
+	for _, tip := range tips {
+		if tip.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleIDs extracts RuleIDs from tips for error messages.
+func ruleIDs(tips []RecordingTip) []string {
+	ids := make([]string, len(tips))
+	for i, tip := range tips {
+		ids[i] = tip.RuleID
+	}
+	return ids
+}
+
+func TestGenerateRecordingTips(t *testing.T) {
+	tests := []struct {
+		name             string
+		measurements     *processor.AudioMeasurements
+		config           *processor.FilterChainConfig
+		wantRuleIDs      []string // these RuleIDs must be present
+		excludeRuleIDs   []string // these RuleIDs must NOT be present
+		checkFirstRuleID string   // if set, first tip must have this RuleID
+		maxTips          int      // if > 0, verify len(tips) <= this
+		wantExact        int      // if > 0, verify len(tips) == this
+		wantEmpty        bool     // if true, verify tips is nil or empty
+	}{
+		{
+			name: "mutual exclusion suppresses level_quiet and poor_snr",
+			measurements: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.InputI = -28.0
+				m.InputTP = -10.0
+				m.NoiseReductionHeadroom = 8.0
+				m.SpeechProfile = &processor.SpeechCandidateMetrics{RMSLevel: -35.0}
+				m.NoiseProfile = &processor.NoiseProfile{MeasuredNoiseFloor: -70.0}
+				m.CrestFactor = 12.0
+				return m
+			}(),
+			wantRuleIDs:    []string{"too_far_from_mic"},
+			excludeRuleIDs: []string{"level_quiet", "poor_snr"},
+		},
+		{
+			name: "implicit exclusion level_too_quiet not level_quiet",
+			measurements: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.InputI = -35.0
+				m.InputTP = -10.0
+				m.CrestFactor = 12.0
+				return m
+			}(),
+			wantRuleIDs:    []string{"level_too_quiet"},
+			excludeRuleIDs: []string{"level_quiet"},
+		},
+		{
+			name: "priority ordering highest first",
+			measurements: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.InputI = -35.0
+				m.InputTP = -10.0
+				m.AstatsNoiseFloor = -42.0
+				m.NoiseReductionHeadroom = 8.0
+				m.CrestFactor = 12.0
+				return m
+			}(),
+			checkFirstRuleID: "level_too_quiet",
+		},
+		{
+			name: "max cap at 5 tips",
+			measurements: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.InputI = -35.0
+				m.InputTP = 0.5
+				m.AstatsNoiseFloor = -42.0
+				m.NoiseReductionHeadroom = 8.0
+				m.SpectralDecrease = -0.15
+				m.InputLRA = 20.0
+				m.CrestFactor = 4.0
+				return m
+			}(),
+			maxTips: 5,
+		},
+		{
+			name: "clean recording no tips",
+			measurements: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.InputI = -20.0
+				m.InputTP = -6.0
+				m.InputLRA = 8.0
+				m.AstatsNoiseFloor = -70.0
+				m.CrestFactor = 12.0
+				m.NoiseReductionHeadroom = 25.0
+				m.SpectralDecrease = -0.02
+				m.SpectralSkewness = 0.5
+				return m
+			}(),
+			wantEmpty: true,
+		},
+		{
+			name: "all bad recording returns exactly 5",
+			measurements: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.InputI = -35.0
+				m.InputTP = 0.5
+				m.AstatsNoiseFloor = -42.0
+				m.NoiseReductionHeadroom = 8.0
+				m.SpectralDecrease = -0.15
+				m.InputLRA = 20.0
+				m.CrestFactor = 4.0
+				m.NoiseProfile = &processor.NoiseProfile{
+					MeasuredNoiseFloor: -42.0,
+					Entropy:            0.15,
+					SpectralFlatness:   0.10,
+				}
+				return m
+			}(),
+			wantExact: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tips := GenerateRecordingTips(tt.measurements, tt.config)
+
+			if tt.wantEmpty {
+				if len(tips) != 0 {
+					t.Errorf("expected no tips, got %d: %v", len(tips), ruleIDs(tips))
+				}
+				return
+			}
+
+			for _, wantID := range tt.wantRuleIDs {
+				if !hasRuleID(tips, wantID) {
+					t.Errorf("expected RuleID %q in tips, got %v", wantID, ruleIDs(tips))
+				}
+			}
+
+			for _, excludeID := range tt.excludeRuleIDs {
+				if hasRuleID(tips, excludeID) {
+					t.Errorf("RuleID %q should be excluded, got %v", excludeID, ruleIDs(tips))
+				}
+			}
+
+			if tt.checkFirstRuleID != "" && len(tips) > 0 {
+				if tips[0].RuleID != tt.checkFirstRuleID {
+					t.Errorf("first tip RuleID = %q, want %q (tips: %v)", tips[0].RuleID, tt.checkFirstRuleID, ruleIDs(tips))
+				}
+			}
+
+			if tt.maxTips > 0 && len(tips) > tt.maxTips {
+				t.Errorf("got %d tips, want at most %d: %v", len(tips), tt.maxTips, ruleIDs(tips))
+			}
+
+			if tt.wantExact > 0 && len(tips) != tt.wantExact {
+				t.Errorf("got %d tips, want exactly %d: %v", len(tips), tt.wantExact, ruleIDs(tips))
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add internal/logging/recording_tips.go implementing GenerateRecordingTips and
  RecordingTip. Provides prioritized, rule-driven recording advice derived from
  processor.AudioMeasurements and FilterChainConfig (wrapText, exclusions,
  priority sorting, MaxRecordingTips cap).
- Integrate GenerateRecordingTips into DisplayAnalysisResults to print a "RECORDING TIPS" section in analysis output with wrapped, human-friendly
  messages.
- Add comprehensive unit tests in internal/logging/recording_tips_test.go that
  cover wrapping, each tip rule, mutual exclusions, priority ordering and the
  maximum-tip cap.
- Limit tips to at most 5 entries; behaviour is additive and non-breaking.

IMPACT:
- CLI analysis now surfaces actionable, prioritized recording suggestions to
  help users improve mic setup and recording quality. No breaking changes. Closes #25