### PR TITLE
feat(logging): normalise final spectral metrics for gain comparison

### DIFF
--- a/internal/logging/table.go
+++ b/internal/logging/table.go
@@ -284,3 +284,16 @@ func (t *MetricTable) AddMetricRow(label string, input, filtered, final float64,
 		Interpretation: interpretation,
 	})
 }
+
+// normaliseForGain compensates a spectral metric value for the gain applied during normalisation.
+// scalingPower is 1 for metrics that scale linearly with gain (Mean, Slope)
+// or 2 for metrics that scale with gain squared (Variance, Flux).
+// Returns math.NaN() if rawValue is NaN, gain is NaN, or gainDB is 0
+// (a zero gain means no normalisation occurred and the caller should use the raw value).
+func normaliseForGain(rawValue, gainDB float64, scalingPower int) float64 {
+	if math.IsNaN(rawValue) || math.IsNaN(gainDB) || gainDB == 0 {
+		return math.NaN()
+	}
+	divisor := math.Pow(10, gainDB*float64(scalingPower)/20.0)
+	return rawValue / divisor
+}


### PR DESCRIPTION
- Propagate NormalisationResult into report generation and pass to noise-floor and speech-region tables
- Compute effective normalisation gain (dB) and enable gain-normalise mode when available
- Compensate final spectral metrics (mean, variance, flux, slope) by dividing out applied gain using scaling power per-metric
- Add normaliseForGain helper to internal/logging/table.go
- Add tests for normaliseForGain and for table output:
  - verify † markers and footnote appear when normalisation present
  - verify no markers/footnote when normalisation absent

Impact: final spectral metrics in reports are now gain-normalised for reliable cross-stage comparisons; reports include a † marker and a footnote showing the effective gain when applied.