### PR TITLE
docs: add some missing links to references

### DIFF
--- a/docs/FilterCompressor-Teletronix LA-2A.md
+++ b/docs/FilterCompressor-Teletronix LA-2A.md
@@ -170,8 +170,8 @@ The LA-2A operates on already-cleaned audio, so it can focus on its strength: ge
 
 ## References
 
-- Teletronix Engineering, LA-2A Leveling Amplifier Manual (1965)
-- Universal Audio, "LA-2A Leveling Amplifier" reissue documentation
+- [Teletronix Engineering, LA-2A Leveling Amplifier Manual (1965) ](https://tile.loc.gov/storage-services/master/mbrs/recording_preservation/manuals/Teletronix%20Model%20LA-2A%20Leveling%20Amplifier.pdf)
+- [Universal Audio, "LA-2A Leveling Amplifier" reissue documentation](https://media.uaudio.com/assetlibrary/l/a/la-2a_manual.pdf)
 - Dennis Fink, "The History of the LA-2A" (Mix Magazine, 2003)
-- FFmpeg Documentation: `acompressor` filter
+- FFmpeg Documentation: [`acompressor` filter](https://ffmpeg.org/ffmpeg-filters.html#acompressor)
 - https://github.com/aim-qmul/4a2a

--- a/docs/Spectral-Metrics-Reference.md
+++ b/docs/Spectral-Metrics-Reference.md
@@ -472,9 +472,9 @@ The singer's formant allows classical singers to project over orchestral accompa
 
 5. Wikipedia. "Spectral Flatness." https://en.wikipedia.org/wiki/Spectral_flatness
 
-6. Johnston, J.D. (1988). "Transform Coding of Audio Signals Using Perceptual Noise Criteria." IEEE Journal on Selected Areas in Communications, 6(2), 314-323.
+6. Johnston, J.D. (1988). ["Transform Coding of Audio Signals Using Perceptual Noise Criteria."](https://www.ee.columbia.edu/~dpwe/papers/Johns88-audiocoding.pdf) [IEEE Journal on Selected Areas in Communications, 6(2), 314-323.](https://ieeexplore.ieee.org/document/608)
 
-7. Dubnov, S. (2004). "Generalization of Spectral Flatness Measure for Non-Gaussian Linear Processes." IEEE Signal Processing Letters, 11(8), 698-701.
+7. Dubnov, S. (2004). ["Generalization of Spectral Flatness Measure for Non-Gaussian Linear Processes."](https://www.researchgate.net/publication/3343094_Generalization_of_Spectral_Flatness_Measure_for_Non-Gaussian_Linear_Processes) [IEEE Signal Processing Letters, 11(8), 698-701.](https://ieeexplore.ieee.org/document/1316889/)
 
 8. Misra, H. et al. (2004). "Spectral Entropy Based Feature for Robust ASR." ICASSP'04.
 


### PR DESCRIPTION
Note Johnson and Dubnov references have both links to on-line papers (uni and researchgate) and links to relevant ieee portal purchase pages.  