### PR TITLE
feat(processor): add --silence-scan-duration flag to limit silence-sample scan

### DIFF
--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -25,11 +25,12 @@ var errCancelledByUser = errors.New("cancelled by user")
 
 // CLI defines the command-line interface
 type CLI struct {
-	Version      bool     `short:"v" help:"Show version information"`
-	Debug        bool     `short:"d" help:"Enable debug logging to jivetalking-debug.log"`
-	Logs         bool     `help:"Save detailed analysis logs"`
-	AnalysisOnly bool     `short:"a" help:"Run analysis only (Pass 1), display results, skip processing"`
-	Files        []string `arg:"" name:"files" help:"Audio files to process" type:"existingfile" optional:""`
+	Version             bool          `short:"v" help:"Show version information"`
+	Debug               bool          `short:"d" help:"Enable debug logging to jivetalking-debug.log"`
+	Logs                bool          `help:"Save detailed analysis logs"`
+	AnalysisOnly        bool          `short:"a" help:"Run analysis only (Pass 1), display results, skip processing"`
+	SilenceScanDuration time.Duration `help:"Cap silence-candidate scan to the first DURATION of input (e.g. 30s, 1m30s). Faster on long files at the cost of coverage; loudness, true peak, LRA, spectral, and speech analysis remain whole-file. Fewer silence candidates also reach voice-activated detection when capped. 0s means scan the whole file." placeholder:"DURATION" default:"0s"`
+	Files               []string      `arg:"" name:"files" help:"Audio files to process" type:"existingfile" optional:""`
 }
 
 func main() {
@@ -61,8 +62,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if cliArgs.SilenceScanDuration < 0 {
+		cli.PrintError(fmt.Sprintf("--silence-scan-duration must be >= 0, got %s", cliArgs.SilenceScanDuration))
+		os.Exit(1)
+	}
+
 	// Create default filter configuration
 	config := processor.DefaultFilterConfig()
+	config.SilenceScanDuration = cliArgs.SilenceScanDuration
 
 	// Open debug log file if --debug flag is set
 	var debugLog *os.File
@@ -81,7 +88,7 @@ func main() {
 
 	// Handle analysis-only mode: run Pass 1 and display results, skip TUI
 	if cliArgs.AnalysisOnly {
-		runAnalysisOnly(cliArgs.Files, log)
+		runAnalysisOnly(cliArgs.Files, config, log)
 		return
 	}
 
@@ -222,9 +229,7 @@ func (ph *progressHandler) callback(pass processor.PassNumber, passName string, 
 
 // runAnalysisOnly performs Pass 1 analysis on each file with a progress UI,
 // then displays results to console. Skips full 4-pass processing.
-func runAnalysisOnly(files []string, log func(string, ...any)) {
-	config := processor.DefaultFilterConfig()
-
+func runAnalysisOnly(files []string, config *processor.FilterChainConfig, log func(string, ...any)) {
 	// Check if we have a TTY for the progress UI
 	hasTTY := isTTY()
 

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -325,6 +325,13 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 	// Interval sampling for silence detection (250ms windows)
 	const intervalDuration = 250 * time.Millisecond
 	var intervals []IntervalSample
+	// silenceIntervals is the prefix-restricted view fed to the silence pipeline
+	// (room-tone election, noise profile). When config.SilenceScanDuration is zero
+	// (no cap), it is aliased to intervals after the loop. When a cap is set, only
+	// intervals whose start time is before the cap are appended here. The whole-file
+	// intervals slice continues to feed speech detection and measurements.IntervalSamples
+	// so loudness, spectral, and reporting remain whole-file.
+	var silenceIntervals []IntervalSample
 	var intervalAcc intervalAccumulator
 	var intervalStartTime time.Duration
 
@@ -357,7 +364,11 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 			// Check if interval complete (250ms elapsed) based on input time
 			if inputFrameTime-intervalStartTime >= intervalDuration {
 				// Finalize and store completed interval
-				intervals = append(intervals, intervalAcc.finalize(intervalStartTime))
+				finalised := intervalAcc.finalize(intervalStartTime)
+				intervals = append(intervals, finalised)
+				if config.SilenceScanDuration > 0 && intervalStartTime < config.SilenceScanDuration {
+					silenceIntervals = append(silenceIntervals, finalised)
+				}
 				intervalStartTime = inputFrameTime
 				intervalAcc.reset()
 			}
@@ -392,7 +403,17 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 
 	// Finalize any remaining partial interval (if it has data)
 	if intervalAcc.rawSampleCount > 0 {
-		intervals = append(intervals, intervalAcc.finalize(intervalStartTime))
+		finalised := intervalAcc.finalize(intervalStartTime)
+		intervals = append(intervals, finalised)
+		if config.SilenceScanDuration > 0 && intervalStartTime < config.SilenceScanDuration {
+			silenceIntervals = append(silenceIntervals, finalised)
+		}
+	}
+
+	// When no cap is set, the silence pipeline reads the same whole-file slice as
+	// the rest of the analysis. Aliasing avoids duplicating every append above.
+	if config.SilenceScanDuration == 0 {
+		silenceIntervals = intervals
 	}
 
 	// Note: We intentionally discard partial intervals with no data
@@ -405,9 +426,9 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 	// This replaces the previous separate pre-scan pass
 
 	// Pre-compute silence detection medians (shared by noise estimation and candidate detection)
-	silMedians := computeSilenceMedians(intervals)
+	silMedians := computeSilenceMedians(silenceIntervals)
 
-	noiseFloorEstimate, silenceThreshold, ok := estimateNoiseFloorAndThreshold(intervals, silMedians)
+	noiseFloorEstimate, silenceThreshold, ok := estimateNoiseFloorAndThreshold(silenceIntervals, silMedians)
 	if !ok {
 		// Fallback if insufficient interval data (very short recordings)
 		noiseFloorEstimate = defaultNoiseFloor
@@ -523,11 +544,11 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 
 	// Detect silence regions using threshold already computed from interval distribution
 	// The silenceThreshold was calculated above via estimateNoiseFloorAndThreshold()
-	measurements.SilenceRegions = findSilenceCandidatesFromIntervals(intervals, silenceThreshold, silMedians)
+	measurements.SilenceRegions = findSilenceCandidatesFromIntervals(silenceIntervals, silenceThreshold, silMedians)
 
 	// Extract noise profile from best silence region (if available)
 	// Uses interval data for all measurements - no file re-reading required
-	silenceResult := findBestSilenceRegion(measurements.SilenceRegions, intervals, totalDuration)
+	silenceResult := findBestSilenceRegion(measurements.SilenceRegions, silenceIntervals, totalDuration)
 
 	// Store all evaluated candidates for reporting/debugging
 	measurements.SilenceCandidates = silenceResult.Candidates
@@ -548,7 +569,7 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 		wasRefined := refinedRegion.Start != originalRegion.Start || refinedRegion.Duration != originalRegion.Duration
 
 		// Extract noise profile from interval data (no file re-read)
-		if profile := extractNoiseProfileFromIntervals(refinedRegion, intervals); profile != nil {
+		if profile := extractNoiseProfileFromIntervals(refinedRegion, silenceIntervals); profile != nil {
 			noiseProfile = profile
 			measurements.NoiseProfile = profile
 

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -2393,3 +2393,232 @@ func TestDetectVoiceActivated(t *testing.T) {
 		})
 	}
 }
+
+func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
+	// Deterministic synthetic input for the silence-scan-duration cap.
+	//
+	// Layout (85 seconds total):
+	//   [0,  8 s)   tone + noise floor (32 intervals at ~-23 dBFS RMS)
+	//   [8, 55 s)   silence with -60 dBFS noise floor (188 intervals; >= the
+	//               32-interval / 8 s minimum used by the silence pipeline)
+	//   [55, 85 s)  tone + noise floor (120 intervals at ~-23 dBFS RMS)
+	//
+	// The silence gap inherits the configured noise floor (see generateTestAudio)
+	// so the silence pipeline scores it as real room tone rather than rejecting
+	// it as digital silence (RMSLevel <= -115 dBFS).
+	//
+	// The 188 / 152 split (silence > tone) is required so the median RMS used
+	// by roomToneScore falls in the silence range, which in turn lets
+	// estimateNoiseFloorAndThreshold pin the silence threshold near the noise
+	// floor. With a tone-dominated split the median sits at the tone level,
+	// every interval scores 1.0, and the top-20% selection becomes order-
+	// dependent on Go's unstable sort.
+	opts := TestAudioOptions{
+		DurationSecs: 85.0,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -23.0,
+		NoiseLevel:   -60.0,
+	}
+	opts.SilenceGap.Start = 8.0
+	opts.SilenceGap.Duration = 47.0
+
+	testFile := generateTestAudio(t, opts)
+	defer cleanupTestAudio(t, testFile)
+
+	// Loudness fields are derived from ebur128 metadata, which is bit-stable
+	// frame-by-frame for identical input. Allow a small tolerance to absorb
+	// any non-determinism in floating-point reductions across runs.
+	const loudnessTolerance = 0.01
+
+	baselineConfig := newTestConfig()
+	baselineConfig.AnalysisEnabled = true
+
+	baseline, err := AnalyzeAudio(testFile, baselineConfig, nil)
+	if err != nil {
+		t.Fatalf("baseline AnalyzeAudio failed: %v", err)
+	}
+	if baseline == nil {
+		t.Fatal("baseline measurements are nil")
+	}
+	if baseline.NoiseProfile == nil {
+		t.Fatalf("baseline NoiseProfile is nil; the silence pipeline did not elect a region "+
+			"for the synthetic input (regions=%d)", len(baseline.SilenceRegions))
+	}
+
+	abs := func(x float64) float64 {
+		if x < 0 {
+			return -x
+		}
+		return x
+	}
+
+	assertLoudnessMatches := func(t *testing.T, got *AudioMeasurements) {
+		t.Helper()
+		if d := abs(got.InputI - baseline.InputI); d > loudnessTolerance {
+			t.Errorf("InputI = %.4f, baseline = %.4f, diff = %.4f (tolerance %.4f)",
+				got.InputI, baseline.InputI, d, loudnessTolerance)
+		}
+		if d := abs(got.InputTP - baseline.InputTP); d > loudnessTolerance {
+			t.Errorf("InputTP = %.4f, baseline = %.4f, diff = %.4f (tolerance %.4f)",
+				got.InputTP, baseline.InputTP, d, loudnessTolerance)
+		}
+		if d := abs(got.InputLRA - baseline.InputLRA); d > loudnessTolerance {
+			t.Errorf("InputLRA = %.4f, baseline = %.4f, diff = %.4f (tolerance %.4f)",
+				got.InputLRA, baseline.InputLRA, d, loudnessTolerance)
+		}
+		if d := abs(got.NoiseFloor - baseline.NoiseFloor); d > loudnessTolerance {
+			t.Errorf("NoiseFloor = %.4f, baseline = %.4f, diff = %.4f (tolerance %.4f)",
+				got.NoiseFloor, baseline.NoiseFloor, d, loudnessTolerance)
+		}
+	}
+
+	t.Run("zero_matches_baseline", func(t *testing.T) {
+		// AC1 / AC5: explicit zero is identical to flag absent (no cap).
+		config := newTestConfig()
+		config.AnalysisEnabled = true
+		config.SilenceScanDuration = 0
+
+		got, err := AnalyzeAudio(testFile, config, nil)
+		if err != nil {
+			t.Fatalf("AnalyzeAudio failed: %v", err)
+		}
+		if got == nil {
+			t.Fatal("measurements are nil")
+		}
+
+		assertLoudnessMatches(t, got)
+
+		if !regionsEqual(got.SilenceRegions, baseline.SilenceRegions) {
+			t.Errorf("SilenceRegions = %+v, baseline = %+v",
+				got.SilenceRegions, baseline.SilenceRegions)
+		}
+		if !speechRegionsEqual(got.SpeechRegions, baseline.SpeechRegions) {
+			t.Errorf("SpeechRegions = %+v, baseline = %+v",
+				got.SpeechRegions, baseline.SpeechRegions)
+		}
+		if !noiseProfilesEqual(got.NoiseProfile, baseline.NoiseProfile) {
+			t.Errorf("NoiseProfile = %+v, baseline = %+v",
+				got.NoiseProfile, baseline.NoiseProfile)
+		}
+	})
+
+	t.Run("cap_excludes_silence_beyond_it", func(t *testing.T) {
+		// AC6: with a cap of 2 s, the silence at 8-55 s falls outside the silence
+		// pipeline's view, so no candidates are formed and no profile is extracted.
+		// 2 s lands cleanly between the 1.75 s and 2.0 s interval start times.
+		config := newTestConfig()
+		config.AnalysisEnabled = true
+		config.SilenceScanDuration = 2 * time.Second
+
+		got, err := AnalyzeAudio(testFile, config, nil)
+		if err != nil {
+			t.Fatalf("AnalyzeAudio failed: %v", err)
+		}
+		if got == nil {
+			t.Fatal("measurements are nil")
+		}
+
+		if len(got.SilenceRegions) != 0 {
+			t.Errorf("len(SilenceRegions) = %d, want 0 (cap should exclude silence at 8-55 s)",
+				len(got.SilenceRegions))
+		}
+		if got.NoiseProfile != nil {
+			t.Errorf("NoiseProfile = %+v, want nil", got.NoiseProfile)
+		}
+	})
+
+	t.Run("cap_longer_than_silence_matches_uncapped", func(t *testing.T) {
+		// AC7: cap at 60 s comfortably covers the silence at 8-55 s, so the
+		// silence pipeline elects the same region as the uncapped run and
+		// produces the same NoiseProfile placement.
+		config := newTestConfig()
+		config.AnalysisEnabled = true
+		config.SilenceScanDuration = 60 * time.Second
+
+		got, err := AnalyzeAudio(testFile, config, nil)
+		if err != nil {
+			t.Fatalf("AnalyzeAudio failed: %v", err)
+		}
+		if got == nil {
+			t.Fatal("measurements are nil")
+		}
+
+		if got.NoiseProfile == nil {
+			t.Fatalf("NoiseProfile is nil; expected the same region as the uncapped run "+
+				"(baseline.NoiseProfile.Start = %v)", baseline.NoiseProfile.Start)
+		}
+		if got.NoiseProfile.Start != baseline.NoiseProfile.Start {
+			t.Errorf("NoiseProfile.Start = %v, baseline = %v",
+				got.NoiseProfile.Start, baseline.NoiseProfile.Start)
+		}
+		if got.NoiseProfile.Duration != baseline.NoiseProfile.Duration {
+			t.Errorf("NoiseProfile.Duration = %v, baseline = %v",
+				got.NoiseProfile.Duration, baseline.NoiseProfile.Duration)
+		}
+	})
+
+	t.Run("other_measurements_unaffected_by_cap", func(t *testing.T) {
+		// AC8: with the cap engaged (cap > silence end so the silence pipeline
+		// elects the same region), whole-file measurements (loudness, true peak,
+		// LRA, speech regions, interval samples) match the uncapped run because
+		// only the silence pipeline reads the capped slice.
+		config := newTestConfig()
+		config.AnalysisEnabled = true
+		config.SilenceScanDuration = 60 * time.Second
+
+		got, err := AnalyzeAudio(testFile, config, nil)
+		if err != nil {
+			t.Fatalf("AnalyzeAudio failed: %v", err)
+		}
+		if got == nil {
+			t.Fatal("measurements are nil")
+		}
+
+		assertLoudnessMatches(t, got)
+
+		if !speechRegionsEqual(got.SpeechRegions, baseline.SpeechRegions) {
+			t.Errorf("SpeechRegions = %+v, baseline = %+v",
+				got.SpeechRegions, baseline.SpeechRegions)
+		}
+		if len(got.IntervalSamples) != len(baseline.IntervalSamples) {
+			t.Errorf("len(IntervalSamples) = %d, baseline = %d",
+				len(got.IntervalSamples), len(baseline.IntervalSamples))
+		}
+	})
+}
+
+// regionsEqual returns true when two SilenceRegion slices match element-wise.
+func regionsEqual(a, b []SilenceRegion) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// speechRegionsEqual returns true when two SpeechRegion slices match element-wise.
+func speechRegionsEqual(a, b []SpeechRegion) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// noiseProfilesEqual returns true when two NoiseProfile pointers refer to
+// equivalent values (or are both nil).
+func noiseProfilesEqual(a, b *NoiseProfile) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
 )
@@ -126,6 +127,14 @@ type FilterChainConfig struct {
 	// Analysis (ebur128 + astats + aspectralstats) - audio measurement collection
 	// Captures loudness, dynamics, spectral characteristics
 	AnalysisEnabled bool
+
+	// SilenceScanDuration caps how much of the input is examined when collecting
+	// silence candidates for room-tone election. Zero is the sentinel meaning
+	// "scan whole file" (current behaviour); a positive value restricts silence
+	// candidate collection to intervals before this input time. Loudness, true
+	// peak, LRA, spectral statistics, and speech detection always remain
+	// whole-file regardless of this cap.
+	SilenceScanDuration time.Duration
 
 	// Resample (aformat) - output format standardisation
 	// Pass 2 only - ensures consistent output format

--- a/internal/processor/testutil_test.go
+++ b/internal/processor/testutil_test.go
@@ -68,10 +68,24 @@ func generateTestAudio(t *testing.T, opts TestAudioOptions) string {
 
 	maxInt16 := float64(math.MaxInt16)
 
-	for i := 0; i < totalSamples; i++ {
+	for i := range totalSamples {
 		// Check if we're in the silence gap
 		if i >= silenceStart && i < silenceEnd && opts.SilenceGap.Duration > 0 {
-			samples[i] = 0
+			// When a noise floor is configured, the gap inherits it so the
+			// silence pipeline sees a real-room recording rather than digital
+			// silence. Without a noise floor, write literal zero to preserve
+			// behaviour for callers that want hard digital silence.
+			if noiseAmp > 0 {
+				sample := noiseAmp * nextRandom()
+				if sample > 1.0 {
+					sample = 1.0
+				} else if sample < -1.0 {
+					sample = -1.0
+				}
+				samples[i] = int16(sample * maxInt16)
+			} else {
+				samples[i] = 0
+			}
 			continue
 		}
 


### PR DESCRIPTION
Add a CLI flag to constrain how much of the input is examined when collecting silence candidates for room-tone election during Pass 1 analysis.

Changes:
- Add `--silence-scan-duration` Kong flag with duration syntax (30s, 1m, etc)
- New `SilenceScanDuration` field on FilterChainConfig (default zero = whole file)
- Split `silenceIntervals` from `intervals` in AnalyzeAudio to gate silence-candidate collection by the cap, whilst keeping speech detection and all other measurements (ebur128, astats, spectral) reading the whole file unchanged
- Extend generateTestAudio to support noise floor in silence gaps for deterministic testing
- Comprehensive test (TestAnalyzeAudio_SilenceScanDuration) covering four scenarios: zero-cap parity, cap excludes silence beyond it, cap-longer equivalence, and unaffected measurements (loudness, speech regions, interval samples)

Close #71