### PR TITLE
feat(processor)!: add benchmark suite, always-on reports, and tuned filter defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /jivetalking
 jivetalking-debug.log
 testdata/
+.bench/
 
 # ffmpeg-statigo libraries (downloaded, not committed)
 third_party/ffmpeg-statigo/lib/*/libffmpeg.a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,12 @@ internal/
 
 **Filter chain order (Pass 2):**
 ```
-downmix → ds201_highpass → ds201_lowpass → noiseremove (anlmdn+compand) → ds201_gate → la2a_compressor → deesser → analysis → resample
+downmix → ds201_highpass → ds201_lowpass → noiseremove (32 kHz pre-anlmdn, r=0.0045 + compand) → ds201_gate → la2a_compressor → deesser → analysis → resample
 ```
 
-Order rationale: downmix to mono first; HP/LP removes frequency extremes before gate (DS201 frequency-conscious side-chain pattern); denoising before gating (lowers noise floor for gate); compression before de-essing (compression emphasises sibilance); analysis measures processed signal; resample standardises output format last.
+Order rationale: downmix to mono first; HP/LP removes frequency extremes before gate (DS201 frequency-conscious side-chain pattern); denoising before gating (lowers noise floor for gate); compression before de-essing (compression emphasises sibilance); analysis measures processed signal; final resample standardises output format last.
+
+**Noise removal default:** Production uses `anlmdn_sr_32000_best_r`: resample to 32 kHz before `anlmdn`, use `r=0.0045`, then continue through compand. In benchmark context, refer to the old production path as `anlmdn_legacy_default`.
 
 **Normalisation (Pass 3/4):**
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ Order rationale: downmix to mono first; HP/LP removes frequency extremes before 
 
 **Noise removal default:** Production uses `anlmdn_sr_32000_best_r`: resample to 32 kHz before `anlmdn`, use `r=0.0045`, then continue through compand. In benchmark context, refer to the old production path as `anlmdn_legacy_default`.
 
+**Adeclick default:** Production uses `adeclick=t=2.0:w=55:o=50:m=s` (spline interpolation, halved overlap vs prior default) for ~75% Pass 4 runtime reduction at metric-parity quality; the gentle limiter attack keeps source clicks below the relaxed threshold. In benchmark context, refer to the production path as `adeclick_current_t_2_0_w_55_o_50_m_s`. No legacy variant is retained in the matrix.
+
 **Normalisation (Pass 3/4):**
 ```
 Pass 3: [volume (pre-gain, when clamped) → alimiter (Volumax)] → loudnorm (measure-only, print_format=json) → captures LoudnormStats JSON

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ internal/
 ├── logging/
 │   ├── analysis_display.go # DisplayAnalysisResults() - console output for --analysis-only mode
 │   ├── recording_tips.go   # Actionable recording advice from measurements
-│   ├── report.go           # GenerateReport() - detailed analysis log files (--logs)
+│   ├── report.go           # GenerateReport() - always-on detailed processing report files
 │   └── table.go            # MetricRow, reusable multi-column table formatting (Input/Filtered/Final)
 ├── ui/
 │   ├── analysis_model.go   # AnalysisModel - Bubbletea model for --analysis-only progress TUI
@@ -50,7 +50,7 @@ internal/
 └── cli/                    # Help styling, version output, error formatting
 ```
 
-**Data flow (processing):** `main.go` spawns goroutine → `ProcessAudio()` → Pass 1 (`AnalyzeAudio`) → `AdaptConfig()` → Pass 2 (filter chain) → Pass 3/4 (`ApplyNormalisation`) → sends `ui.*Msg` to TUI via `tea.Program.Send()`.
+**Data flow (processing):** `main.go` spawns goroutine → `ProcessAudio()` → Pass 1 (`AnalyzeAudio`) → `AdaptConfig()` → Pass 2 (filter chain) → Pass 3/4 (`ApplyNormalisation`) → `GenerateReport()` writes an always-on processing report → sends `ui.*Msg` to TUI via `tea.Program.Send()`.
 
 **Data flow (analysis-only):** `main.go` → `runAnalysisOnly()` → `AnalyzeOnly()` → Pass 1 + `AdaptConfig()` → `AnalysisModel` TUI shows progress → `DisplayAnalysisResults()` prints report to console. No output files created.
 

--- a/CPU-OVERVIEW.md
+++ b/CPU-OVERVIEW.md
@@ -1,0 +1,343 @@
+# Jivetalking CPU Performance Overview
+
+## Scope
+
+This review covers CPU-bound performance on the primary audio processing path in Jivetalking.
+
+Included:
+
+- Full processing mode: `ProcessAudio`, `AnalyzeAudio`, `processWithFilters`, `ApplyNormalisation`, and output region measurement.
+- Analysis-only mode where it shares the same CPU-heavy analysis path.
+- FFmpeg filter graph CPU use, repeated decode/filter passes, per-frame metadata extraction, per-sample Go loops, and CPU-relevant test affordances.
+
+Excluded:
+
+- I/O-only changes, network, build-time work, TUI polish, debug logging, text report formatting unless profiling says otherwise, and memory-only changes.
+- Metric collection for reports and future GUI product data remains in scope when it consumes CPU on the processing path.
+- Changes that trade audio quality for speed without profile data and listening validation.
+- Broad pipeline redesign.
+
+## Methodology
+
+This is a static CPU-path audit of the Go code and local FFmpeg filter options.
+
+No runtime CPU profile was captured for this document. Treat the impact ratings as candidate priorities. Do not implement CPU optimisations until a profile confirms the bottleneck on representative recordings.
+
+The product framing has changed since the first review. Detailed reports are likely to become always-on because the metrics are useful now and will become product data for a future GUI app. The optimisation target is therefore no longer "avoid full analysis unless `--logs` is requested". The target is "collect the required default metric set as cheaply as possible, then reserve deeper diagnostic fields for an explicit diagnostic tier".
+
+Files inspected:
+
+- `cmd/jivetalking/main.go`
+- `internal/audio/reader.go`
+- `internal/processor/processor.go`
+- `internal/processor/frame_processor.go`
+- `internal/processor/filters.go`
+- `internal/processor/analyzer.go`
+- `internal/processor/analyzer_metrics.go`
+- `internal/processor/analyzer_candidates.go`
+- `internal/processor/analyzer_output.go`
+- `internal/processor/normalise.go`
+- `internal/processor/encoder.go`
+- existing processor tests and `justfile`
+
+Local FFmpeg help confirmed that `astats` and `aspectralstats` both support selecting measured fields, and that `aspectralstats` uses slice threading.
+
+## CPU-Critical Paths
+
+### Processing Mode
+
+`ProcessAudio` currently performs these CPU-heavy stages for each input file:
+
+1. Pass 1, `AnalyzeAudio`
+   - Decodes the input.
+   - Runs `downmix -> astats -> aspectralstats -> ebur128`.
+   - `ebur128` calculates true peak and upsamples internally.
+   - Go scans input samples for interval RMS and peak.
+   - Go extracts and parses frame metadata for all analysis metrics.
+
+2. Pass 2, `processWithFilters`
+   - Decodes the input again.
+   - Runs `downmix -> highpass -> lowpass -> anlmdn -> compand -> agate -> acompressor -> deesser -> astats -> aspectralstats -> ebur128 -> resample`.
+   - Encodes FLAC output.
+   - Extracts output analysis metadata on each filtered frame.
+
+3. Pass 2 region measurement
+   - `MeasureOutputRegions` reopens the processed file.
+   - It measures silence and speech regions with separate filter graph runs when both profiles exist.
+   - The shared reader seeks back to zero for the speech region, so this can decode the processed file twice.
+
+4. Pass 3, `measureWithLoudnorm`
+   - Decodes the processed file.
+   - Runs optional `volume -> alimiter`, then `loudnorm` in measurement mode.
+
+5. Pass 4, `applyLoudnormAndMeasure`
+   - Decodes the processed file again.
+   - Runs optional `volume -> alimiter -> loudnorm -> adeclick -> astats -> aspectralstats -> ebur128 -> resample`.
+   - Encodes FLAC output again.
+
+6. Pass 4 region measurement
+   - Repeats the post-output region measurement pattern on the final file.
+
+### Analysis-Only Mode
+
+`AnalyzeOnly` runs Pass 1 and `AdaptConfig`.
+
+Its CPU cost is dominated by decode, `astats`, `aspectralstats`, `ebur128`, Go sample scanning, and per-frame metadata parsing.
+
+### Go Hot Loops
+
+The Go-side CPU candidates are smaller than the FFmpeg filter costs, but they run once per frame:
+
+- `frameSumSquaresAndPeak` scans every sample in a frame.
+- `AnalyzeAudio` calls `calculateFrameLevel` and then `intervalAcc.addFrameRMSAndPeak`; both call `frameSumSquaresAndPeak`, so Pass 1 scans the same input frame samples twice.
+- `getFloatMetadata` performs repeated dictionary lookups and `strconv.ParseFloat` calls for many metadata keys on every analysis frame.
+- Candidate scoring works over 250 ms intervals. This is cheap compared with FFmpeg filters for normal podcast durations.
+
+## Findings
+
+### 1. Post-processing region measurement re-decodes output files
+
+**Expected Impact:** Remove up to four extra output-file decode/filter traversals per processed file when both silence and speech profiles exist. This becomes normal-path CPU work if reports and GUI metrics are always-on. The saving should be clearly measurable on long recordings and may be human-perceptible for batch processing.
+
+**Evidence:**
+
+- `ProcessAudio` calls `MeasureOutputRegions` after Pass 2.
+- `applyLoudnormAndMeasure` calls `MeasureOutputRegions` again after Pass 4.
+- `MeasureOutputRegions` measures silence first, seeks to the beginning, then measures speech.
+- `measureOutputRegionFromReader` builds an `atrim -> astats -> aspectralstats -> ebur128` graph and drives it through `runFilterGraph`.
+
+**Implementation Plan:**
+
+- M: Add a small region accumulator that can consume already-filtered frames during Pass 2 and Pass 4.
+- S: Use frame timestamps to decide whether a frame overlaps the elected silence or speech region.
+- M: For each selected region, accumulate raw RMS/peak from frame samples and average per-frame spectral/loudness metadata.
+- S: Keep `MeasureOutputRegions` as a fallback for tests or debug comparison during rollout.
+- S: Compare old and new region metrics on existing fixtures.
+
+**Risk Assessment:** Medium. Audio output is unchanged, but metric parity needs careful tolerance checks because `atrim`-scoped `astats` and streaming accumulators may differ at region boundaries.
+
+**Effort Estimate:** M
+
+**Impact Rating:** 8/10
+
+**Measurement:**
+
+- Run full processing with the always-on default metric set on 10, 30, and 60 minute fixtures.
+- Until metrics become default, use `--logs` as the proxy for that baseline.
+- Compare total wall time, pass timings, and CPU profile before and after.
+- Check region RMS, peak, centroid, LUFS, true peak, and sample peak deltas against existing `MeasureOutputRegions`.
+
+### 2. Full output analysis needs a default metric contract
+
+**Expected Impact:** Reduce CPU in Pass 2 and Pass 4 by replacing all-field output analysis with a defined default app/report metric set plus an optional diagnostic tier. This should be material on normal episode-length files because it limits FFT-heavy and true-peak analysis to fields the default product path actually uses.
+
+**Evidence:**
+
+- `ProcessAudio` sets `config.OutputAnalysisEnabled = true` unconditionally.
+- Pass 2 filter order includes `FilterAnalysis` before resampling.
+- `buildAnalysisFilter` uses `astats=metadata=1:measure_perchannel=all`, `aspectralstats=...:measure=all`, and `ebur128=...:peak=sample+true`.
+- Pass 4 `buildLoudnormFilterSpec` appends `astats`, `aspectralstats`, `ebur128`, and `aformat` after `loudnorm`.
+- `LoudnormStats` already includes `output_i` and `output_tp`, so final filename data can come from loudnorm JSON if validated.
+
+**Implementation Plan:**
+
+- S: Define a default app/report metric contract covering processing decisions, output naming, user-facing report fields, and future GUI data.
+- S: Define a diagnostic tier for deeper before/after comparisons, validation, and developer investigations.
+- M: In normal processing, collect the default metric contract instead of every available `astats`, `aspectralstats`, and `ebur128` field.
+- M: Use diagnostic metrics only when an explicit diagnostic path, comparison run, or test requires them.
+- S: Parse and validate `LoudnormStats.OutputI` and `OutputTP` for final LUFS and true peak where Pass 4 currently relies on the trailing `ebur128` accumulator.
+- M: Keep a strict comparison mode until loudnorm JSON and validation `ebur128` agree within tolerance across fixtures.
+
+**Risk Assessment:** Medium. The audio samples should remain unchanged, but report and GUI data become a product contract. Narrowing full analysis must preserve required default fields and keep diagnostic parity available.
+
+**Effort Estimate:** M
+
+**Impact Rating:** 7/10
+
+**Measurement:**
+
+- Profile Pass 2 and Pass 4 with current all-field analysis, the proposed default metric contract, and the diagnostic tier.
+- Record CPU samples attributed to `aspectralstats`, `astats`, `ebur128`, metadata extraction, and FLAC encode.
+- Verify final LUFS, true peak, output filename, default report fields, and GUI-bound metric fields.
+
+### 3. Pass 2 and Pass 4 request more metadata than the default metric contract may need
+
+**Expected Impact:** Reduce per-frame FFmpeg analysis CPU and Go metadata parsing in the output paths while keeping always-on report and app metrics. This matters if metrics become part of the normal product path.
+
+**Evidence:**
+
+- `astats` supports selecting measured fields.
+- `aspectralstats` supports selecting measured fields.
+- The code parses many fields every frame through `getFloatMetadata`.
+- Pass 2 and Pass 4 need enough loudness, peak, spectral, and region data to satisfy the default report and future GUI contract. Full all-field spectral comparison is mainly diagnostic unless a field is explicitly promoted into that contract.
+
+**Implementation Plan:**
+
+- S: Inventory fields consumed by adaptive tuning, limiter decisions, filename generation, console output, default reports, future GUI views, and diagnostic reports.
+- M: Split analysis builders by pass and purpose.
+- S: Use `astats` selected fields instead of `measure_perchannel=all` where the default contract does not need every field.
+- S: Use `aspectralstats` selected fields where the default contract needs spectral data, and keep `measure=all` for the diagnostic tier.
+- S: Add regression tests for filter specs and report field presence.
+
+**Risk Assessment:** Low to medium. The main risk is accidentally removing a metric used by adaptive tuning or reports. Pass 1 should stay conservative until profiling proves a narrower metric set preserves decisions.
+
+**Effort Estimate:** M
+
+**Impact Rating:** 6/10
+
+**Measurement:**
+
+- Use `ffmpeg` `abench` around analysis subchains or CPU profiles around Jivetalking passes.
+- Compare processing time and default report metrics with `measure=all` versus selected fields.
+- Measure diagnostic-tier runtime separately from default metric collection.
+- Assert adaptive config remains identical on representative fixtures before changing Pass 1.
+
+### 4. Pass 1 scans input frame samples twice
+
+**Expected Impact:** Reduce Go CPU in analysis-only mode and Pass 1. This is smaller than filter-pass reductions, but it is deterministic and low risk if profiles show Go-side sample scanning above noise.
+
+**Evidence:**
+
+- `AnalyzeAudio` calls `calculateFrameLevel(inputFrame)`.
+- It then calls `intervalAcc.addFrameRMSAndPeak(inputFrame)`.
+- Both paths call `frameSumSquaresAndPeak`, which iterates all samples in the frame.
+
+**Implementation Plan:**
+
+- XS: Add a helper returning display level plus interval sum-of-squares, sample count, and peak from one `frameSumSquaresAndPeak` call.
+- S: Use the same result for progress level and interval accumulation in Pass 1.
+- XS: Keep Pass 2 and Pass 4 unchanged unless profiles show VU level calculation is meaningful CPU cost.
+
+**Risk Assessment:** Low. The change reuses the same calculation and should preserve existing level and interval values.
+
+**Effort Estimate:** S
+
+**Impact Rating:** 5/10
+
+**Measurement:**
+
+- Add a benchmark for `AnalyzeAudio` on a synthetic 5 to 10 minute file.
+- Run `go test -bench AnalyzeAudio -cpuprofile cpu.out ./internal/processor`.
+- Confirm fewer samples in `frameSumSquaresAndPeak` and no metric drift.
+
+## Recommendations
+
+1. Profile before changing code.
+   - Use representative real fixtures, not the current 3 second integration test.
+   - Capture full processing with always-on default metrics and analysis-only separately.
+   - Record pass timings already available through the existing progress/report path.
+
+2. Prioritise streaming region measurement.
+   - It removes repeated work without changing the audio processing chain.
+   - It has the clearest CPU waste pattern in the current code.
+   - Always-on metrics make the repeated region traversal part of the normal path.
+
+3. Define the default app/report metric contract.
+   - Keep required report and future GUI metrics in the normal path.
+   - Move developer-only comparisons and deep validation fields into a diagnostic tier.
+
+4. Narrow FFmpeg metric selection only after the default contract exists.
+   - This avoids treating product metrics as incidental logging.
+
+5. Fold the duplicate Pass 1 sample scan into one calculation.
+   - This is small, local, and easy to verify.
+
+## Suggested Benchmarks And Measurements
+
+### Baseline Runs
+
+Use at least three fixture lengths:
+
+- Short: 3 to 5 minutes.
+- Typical: 30 to 60 minutes.
+- Long: 90 minutes or more.
+
+Capture:
+
+- Total elapsed time.
+- User CPU time.
+- System CPU time.
+- Pass 1, Pass 2, Pass 3, and Pass 4 timings.
+- Output LUFS and true peak.
+- Region metric deltas.
+- Runtime with current all-field metrics.
+- Runtime with the proposed default metric contract.
+- Runtime with the diagnostic tier enabled.
+- Runtime of text report generation separately from metric collection, if profiling suggests it is visible.
+
+### Go Benchmarks
+
+Add benchmarks under `internal/processor`:
+
+- `BenchmarkAnalyzeAudioSynthetic5m`
+- `BenchmarkProcessAudioDefaultSynthetic5m`
+- `BenchmarkProcessAudioFixture`
+- `BenchmarkMeasureOutputRegions`
+
+Run:
+
+```bash
+go test -run '^$' -bench 'Benchmark(AnalyzeAudio|ProcessAudio|MeasureOutputRegions)' -benchmem -cpuprofile cpu.out ./internal/processor
+go tool pprof cpu.out
+```
+
+Add narrower benchmarks or sub-benchmarks for:
+
+- Default metric collection.
+- Selected `astats` and `aspectralstats` fields.
+- Diagnostic-tier all-field analysis.
+- `MeasureOutputRegions`.
+- Text report generation, only if CPU profiles show report formatting above noise.
+
+### CLI-Level Timing
+
+Run the built binary so CGO and version-injected build settings match normal use:
+
+```bash
+just build
+/usr/bin/time -v ./jivetalking --analysis-only testdata/LMP-72-martin.flac
+/usr/bin/time -v ./jivetalking testdata/LMP-72-martin.flac
+/usr/bin/time -v ./jivetalking --logs testdata/LMP-72-martin.flac
+```
+
+Treat the always-on report or metric path as the baseline. Until the CLI default changes, the `--logs` run is the closest proxy for always-on default metrics. Keep text report generation separate from metric collection when profiling report-related cost.
+
+### FFmpeg Filter Timing
+
+For temporary experiments, insert FFmpeg `abench` around candidate subchains:
+
+- Pass 2 analysis block.
+- Pass 4 validation analysis block.
+- `anlmdn` and `compand`.
+- `aspectralstats`.
+- `ebur128`.
+
+Remove `abench` instrumentation before merging.
+
+## Exclusions
+
+### Multi-file parallel processing
+
+Processing multiple files concurrently may reduce wall-clock time for batches, but it does not reduce CPU consumed per file. It also increases instantaneous CPU demand. Excluded from this CPU-reduction plan.
+
+### `anlmdn` parameter changes
+
+`anlmdn` is likely CPU-heavy, but the current settings are documented as spike-validated. Changing patch, research, or smoothing parameters would trade audio quality for CPU. Excluded until profiling and listening tests justify it.
+
+### FLAC compression level
+
+The encoder uses FLAC compression level 5. Lowering it could reduce encode CPU, but it trades CPU for larger files and more downstream I/O. Excluded until CPU profiles show FLAC encoding is a major share of processing time.
+
+### `--silence-scan-duration` as a primary CPU fix
+
+The flag caps the silence-candidate slice used after Pass 1 collection. It does not reduce full-file decode, `astats`, `aspectralstats`, or `ebur128` work. It can reduce candidate scoring on very long files, but this is unlikely to reach impact 5 on normal inputs.
+
+### Filter string construction and small allocations
+
+Filter specs are built once per pass. String construction, builder maps, and config formatting are not meaningful CPU targets for the primary audio path.
+
+### TUI and logging
+
+Progress messages, Bubbletea rendering, debug logging, and text report formatting are outside scope unless a CPU profile shows they materially affect processing runs. The current update interval is already coarse.
+
+Metric collection is not logging. Always-on report and GUI metrics are part of the CPU-critical processing path when they require FFmpeg analysis filters, frame metadata parsing, or region traversal.

--- a/CPU-OVERVIEW.md
+++ b/CPU-OVERVIEW.md
@@ -123,7 +123,6 @@ The Go-side CPU candidates are smaller than the FFmpeg filter costs, but they ru
 **Measurement:**
 
 - Run full processing with the always-on default metric set on 10, 30, and 60 minute fixtures.
-- Until metrics become default, use `--logs` as the proxy for that baseline.
 - Compare total wall time, pass timings, and CPU profile before and after.
 - Check region RMS, peak, centroid, LUFS, true peak, and sample peak deltas against existing `MeasureOutputRegions`.
 
@@ -297,10 +296,9 @@ Run the built binary so CGO and version-injected build settings match normal use
 just build
 /usr/bin/time -v ./jivetalking --analysis-only testdata/LMP-72-martin.flac
 /usr/bin/time -v ./jivetalking testdata/LMP-72-martin.flac
-/usr/bin/time -v ./jivetalking --logs testdata/LMP-72-martin.flac
 ```
 
-Treat the always-on report or metric path as the baseline. Until the CLI default changes, the `--logs` run is the closest proxy for always-on default metrics. Keep text report generation separate from metric collection when profiling report-related cost.
+The default `./jivetalking` invocation is now the always-on baseline since reports are always written. Keep text report generation separate from metric collection when profiling report-related cost.
 
 ### FFmpeg Filter Timing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Filter chain inspired by studio legends, tuned to your specific audio:
 | Filter | Hardware Inspiration | What It Does |
 |--------|---------------------|--------------|
 | **Highpass** | Drawmer DS201 | Removes subsonic rumble (60-120 Hz, adaptive to spectral content) |
-| **Noise reduction** | Non-Local Means | Adaptive anlmdn denoiser; compand residual suppression added when a noise profile is available |
+| **Noise reduction** | Non-Local Means | Adaptive `anlmdn` denoiser using the production `anlmdn_sr_32000_best_r` path: 32 kHz before `anlmdn`, `r=0.0045`, then compand residual suppression when a noise profile is available |
 | **Gate** | DS201 expander | Soft expansion for natural inter-phrase cleanup; breath reduction option positions threshold between noise floor and quiet speech level |
 | **Compressor** | Teletronix LA-2A | Programme-dependent optical compression; ratio and release adapt to kurtosis and flux. High-crest override pushes ratio, threshold, release, and knee when predicted limiter ceiling deficit is positive |
 | **De-esser** | — | Adaptive intensity (0.0-0.6) based on spectral centroid and rolloff |
@@ -210,7 +210,7 @@ Record → Process → Edit → Finalise
   └─ Each presenter records separately, exports FLAC
 ```
 
-**Include 10-15 seconds of silence somewhere in your recording.** Just sit quietly and let the room breathe - at the start, between sections, or at the end. Jivetalking scans the entire file to find the cleanest quiet section for building a noise profile, which drives the adaptive noise reduction in Pass 2. Without a clean quiet section, the NR compander is disabled entirely and only the self-adapting spectral denoiser runs.
+**Include 10-15 seconds of silence somewhere in your recording.** Just sit quietly and let the room breathe - at the start, between sections, or at the end. Jivetalking scans the entire file to find the cleanest quiet section for building a noise profile, which drives the adaptive noise reduction in Pass 2. Without a clean quiet section, the NR compander is disabled entirely and the 32 kHz `anlmdn` path still runs.
 
 ---
 
@@ -257,7 +257,23 @@ just bench-cli FILE
 
 # Analysis-only CLI benchmark against a copied input file
 just bench-analysis FILE
+
+# Focused anlmdn variant benchmarks
+JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn
+
+# Capture processed outputs, filter specs, metrics, validation reports, and timing
+just bench-anlmdn-capture
+
+# Profile the production anlmdn variant, anlmdn_sr_32000_best_r
+JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn-profile
+
+# Profile the legacy default for comparison
+JIVETALKING_ANLMDN_PROFILE_VARIANT=anlmdn_legacy_default \
+  JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" \
+  just bench-anlmdn-profile
 ```
+
+`anlmdn_sr_32000_best_r` is the production default. It caps the signal to 32 kHz before `anlmdn`, uses `r=0.0045`, and restores the normal 44.1 kHz mono output path afterwards. `anlmdn_legacy_default` keeps the old uncapped path with `r=0.0058` for comparison.
 
 ### Project Structure
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ jivetalking [flags] <files...>
 | `-v, --version` | Show version and exit |
 | `-a, --analysis-only` | Run analysis only (Pass 1), display results, skip processing |
 | `-d, --debug` | Enable debug logging to `jivetalking-debug.log` |
-| `--logs` | Save detailed analysis reports alongside output |
 | `--silence-scan-duration=DURATION` | Cap silence-candidate scan to the first `DURATION` of input (e.g. `30s`, `1m30s`). Default `0s` scans the whole file |
 
 
@@ -122,11 +121,13 @@ jivetalking presenter1.flac presenter2.flac presenter3.flac
 jivetalking -a presenter1.flac presenter2.flac
 
 # Debug a problematic recording
-jivetalking -d --logs troublesome-recording.flac
+jivetalking -d troublesome-recording.flac
 
 # Process all FLAC files in directory
 jivetalking *.flac
 ```
+
+Processing writes a per-file `.log` report by default next to each processed output. For example, `recording-LUFS-16-processed.flac` gets `recording-LUFS-16-processed.log`.
 
 ### Limiting silence-scan duration
 
@@ -233,8 +234,29 @@ just build
 # Run tests
 just test
 
+# Run processor benchmarks
+just bench
+
 # Install to ~/.local/bin
 just install
+```
+
+### Benchmarks
+
+Benchmark artefacts live under `.bench/`. They are separate from generated per-file `.log` reports.
+
+```bash
+# Processor package benchmarks
+just bench
+
+# Processor benchmarks with CPU profile at .bench/cpu.out
+just bench-profile
+
+# Full CLI processing benchmark against a copied input file
+just bench-cli FILE
+
+# Analysis-only CLI benchmark against a copied input file
+just bench-analysis FILE
 ```
 
 ### Project Structure

--- a/README.md
+++ b/README.md
@@ -243,37 +243,7 @@ just install
 
 ### Benchmarks
 
-Benchmark artefacts live under `.bench/`. They are separate from generated per-file `.log` reports.
-
-```bash
-# Processor package benchmarks
-just bench
-
-# Processor benchmarks with CPU profile at .bench/cpu.out
-just bench-profile
-
-# Full CLI processing benchmark against a copied input file
-just bench-cli FILE
-
-# Analysis-only CLI benchmark against a copied input file
-just bench-analysis FILE
-
-# Focused anlmdn variant benchmarks
-JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn
-
-# Capture processed outputs, filter specs, metrics, validation reports, and timing
-just bench-anlmdn-capture
-
-# Profile the production anlmdn variant, anlmdn_sr_32000_best_r
-JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn-profile
-
-# Profile the legacy default for comparison
-JIVETALKING_ANLMDN_PROFILE_VARIANT=anlmdn_legacy_default \
-  JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" \
-  just bench-anlmdn-profile
-```
-
-`anlmdn_sr_32000_best_r` is the production default. It caps the signal to 32 kHz before `anlmdn`, uses `r=0.0045`, and restores the normal 44.1 kHz mono output path afterwards. `anlmdn_legacy_default` keeps the old uncapped path with `r=0.0058` for comparison.
+Benchmark recipes, capture and profile workflows, and the `anlmdn`/`adeclick` variant matrices are documented in [docs/Benchmarks.md](docs/Benchmarks.md). Artefacts land under `.bench/`.
 
 ### Project Structure
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -130,31 +130,18 @@ func main() {
 			}
 			pass2Time := time.Since(pass2Start) - ph.pass1Time - ph.pass3Time - ph.pass4Time
 
-			// Get file metadata for logging
-			var metadata *audio.Metadata
-			if cliArgs.Logs {
-				reader, meta, err := audio.OpenAudioFile(inputPath)
-				if err == nil {
-					metadata = meta
-					reader.Close()
-				}
-			}
-
 			// Generate analysis report if --logs flag is set
-			if cliArgs.Logs && metadata != nil {
+			if cliArgs.Logs {
 				reportData := logging.ReportData{
 					InputPath:    inputPath,
 					OutputPath:   result.OutputPath,
 					StartTime:    fileStartTime,
 					EndTime:      time.Now(),
-					Pass1Time:    ph.pass1Time,
-					Pass2Time:    pass2Time,
-					Pass3Time:    ph.pass3Time,
-					Pass4Time:    ph.pass4Time,
+					Timings:      ph.timings(pass2Time),
 					Result:       result,
-					SampleRate:   metadata.SampleRate,
-					Channels:     metadata.Channels,
-					DurationSecs: metadata.Duration,
+					SampleRate:   result.InputMetadata.SampleRate,
+					Channels:     result.InputMetadata.Channels,
+					DurationSecs: result.InputMetadata.DurationSecs,
 				}
 				if err := logging.GenerateReport(reportData); err != nil {
 					log("[MAIN] Failed to generate log file: %v", err)
@@ -184,6 +171,15 @@ func main() {
 			debugLog.Close()
 		}
 		os.Exit(1) //nolint:gocritic // exitAfterDefer: debugLog explicitly closed above
+	}
+}
+
+func (ph *progressHandler) timings(pass2Time time.Duration) logging.ProcessingTimings {
+	return logging.ProcessingTimings{
+		Pass1: ph.pass1Time,
+		Pass2: pass2Time,
+		Pass3: ph.pass3Time,
+		Pass4: ph.pass4Time,
 	}
 }
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -27,7 +27,6 @@ var errCancelledByUser = errors.New("cancelled by user")
 type CLI struct {
 	Version             bool          `short:"v" help:"Show version information"`
 	Debug               bool          `short:"d" help:"Enable debug logging to jivetalking-debug.log"`
-	Logs                bool          `help:"Save detailed analysis logs"`
 	AnalysisOnly        bool          `short:"a" help:"Run analysis only (Pass 1), display results, skip processing"`
 	SilenceScanDuration time.Duration `help:"Cap silence-candidate scan to the first DURATION of input (e.g. 30s, 1m30s). Faster on long files at the cost of coverage; loudness, true peak, LRA, spectral, and speech analysis remain whole-file. Fewer silence candidates also reach voice-activated detection when capped. 0s means scan the whole file." placeholder:"DURATION" default:"0s"`
 	Files               []string      `arg:"" name:"files" help:"Audio files to process" type:"existingfile" optional:""`
@@ -97,6 +96,7 @@ func main() {
 
 	// Start the TUI
 	p := tea.NewProgram(model, tea.WithAltScreen())
+	reportWarnings := make(chan string, len(cliArgs.Files))
 
 	// Start processing in background
 	go func() {
@@ -130,22 +130,10 @@ func main() {
 			}
 			pass2Time := time.Since(pass2Start) - ph.pass1Time - ph.pass3Time - ph.pass4Time
 
-			// Generate analysis report if --logs flag is set
-			if cliArgs.Logs {
-				reportData := logging.ReportData{
-					InputPath:    inputPath,
-					OutputPath:   result.OutputPath,
-					StartTime:    fileStartTime,
-					EndTime:      time.Now(),
-					Timings:      ph.timings(pass2Time),
-					Result:       result,
-					SampleRate:   result.InputMetadata.SampleRate,
-					Channels:     result.InputMetadata.Channels,
-					DurationSecs: result.InputMetadata.DurationSecs,
-				}
-				if err := logging.GenerateReport(reportData); err != nil {
-					log("[MAIN] Failed to generate log file: %v", err)
-				}
+			reportData := buildProcessingReportData(inputPath, fileStartTime, ph.timings(pass2Time), result)
+			if err := logging.GenerateReport(reportData); err != nil {
+				log("[MAIN] Failed to generate log file: %v", err)
+				reportWarnings <- fmt.Sprintf("Report was not written for %s: %v", inputPath, err)
 			}
 
 			// Signal file complete with actual data
@@ -171,6 +159,29 @@ func main() {
 			debugLog.Close()
 		}
 		os.Exit(1) //nolint:gocritic // exitAfterDefer: debugLog explicitly closed above
+	}
+
+	for {
+		select {
+		case warning := <-reportWarnings:
+			cli.PrintWarning(warning)
+		default:
+			return
+		}
+	}
+}
+
+func buildProcessingReportData(inputPath string, fileStartTime time.Time, timings logging.ProcessingTimings, result *processor.ProcessingResult) logging.ReportData {
+	return logging.ReportData{
+		InputPath:    inputPath,
+		OutputPath:   result.OutputPath,
+		StartTime:    fileStartTime,
+		EndTime:      time.Now(),
+		Timings:      timings,
+		Result:       result,
+		SampleRate:   result.InputMetadata.SampleRate,
+		Channels:     result.InputMetadata.Channels,
+		DurationSecs: result.InputMetadata.DurationSecs,
 	}
 }
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -185,6 +187,37 @@ func buildProcessingReportData(inputPath string, fileStartTime time.Time, timing
 	}
 }
 
+type analysisOnlyDeps struct {
+	stdout          io.Writer
+	hasTTY          func() bool
+	openMetadata    func(string) (*audio.Metadata, error)
+	runWithTUI      func(string, *processor.FilterChainConfig, func(string, ...any)) (*processor.AnalysisResult, error)
+	analyzeDetailed func(string, *processor.FilterChainConfig, func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error)
+	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.FilterChainConfig, ...logging.AnalysisTimings)
+	printError      func(string)
+}
+
+func defaultAnalysisOnlyDeps() analysisOnlyDeps {
+	return analysisOnlyDeps{
+		stdout:          os.Stdout,
+		hasTTY:          isTTY,
+		openMetadata:    openAudioMetadata,
+		runWithTUI:      runAnalysisWithTUI,
+		analyzeDetailed: processor.AnalyzeOnlyDetailed,
+		displayResults:  logging.DisplayAnalysisResults,
+		printError:      cli.PrintError,
+	}
+}
+
+func openAudioMetadata(inputPath string) (*audio.Metadata, error) {
+	reader, metadata, err := audio.OpenAudioFile(inputPath)
+	if err != nil {
+		return nil, err
+	}
+	reader.Close()
+	return metadata, nil
+}
+
 func (ph *progressHandler) timings(pass2Time time.Duration) logging.ProcessingTimings {
 	return logging.ProcessingTimings{
 		Pass1: ph.pass1Time,
@@ -237,36 +270,39 @@ func (ph *progressHandler) callback(pass processor.PassNumber, passName string, 
 // runAnalysisOnly performs Pass 1 analysis on each file with a progress UI,
 // then displays results to console. Skips full 4-pass processing.
 func runAnalysisOnly(files []string, config *processor.FilterChainConfig, log func(string, ...any)) {
+	runAnalysisOnlyWithDeps(files, config, log, defaultAnalysisOnlyDeps())
+}
+
+func runAnalysisOnlyWithDeps(files []string, config *processor.FilterChainConfig, log func(string, ...any), deps analysisOnlyDeps) {
 	// Check if we have a TTY for the progress UI
-	hasTTY := isTTY()
+	hasTTY := deps.hasTTY()
 
 	for i, inputPath := range files {
 		// Add separator between multiple files
 		if i > 0 {
-			fmt.Println()
+			fmt.Fprintln(deps.stdout)
 		}
 
 		log("[ANALYSIS] Starting analysis for %s", inputPath)
 
 		// Get file metadata for duration/sample rate display
-		reader, metadata, err := audio.OpenAudioFile(inputPath)
+		metadata, err := deps.openMetadata(inputPath)
 		if err != nil {
-			cli.PrintError(fmt.Sprintf("Failed to open %s: %v", inputPath, err))
+			deps.printError(fmt.Sprintf("Failed to open %s: %v", inputPath, err))
 			continue
 		}
-		reader.Close()
 
 		var analysisResult *processor.AnalysisResult
 		var analysisErr error
 
 		if hasTTY {
 			// Run with TUI progress display
-			analysisResult, analysisErr = runAnalysisWithTUI(inputPath, config, log)
+			analysisResult, analysisErr = deps.runWithTUI(inputPath, config, log)
 		} else {
 			// Fallback: run without TUI (for non-interactive environments)
 			log("[ANALYSIS] No TTY available, running without progress UI")
-			fmt.Printf("Analysing: %s\n", inputPath)
-			analysisResult, analysisErr = processor.AnalyzeOnlyDetailed(inputPath, config, nil)
+			fmt.Fprintf(deps.stdout, "Analysing: %s\n", filepath.Base(inputPath))
+			analysisResult, analysisErr = deps.analyzeDetailed(inputPath, config, nil)
 		}
 
 		if analysisErr != nil {
@@ -274,7 +310,7 @@ func runAnalysisOnly(files []string, config *processor.FilterChainConfig, log fu
 				// User pressed Ctrl+C - exit immediately, don't process remaining files
 				return
 			}
-			cli.PrintError(fmt.Sprintf("Analysis failed for %s: %v", inputPath, analysisErr))
+			deps.printError(fmt.Sprintf("Analysis failed for %s: %v", inputPath, analysisErr))
 			continue
 		}
 
@@ -285,7 +321,7 @@ func runAnalysisOnly(files []string, config *processor.FilterChainConfig, log fu
 			Analysis:   analysisResult.AnalysisDuration,
 			Adaptation: analysisResult.AdaptationDuration,
 		}
-		logging.DisplayAnalysisResults(os.Stdout, inputPath, metadata, analysisResult.Measurements, analysisResult.Config, timings)
+		deps.displayResults(deps.stdout, inputPath, metadata, analysisResult.Measurements, analysisResult.Config, timings)
 	}
 }
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -256,18 +256,17 @@ func runAnalysisOnly(files []string, config *processor.FilterChainConfig, log fu
 		}
 		reader.Close()
 
-		var measurements *processor.AudioMeasurements
-		var adaptedConfig *processor.FilterChainConfig
+		var analysisResult *processor.AnalysisResult
 		var analysisErr error
 
 		if hasTTY {
 			// Run with TUI progress display
-			measurements, adaptedConfig, analysisErr = runAnalysisWithTUI(inputPath, config, log)
+			analysisResult, analysisErr = runAnalysisWithTUI(inputPath, config, log)
 		} else {
 			// Fallback: run without TUI (for non-interactive environments)
 			log("[ANALYSIS] No TTY available, running without progress UI")
 			fmt.Printf("Analysing: %s\n", inputPath)
-			measurements, adaptedConfig, analysisErr = processor.AnalyzeOnly(inputPath, config, nil)
+			analysisResult, analysisErr = processor.AnalyzeOnlyDetailed(inputPath, config, nil)
 		}
 
 		if analysisErr != nil {
@@ -282,7 +281,11 @@ func runAnalysisOnly(files []string, config *processor.FilterChainConfig, log fu
 		log("[ANALYSIS] Analysis complete for %s", inputPath)
 
 		// Display results to console
-		logging.DisplayAnalysisResults(os.Stdout, inputPath, metadata, measurements, adaptedConfig)
+		timings := logging.AnalysisTimings{
+			Analysis:   analysisResult.AnalysisDuration,
+			Adaptation: analysisResult.AdaptationDuration,
+		}
+		logging.DisplayAnalysisResults(os.Stdout, inputPath, metadata, analysisResult.Measurements, analysisResult.Config, timings)
 	}
 }
 
@@ -295,8 +298,8 @@ func isTTY() bool {
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
 }
 
-// runAnalysisWithTUI runs analysis with the Bubbletea progress UI
-func runAnalysisWithTUI(inputPath string, config *processor.FilterChainConfig, log func(string, ...any)) (*processor.AudioMeasurements, *processor.FilterChainConfig, error) {
+// runAnalysisWithTUI runs analysis with the Bubbletea progress UI.
+func runAnalysisWithTUI(inputPath string, config *processor.FilterChainConfig, log func(string, ...any)) (*processor.AnalysisResult, error) {
 	// Create the analysis UI model
 	model := ui.NewAnalysisModel()
 
@@ -321,37 +324,36 @@ func runAnalysisWithTUI(inputPath string, config *processor.FilterChainConfig, l
 		}
 
 		// Run analysis-only with progress callback
-		measurements, adaptedConfig, err := processor.AnalyzeOnly(path, config, progressCallback)
+		result, err := processor.AnalyzeOnlyDetailed(path, config, progressCallback)
 
 		// Signal completion
 		p.Send(ui.AnalysisCompleteMsg{
-			Measurements: measurements,
-			Config:       adaptedConfig,
-			Error:        err,
+			Result: result,
+			Error:  err,
 		})
 	}(inputPath)
 
 	// Run the TUI until analysis completes
 	finalModel, err := p.Run()
 	if err != nil {
-		return nil, nil, fmt.Errorf("UI error: %w", err)
+		return nil, fmt.Errorf("UI error: %w", err)
 	}
 
 	// Get the final model state
 	analysisModel, ok := finalModel.(ui.AnalysisModel)
 	if !ok {
-		return nil, nil, fmt.Errorf("unexpected model type")
+		return nil, fmt.Errorf("unexpected model type")
 	}
 
 	// Check for analysis error
 	if analysisModel.Error != nil {
-		return nil, nil, analysisModel.Error
+		return nil, analysisModel.Error
 	}
 
 	// Check for user cancellation (TUI exited without completing analysis)
 	if !analysisModel.Done {
-		return nil, nil, errCancelledByUser
+		return nil, errCancelledByUser
 	}
 
-	return analysisModel.Measurements, analysisModel.Config, nil
+	return analysisModel.Result, nil
 }

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linuxmatters/jivetalking/internal/audio"
+	"github.com/linuxmatters/jivetalking/internal/logging"
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
+	inputPath := ".bench/analysis/input/sample.wav"
+	config := processor.DefaultFilterConfig()
+	var output bytes.Buffer
+
+	runAnalysisOnlyWithDeps([]string{inputPath}, config, func(string, ...any) {}, analysisOnlyDeps{
+		stdout: &output,
+		hasTTY: func() bool {
+			return false
+		},
+		openMetadata: func(path string) (*audio.Metadata, error) {
+			if path != inputPath {
+				t.Fatalf("openMetadata path = %q, want %q", path, inputPath)
+			}
+			return &audio.Metadata{
+				Duration:   120,
+				SampleRate: 48000,
+				Channels:   1,
+			}, nil
+		},
+		runWithTUI: func(string, *processor.FilterChainConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
+			t.Fatal("runWithTUI should not be called for non-TTY output")
+			return nil, nil
+		},
+		analyzeDetailed: func(path string, cfg *processor.FilterChainConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
+			if path != inputPath {
+				t.Fatalf("analyzeDetailed path = %q, want %q", path, inputPath)
+			}
+			if progress != nil {
+				t.Fatal("progress callback should be nil for non-TTY output")
+			}
+			return &processor.AnalysisResult{
+				Measurements:       makeAnalysisOnlyTestMeasurements(),
+				Config:             cfg,
+				AnalysisDuration:   2 * time.Second,
+				AdaptationDuration: 100 * time.Millisecond,
+			}, nil
+		},
+		displayResults: logging.DisplayAnalysisResults,
+		printError: func(message string) {
+			t.Fatalf("printError called: %s", message)
+		},
+	})
+
+	got := output.String()
+	if strings.Contains(got, ".bench/") {
+		t.Fatalf("analysis-only output leaked benchmark path:\n%s", got)
+	}
+	for _, want := range []string{
+		"Analysing: sample.wav",
+		"ANALYSIS: sample.wav",
+		"ANALYSIS TIMINGS",
+		"Analysis:",
+		"Adaptation:",
+		"Report Output:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("analysis-only output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func makeAnalysisOnlyTestMeasurements() *processor.AudioMeasurements {
+	return &processor.AudioMeasurements{
+		BaseMeasurements: processor.BaseMeasurements{
+			RMSLevel:     -24,
+			PeakLevel:    -6,
+			DynamicRange: 18,
+		},
+		InputI:             -23,
+		InputTP:            -1,
+		InputLRA:           6,
+		NoiseFloor:         -50,
+		NoiseFloorSource:   "rms_estimate",
+		PreScanNoiseFloor:  -50,
+		SilenceDetectLevel: -45,
+	}
+}

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -1,0 +1,106 @@
+---
+
+# Benchmarks
+
+**Reference for the `just bench-*` recipes: processor microbenchmarks, full CLI runs, and the focused `anlmdn` and `adeclick` variant matrices used to validate filter-chain changes.**
+
+Benchmark artefacts live under `.bench/`. They are separate from the per-file `.log` reports written alongside processed audio.
+
+---
+
+## Processor Package Benchmarks
+
+Go benchmarks against the `internal/processor` package. Useful for measuring the cost of filter-graph construction, adaptation, and analysis paths in isolation.
+
+```bash
+# Processor package benchmarks
+just bench
+
+# Processor benchmarks with CPU profile at .bench/cpu.out
+just bench-profile
+```
+
+---
+
+## Full CLI Benchmarks
+
+End-to-end runs of the `jivetalking` binary against a copied input file. These exercise the full four-pass pipeline (or just Pass 1 for analysis-only) and are the closest measure of real-world processing time.
+
+```bash
+# Full CLI processing benchmark against a copied input file
+just bench-cli FILE
+
+# Analysis-only CLI benchmark against a copied input file
+just bench-analysis FILE
+```
+
+---
+
+## Noise Removal (`anlmdn`) Variant Matrix
+
+Compares candidate `anlmdn` configurations against the production default. Set `JIVETALKING_BENCH_FIXTURE` to an absolute path; the recipes do not resolve relative paths.
+
+```bash
+# Focused anlmdn variant benchmarks
+JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn
+
+# Capture processed outputs, filter specs, metrics, validation reports, and timing
+just bench-anlmdn-capture
+
+# Profile the production anlmdn variant, anlmdn_sr_32000_best_r
+JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn-profile
+
+# Profile the legacy default for comparison
+JIVETALKING_ANLMDN_PROFILE_VARIANT=anlmdn_legacy_default \
+  JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" \
+  just bench-anlmdn-profile
+```
+
+`anlmdn_sr_32000_best_r` is the production default. It caps the signal to 32 kHz before `anlmdn`, uses `r=0.0045`, and restores the normal 44.1 kHz mono output path afterwards. `anlmdn_legacy_default` keeps the old uncapped path with `r=0.0058` for comparison.
+
+---
+
+## Click Removal (`adeclick`) Variant Matrix
+
+Compares the current production `adeclick` clause against a no-adeclick reference and three threshold/window/overlap candidates. Capture writes per-variant artefacts to `.bench/adeclick/<variant>/`.
+
+```bash
+# Focused Pass 4 adeclick variant benchmarks
+JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-adeclick
+
+# Capture per-variant processed outputs, filter specs, metrics, validation reports, and timing
+just bench-adeclick-capture
+
+# Profile the production adeclick variant, adeclick_current_t_2_0_w_55_o_50_m_s
+JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-adeclick-profile
+
+# Profile the without_adeclick reference for comparison
+JIVETALKING_ADECLICK_PROFILE_VARIANT=without_adeclick \
+  JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" \
+  just bench-adeclick-profile
+```
+
+The adeclick benchmark matrix compares the current production `adeclick=t=2.0:w=55:o=50:m=s` clause against `without_adeclick` and three threshold/window/overlap candidates.
+
+---
+
+## Environment Variables
+
+| Variable | Used by | Purpose |
+|----------|---------|---------|
+| `JIVETALKING_BENCH_FIXTURE` | All `bench-anlmdn-*` and `bench-adeclick-*` recipes | Absolute path to the input audio fixture |
+| `JIVETALKING_ANLMDN_PROFILE_VARIANT` | `bench-anlmdn-profile` | Selects which anlmdn variant to profile (default: `anlmdn_sr_32000_best_r`) |
+| `JIVETALKING_ADECLICK_PROFILE_VARIANT` | `bench-adeclick-profile` | Selects which adeclick variant to profile (default: `adeclick_current_t_2_0_w_55_o_50_m_s`) |
+
+---
+
+## Output Layout
+
+```
+.bench/
+├── cpu.out                      # Processor CPU profile (just bench-profile)
+├── anlmdn/<variant>/            # Per-variant capture artefacts (just bench-anlmdn-capture)
+└── adeclick/<variant>/          # Per-variant capture artefacts (just bench-adeclick-capture)
+```
+
+Each capture directory contains processed output audio, the resolved filter spec, post-processing metrics, the validation report, and timing data for the variant.

--- a/docs/Levelator-Comparison-And-Gap-Analysis.md
+++ b/docs/Levelator-Comparison-And-Gap-Analysis.md
@@ -102,7 +102,7 @@ downmix → ds201_highpass → ds201_lowpass → noiseremove → ds201_gate → 
 |--------|---------------------|-------|
 | **DS201 Highpass** | Frequency (60-120Hz), poles, mix | Spectral centroid, spectral decrease, noise floor |
 | **DS201 Lowpass** | Cutoff frequency, enable/disable | Content type detection (speech/music/mixed), rolloff, ZCR |
-| **NoiseRemove** | Compand threshold, expansion depth (disabled when no noise profile) | Measured noise floor + 5 dB, noise severity; compand requires an elected silence region — `anlmdn` always active |
+| **NoiseRemove** | Compand threshold, expansion depth (disabled when no noise profile) | Measured noise floor + 5 dB, noise severity; compand requires an elected silence region; production `anlmdn` uses the `anlmdn_sr_32000_best_r` path |
 | **DS201 Gate** | Threshold, ratio, attack, release, range, knee | LRA, noise floor, quiet speech estimate, spectral flux, entropy |
 | **LA-2A Compressor** | Threshold, ratio, attack, release, knee, mix | Kurtosis, flux, dynamic range, spectral centroid |
 | **De-esser** | Intensity (0.0-0.6) | Spectral centroid + rolloff |
@@ -143,7 +143,7 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 | **Look-ahead Capability** | Yes—infinite look-ahead via multiple passes | Yes—infinite look-ahead via Pass 1 analysis |
 | **Target Loudness Standard** | -18 dB RMS (custom RMS calculation) | -16 LUFS |
 | **Silence Detection** | Fixed: 50ms subsegments > -44 dB | Adaptive: spectral analysis + room tone scoring |
-| **Noise Reduction** | None | anlmdn (Non-Local Means) + compand |
+| **Noise Reduction** | None | `anlmdn` (Non-Local Means, 32 kHz pre-denoise path, `r=0.0045`) + compand |
 | **Dynamics Processing** | Implicit in leveling algorithm | Explicit LA-2A-style compressor + CBS Volumax limiter |
 | **Gating/Expansion** | None | DS201-inspired soft expander (2:1-4:1 ratio) |
 | **Highpass Filtering** | None | Adaptive 60-120Hz with warm voice protection |
@@ -220,7 +220,7 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 
 ### Capabilities Jivetalking Has That Levelator Lacked
 
-1. **Noise Reduction:** Non-Local Means denoising (`anlmdn`) always active; adaptive compand applied when a silence region is elected as the noise profile
+1. **Noise Reduction:** Non-Local Means denoising (`anlmdn`) always active with the production `anlmdn_sr_32000_best_r` path: 32 kHz before `anlmdn`, `r=0.0045`, then restored to the standard processing/output rate. Adaptive compand applies when a silence region is elected as the noise profile
 2. **Gating:** Soft expander for inter-speech cleanup
 3. **True Peak Limiting:** Prevents inter-sample peaks
 4. **De-essing:** Automatic sibilance control

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -27,6 +27,11 @@ var (
 			Bold(true).
 			Foreground(primaryColor)
 
+	// Warning message style
+	WarningStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FFA500"))
+
 	// Key-value pair styles
 	KeyStyle = lipgloss.NewStyle().
 			Foreground(mutedColor)
@@ -46,4 +51,9 @@ func PrintVersion(version string) {
 // PrintError prints an error message
 func PrintError(message string) {
 	fmt.Fprintf(os.Stderr, "%s %s\n", ErrorStyle.Render("Error:"), message)
+}
+
+// PrintWarning prints a warning message
+func PrintWarning(message string) {
+	fmt.Fprintf(os.Stderr, "%s %s\n", WarningStyle.Render("Warning:"), message)
 }

--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -15,13 +15,21 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
+// AnalysisTimings contains reportable analysis-only stage durations.
+type AnalysisTimings struct {
+	Analysis     time.Duration
+	Adaptation   time.Duration
+	ReportOutput time.Duration
+}
+
 // DisplayAnalysisResults outputs Pass 1 analysis results to the console.
 // Used by --analysis-only mode for rapid inspection without full processing.
-func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig) {
+func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig, timings ...AnalysisTimings) {
 	if measurements == nil {
 		fmt.Fprintf(w, "No analysis data available for %s\n", filepath.Base(inputPath))
 		return
 	}
+	reportOutputStart := time.Now()
 
 	// Header
 	fmt.Fprintln(w, strings.Repeat("=", 70))
@@ -300,6 +308,29 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 			fmt.Fprintf(w, "  ⚠ %s\n", wrapped)
 		}
 	}
+
+	if len(timings) > 0 && hasAnalysisTimings(timings[0]) {
+		fmt.Fprintln(w)
+		writeAnalysisTimingSection(w, completeAnalysisTimings(timings[0], reportOutputStart))
+	}
+}
+
+func hasAnalysisTimings(timings AnalysisTimings) bool {
+	return timings.Analysis > 0 || timings.Adaptation > 0 || timings.ReportOutput > 0
+}
+
+func writeAnalysisTimingSection(w io.Writer, timings AnalysisTimings) {
+	writeAnalysisSection(w, "ANALYSIS TIMINGS")
+	fmt.Fprintf(w, "  Analysis:      %s\n", formatDurationHMS(timings.Analysis.Seconds()))
+	fmt.Fprintf(w, "  Adaptation:    %s\n", formatDurationHMS(timings.Adaptation.Seconds()))
+	fmt.Fprintf(w, "  Report Output: %s\n", formatDurationHMS(timings.ReportOutput.Seconds()))
+}
+
+func completeAnalysisTimings(timings AnalysisTimings, reportOutputStart time.Time) AnalysisTimings {
+	if timings.ReportOutput <= 0 {
+		timings.ReportOutput = time.Since(reportOutputStart)
+	}
+	return timings
 }
 
 // writeSilenceCandidateMetrics writes the metric lines for a single silence candidate.

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -141,6 +141,86 @@ func TestDisplayAnalysisResults_CompanderEnabled(t *testing.T) {
 	}
 }
 
+func TestDisplayAnalysisResults_TimingLabels(t *testing.T) {
+	m := makeMinimalMeasurements()
+	config := processor.DefaultFilterConfig()
+	timings := AnalysisTimings{
+		Analysis:     2 * time.Second,
+		Adaptation:   100 * time.Millisecond,
+		ReportOutput: 50 * time.Millisecond,
+	}
+
+	var buf bytes.Buffer
+	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config, timings)
+	output := buf.String()
+
+	for _, want := range []string{
+		"ANALYSIS TIMINGS",
+		"Analysis:",
+		"Adaptation:",
+		"Report Output:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output", want)
+		}
+	}
+}
+
+func TestCompleteAnalysisTimings_CapturesReportOutput(t *testing.T) {
+	timings := AnalysisTimings{
+		Analysis:   2 * time.Second,
+		Adaptation: 100 * time.Millisecond,
+	}
+
+	completed := completeAnalysisTimings(timings, time.Now().Add(-2*time.Second))
+
+	if completed.ReportOutput <= 0 {
+		t.Fatal("expected ReportOutput to be captured")
+	}
+	if completed.Analysis != timings.Analysis {
+		t.Errorf("Analysis = %s, want %s", completed.Analysis, timings.Analysis)
+	}
+	if completed.Adaptation != timings.Adaptation {
+		t.Errorf("Adaptation = %s, want %s", completed.Adaptation, timings.Adaptation)
+	}
+}
+
+func TestDisplayAnalysisResults_ExcludesProcessingOnlyFields(t *testing.T) {
+	m := makeMinimalMeasurements()
+	config := processor.DefaultFilterConfig()
+	timings := AnalysisTimings{
+		Analysis:   2 * time.Second,
+		Adaptation: 100 * time.Millisecond,
+	}
+
+	var buf bytes.Buffer
+	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config, timings)
+	output := buf.String()
+
+	for _, forbidden := range []string{
+		"Pass 2",
+		"Pass 3",
+		"Pass 4",
+		"Filtered Regions",
+		"Filtered Measurements",
+		"Final Regions",
+		"Final Measurements",
+		"Loudnorm",
+		"loudnorm",
+		"-processed.log",
+		".bench/",
+		"pprof",
+		"Wall Time",
+		"User CPU",
+		"System CPU",
+		"RSS",
+	} {
+		if strings.Contains(output, forbidden) {
+			t.Errorf("expected analysis output to omit %q", forbidden)
+		}
+	}
+}
+
 func TestWriteDiagnosticSilence_VoiceActivated_WithCandidates(t *testing.T) {
 	m := makeMinimalMeasurements()
 	m.VoiceActivated = true

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -369,16 +369,21 @@ func writeSection(f *os.File, title string) {
 	fmt.Fprintln(f, strings.Repeat("-", len(title)))
 }
 
+// ProcessingTimings contains reportable processing pass durations.
+type ProcessingTimings struct {
+	Pass1 time.Duration
+	Pass2 time.Duration
+	Pass3 time.Duration // Loudnorm measurement pass (may be 0 if skipped)
+	Pass4 time.Duration // Loudnorm application pass (may be 0 if skipped)
+}
+
 // ReportData contains all the information needed to generate an analysis report
 type ReportData struct {
 	InputPath    string
 	OutputPath   string
 	StartTime    time.Time
 	EndTime      time.Time
-	Pass1Time    time.Duration
-	Pass2Time    time.Duration
-	Pass3Time    time.Duration // Loudnorm measurement pass (may be 0 if skipped)
-	Pass4Time    time.Duration // Loudnorm application pass (may be 0 if skipped)
+	Timings      ProcessingTimings
 	Result       *processor.ProcessingResult
 	SampleRate   int
 	Channels     int
@@ -1027,15 +1032,26 @@ func writeReportHeader(f *os.File, data ReportData) {
 func writeProcessingSummary(f *os.File, data ReportData) {
 	writeSection(f, "Processing Summary")
 
-	fmt.Fprintf(f, "Pass 1 (Analysis):    %s\n", formatDuration(data.Pass1Time))
-	fmt.Fprintf(f, "Pass 2 (Processing):  %s\n", formatDuration(data.Pass2Time))
+	fmt.Fprintf(f, "Pass 1 (Analysis):    %s\n", formatDuration(data.Timings.Pass1))
+	fmt.Fprintf(f, "Pass 2 (Processing):  %s\n", formatDuration(data.Timings.Pass2))
 
-	if data.Pass3Time > 0 || data.Pass4Time > 0 {
-		fmt.Fprintf(f, "Pass 3 (Measuring):   %s\n", formatDuration(data.Pass3Time))
-		fmt.Fprintf(f, "Pass 4 (Normalising): %s\n", formatDuration(data.Pass4Time))
+	if data.Timings.Pass3 > 0 || data.Timings.Pass4 > 0 {
+		fmt.Fprintf(f, "Pass 3 (Measuring):   %s\n", formatDuration(data.Timings.Pass3))
+		fmt.Fprintf(f, "Pass 4 (Normalising): %s\n", formatDuration(data.Timings.Pass4))
 	} else if data.Result != nil && data.Result.NormResult != nil && data.Result.NormResult.Skipped {
 		fmt.Fprintln(f, "Pass 3 (Measuring):   skipped")
 		fmt.Fprintln(f, "Pass 4 (Normalising): skipped")
+	}
+
+	if data.Result != nil && (data.Result.RegionTimings.FilteredOutput > 0 || data.Result.RegionTimings.FinalOutput > 0) {
+		fmt.Fprintln(f, "")
+		fmt.Fprintln(f, "Metric Timings")
+		if data.Result.RegionTimings.FilteredOutput > 0 {
+			fmt.Fprintf(f, "Filtered Regions:     %s\n", formatDuration(data.Result.RegionTimings.FilteredOutput))
+		}
+		if data.Result.RegionTimings.FinalOutput > 0 {
+			fmt.Fprintf(f, "Final Regions:        %s\n", formatDuration(data.Result.RegionTimings.FinalOutput))
+		}
 	}
 
 	totalTime := data.EndTime.Sub(data.StartTime)

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -1025,6 +1025,8 @@ func writeReportHeader(f *os.File, data ReportData) {
 	fmt.Fprintf(f, "File: %s\n", filepath.Base(data.InputPath))
 	fmt.Fprintf(f, "Processed: %s\n", data.EndTime.Format("2006-01-02 15:04:05 MST"))
 	fmt.Fprintf(f, "Duration: %s\n", formatDuration(time.Duration(data.DurationSecs*float64(time.Second))))
+	fmt.Fprintf(f, "Sample Rate: %d Hz\n", data.SampleRate)
+	fmt.Fprintf(f, "Channels: %s\n", channelName(data.Channels))
 	fmt.Fprintln(f, "")
 }
 

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -689,6 +689,9 @@ func formatNoiseRemoveFilter(f *os.File, cfg *processor.FilterChainConfig, m *pr
 	fmt.Fprintf(f, "%snoiseremove: anlmdn + compand (Non-Local Means denoiser)\n", prefix)
 
 	// anlmdn parameters (fixed from spike validation)
+	if cfg.NoiseRemovePreSampleRate > 0 {
+		fmt.Fprintf(f, "        pre-anlmdn sample rate: %d Hz\n", cfg.NoiseRemovePreSampleRate)
+	}
 	fmt.Fprintf(f, "        anlmdn: s=%.5f, p=%.4fs, r=%.4fs, m=%.0f\n",
 		cfg.NoiseRemoveStrength,
 		cfg.NoiseRemovePatchSec,

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -26,8 +26,20 @@ func makeReportData(t *testing.T) ReportData {
 			Pass4: 4 * time.Second,
 		},
 		Result: &processor.ProcessingResult{
-			Config:     processor.DefaultFilterConfig(),
-			NormResult: &processor.NormalisationResult{},
+			Measurements:         makeInputMeasurements(),
+			FilteredMeasurements: makeOutputMeasurements(-20.2, -2.1, 6.4, makeSilenceSample(-64.0), makeSpeechSample(-24.0)),
+			Config:               processor.DefaultFilterConfig(),
+			NormResult: &processor.NormalisationResult{
+				InputLUFS:  -20.2,
+				OutputLUFS: -16.0,
+				FinalMeasurements: makeOutputMeasurements(
+					-16.0,
+					-1.1,
+					5.9,
+					makeSilenceSample(-61.0),
+					makeSpeechSample(-19.8),
+				),
+			},
 			RegionTimings: processor.RegionMeasurementTimings{
 				FilteredOutput: 100 * time.Millisecond,
 				FinalOutput:    200 * time.Millisecond,
@@ -36,6 +48,122 @@ func makeReportData(t *testing.T) ReportData {
 		SampleRate:   48000,
 		Channels:     1,
 		DurationSecs: 120,
+	}
+}
+
+func makeInputMeasurements() *processor.AudioMeasurements {
+	silenceRegion := processor.SilenceRegion{
+		Start:    10 * time.Second,
+		End:      15 * time.Second,
+		Duration: 5 * time.Second,
+	}
+	speechRegion := processor.SpeechRegion{
+		Start:    30 * time.Second,
+		End:      90 * time.Second,
+		Duration: 60 * time.Second,
+	}
+	silenceSample := makeSilenceSample(-58.0)
+	silenceSample.Region = silenceRegion
+	speechSample := makeSpeechSample(-28.0)
+	speechSample.Region = speechRegion
+
+	return &processor.AudioMeasurements{
+		BaseMeasurements: processor.BaseMeasurements{
+			SpectralCentroid:  2200,
+			SpectralKurtosis:  7.2,
+			SpectralFlatness:  0.18,
+			SpectralFlux:      0.004,
+			DynamicRange:      22.0,
+			MomentaryLoudness: -25.0,
+			ShortTermLoudness: -24.5,
+			SamplePeak:        -4.0,
+		},
+		InputI:           -24.1,
+		InputTP:          -3.2,
+		InputLRA:         7.3,
+		NoiseFloor:       -58.0,
+		NoiseFloorSource: "rms_estimate",
+		NoiseProfile: &processor.NoiseProfile{
+			Start:              silenceRegion.Start,
+			Duration:           silenceRegion.Duration,
+			MeasuredNoiseFloor: -58.0,
+			PeakLevel:          -45.0,
+			CrestFactor:        13.0,
+			Entropy:            0.42,
+		},
+		SilenceCandidates: []processor.SilenceCandidateMetrics{*silenceSample},
+		SpeechProfile:     speechSample,
+	}
+}
+
+func makeOutputMeasurements(inputI, inputTP, inputLRA float64, silenceSample *processor.SilenceCandidateMetrics, speechSample *processor.SpeechCandidateMetrics) *processor.OutputMeasurements {
+	return &processor.OutputMeasurements{
+		BaseMeasurements: processor.BaseMeasurements{
+			MomentaryLoudness: inputI - 0.5,
+			ShortTermLoudness: inputI - 0.2,
+			SamplePeak:        inputTP - 0.3,
+		},
+		OutputI:       inputI,
+		OutputTP:      inputTP,
+		OutputLRA:     inputLRA,
+		SilenceSample: silenceSample,
+		SpeechSample:  speechSample,
+	}
+}
+
+func makeSilenceSample(rms float64) *processor.SilenceCandidateMetrics {
+	return &processor.SilenceCandidateMetrics{
+		Region:      processor.SilenceRegion{Start: 10 * time.Second, End: 15 * time.Second, Duration: 5 * time.Second},
+		RMSLevel:    rms,
+		PeakLevel:   rms + 12,
+		CrestFactor: 12,
+		Spectral: processor.SpectralMetrics{
+			Mean:     0.001,
+			Variance: 0.0001,
+			Centroid: 950,
+			Spread:   1200,
+			Skewness: 0.4,
+			Kurtosis: 5.1,
+			Entropy:  0.42,
+			Flatness: 0.32,
+			Crest:    8.5,
+			Flux:     0.002,
+			Slope:    -0.0002,
+			Decrease: 0.04,
+			Rolloff:  3600,
+		},
+		MomentaryLUFS: rms - 2,
+		ShortTermLUFS: rms - 1,
+		TruePeak:      rms + 12,
+		SamplePeak:    rms + 11,
+	}
+}
+
+func makeSpeechSample(rms float64) *processor.SpeechCandidateMetrics {
+	return &processor.SpeechCandidateMetrics{
+		Region:      processor.SpeechRegion{Start: 30 * time.Second, End: 90 * time.Second, Duration: 60 * time.Second},
+		RMSLevel:    rms,
+		PeakLevel:   rms + 10,
+		CrestFactor: 10,
+		Spectral: processor.SpectralMetrics{
+			Mean:     0.01,
+			Variance: 0.002,
+			Centroid: 2400,
+			Spread:   1800,
+			Skewness: 0.7,
+			Kurtosis: 7.4,
+			Entropy:  0.24,
+			Flatness: 0.18,
+			Crest:    26.0,
+			Flux:     0.006,
+			Slope:    -0.0001,
+			Decrease: 0.06,
+			Rolloff:  6200,
+		},
+		MomentaryLUFS: rms - 1,
+		ShortTermLUFS: rms - 0.5,
+		TruePeak:      rms + 10,
+		SamplePeak:    rms + 9,
 	}
 }
 
@@ -62,6 +190,47 @@ func TestGenerateReport_RegionMetricTimings(t *testing.T) {
 	} {
 		if strings.Contains(output, blocked) {
 			t.Errorf("report contains benchmark/runtime artefact field %q", blocked)
+		}
+	}
+}
+
+func TestGenerateReport_MetadataFields(t *testing.T) {
+	output := generateReportText(t, makeReportData(t))
+
+	for _, want := range []string{
+		"Duration: 2m 0s",
+		"Sample Rate: 48000 Hz",
+		"Channels: mono",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}
+
+func TestGenerateReport_AudioMetricTables(t *testing.T) {
+	output := generateReportText(t, makeReportData(t))
+
+	for _, want := range []string{
+		"Loudness Measurements",
+		"Input",
+		"Filtered",
+		"Final",
+		"Integrated Loudness",
+		"-24.1",
+		"-20.2",
+		"-16.0",
+		"Noise Floor Analysis",
+		"RMS Level",
+		"-58.0",
+		"-64.0",
+		"-61.0",
+		"Speech Region Analysis",
+		"Spectral Centroid",
+		"2400",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
 		}
 	}
 }

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -1,0 +1,115 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+func makeReportData(t *testing.T) ReportData {
+	t.Helper()
+
+	start := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return ReportData{
+		InputPath:  filepath.Join(t.TempDir(), "input.wav"),
+		OutputPath: filepath.Join(t.TempDir(), "input-LUFS-16-processed.flac"),
+		StartTime:  start,
+		EndTime:    start.Add(8 * time.Second),
+		Timings: ProcessingTimings{
+			Pass1: 1 * time.Second,
+			Pass2: 2 * time.Second,
+			Pass3: 3 * time.Second,
+			Pass4: 4 * time.Second,
+		},
+		Result: &processor.ProcessingResult{
+			Config:     processor.DefaultFilterConfig(),
+			NormResult: &processor.NormalisationResult{},
+			RegionTimings: processor.RegionMeasurementTimings{
+				FilteredOutput: 100 * time.Millisecond,
+				FinalOutput:    200 * time.Millisecond,
+			},
+		},
+		SampleRate:   48000,
+		Channels:     1,
+		DurationSecs: 120,
+	}
+}
+
+func TestGenerateReport_RegionMetricTimings(t *testing.T) {
+	output := generateReportText(t, makeReportData(t))
+
+	for _, want := range []string{
+		"Metric Timings",
+		"Filtered Regions:     0.1s",
+		"Final Regions:        0.2s",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+
+	for _, blocked := range []string{
+		"wall time",
+		"user CPU",
+		"system CPU",
+		"RSS",
+		"pprof",
+		".bench/",
+	} {
+		if strings.Contains(output, blocked) {
+			t.Errorf("report contains benchmark/runtime artefact field %q", blocked)
+		}
+	}
+}
+
+func generateReportText(t *testing.T, data ReportData) string {
+	t.Helper()
+
+	if err := GenerateReport(data); err != nil {
+		t.Fatalf("GenerateReport failed: %v", err)
+	}
+
+	logPath := strings.TrimSuffix(data.OutputPath, filepath.Ext(data.OutputPath)) + ".log"
+	text, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read report: %v", err)
+	}
+	return string(text)
+}
+
+func TestGenerateReport_ProcessingTimingLabels(t *testing.T) {
+	output := generateReportText(t, makeReportData(t))
+
+	for _, want := range []string{
+		"Pass 1 (Analysis):    1.0s",
+		"Pass 2 (Processing):  2.0s",
+		"Pass 3 (Measuring):   3.0s",
+		"Pass 4 (Normalising): 4.0s",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}
+
+func TestGenerateReport_SkippedNormalisationTimingLabels(t *testing.T) {
+	data := makeReportData(t)
+	data.Timings.Pass3 = 0
+	data.Timings.Pass4 = 0
+	data.Result.NormResult.Skipped = true
+
+	output := generateReportText(t, data)
+
+	for _, want := range []string{
+		"Pass 3 (Measuring):   skipped",
+		"Pass 4 (Normalising): skipped",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -678,7 +678,7 @@ func tuneDS201LowPassForSpeech(config *FilterChainConfig, m *AudioMeasurements) 
 // anlmdn remains constant because spike testing validated these parameters:
 // - strength: 0.00001 (minimum)
 // - patch: 6ms (context window)
-// - research: 5.8ms (search window)
+// - research: production default (search window)
 // - smooth: 11 (weight smoothing)
 func tuneNoiseRemove(config *FilterChainConfig, m *AudioMeasurements) {
 	if !config.NoiseRemoveEnabled {

--- a/internal/processor/adeclick_benchmark_test.go
+++ b/internal/processor/adeclick_benchmark_test.go
@@ -1,0 +1,1472 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linuxmatters/jivetalking/internal/audio"
+)
+
+const (
+	adeclickBenchmarkCaptureEnv      = "JIVETALKING_ADECLICK_BENCH_CAPTURE"
+	adeclickBenchmarkCaptureRootEnv  = "JIVETALKING_ADECLICK_BENCH_CAPTURE_ROOT"
+	adeclickBenchmarkMediaCaptureEnv = "JIVETALKING_ADECLICK_BENCH_MEDIA_CAPTURE"
+	adeclickBenchmarkCaptureRoot     = ".bench/adeclick"
+	adeclickBenchmarkBaselineVariant = "adeclick_current_t_2_0_w_55_o_50_m_s"
+	adeclickBenchmarkExcerptSecs     = 30.0
+)
+
+// adeclickBenchmarkParams describes the variant-specific adeclick clause.
+// Enabled=false produces no adeclick clause, modelling the without_adeclick variant.
+type adeclickBenchmarkParams struct {
+	Enabled   bool
+	Threshold float64
+	Window    float64
+	Overlap   float64
+	Method    string // empty = default ("a"); "s" = spline interpolation
+}
+
+// Clause renders the adeclick FFmpeg filter clause for the variant, or empty
+// when the variant disables adeclick.
+func (p adeclickBenchmarkParams) Clause() string {
+	if !p.Enabled {
+		return ""
+	}
+	clause := fmt.Sprintf("adeclick=t=%.1f:w=%.0f:o=%.0f", p.Threshold, p.Window, p.Overlap)
+	if p.Method != "" {
+		clause += ":m=" + p.Method
+	}
+	return clause
+}
+
+// adeclickBenchmarkVariant identifies a Pass 4 candidate by name with its
+// adeclick clause parameters. The intent and validation priority mirror the
+// shape of the ANLMDN benchmark manifest.
+type adeclickBenchmarkVariant struct {
+	Name               string
+	ParameterIntent    string
+	ValidationPriority string
+	Params             adeclickBenchmarkParams
+}
+
+// adeclickBenchmarkVariants returns the focused Pass 4 adeclick benchmark
+// matrix in proposal order. The current production setting is the second
+// entry; the first variant disables adeclick to provide an upper-bound
+// "no repair" reference.
+func adeclickBenchmarkVariants() []adeclickBenchmarkVariant {
+	return []adeclickBenchmarkVariant{
+		{
+			Name:               "without_adeclick",
+			ParameterIntent:    "Pass 4 without click/pop repair, upper-bound speed reference.",
+			ValidationPriority: "no-adeclick-baseline",
+			Params:             adeclickBenchmarkParams{Enabled: false},
+		},
+		{
+			Name:               "adeclick_current_t_2_0_w_55_o_50_m_s",
+			ParameterIntent:    "Current production settings: t=2.0, w=55ms, o=50% overlap, spline interpolation (m=s).",
+			ValidationPriority: "production-default",
+			Params: adeclickBenchmarkParams{
+				Enabled:   true,
+				Threshold: 2.0,
+				Window:    55.0,
+				Overlap:   50.0,
+				Method:    "s",
+			},
+		},
+		{
+			Name:               "adeclick_t_2_0_w_55_o_75",
+			ParameterIntent:    "Less sensitive threshold (t=2.0) at the previous production window/overlap.",
+			ValidationPriority: "tier1-threshold",
+			Params: adeclickBenchmarkParams{
+				Enabled:   true,
+				Threshold: 2.0,
+				Window:    55.0,
+				Overlap:   75.0,
+			},
+		},
+		{
+			Name:               "adeclick_t_2_0_w_55_o_50",
+			ParameterIntent:    "Less sensitive threshold with lower 50% overlap to reduce cost.",
+			ValidationPriority: "tier2-overlap",
+			Params: adeclickBenchmarkParams{
+				Enabled:   true,
+				Threshold: 2.0,
+				Window:    55.0,
+				Overlap:   50.0,
+			},
+		},
+		{
+			Name:               "adeclick_t_2_0_w_30_o_50",
+			ParameterIntent:    "Less sensitive threshold with smaller 30ms window and lower overlap.",
+			ValidationPriority: "tier2-window",
+			Params: adeclickBenchmarkParams{
+				Enabled:   true,
+				Threshold: 2.0,
+				Window:    30.0,
+				Overlap:   50.0,
+			},
+		},
+	}
+}
+
+// adeclickBenchmarkVariantSpec pairs a variant with its built Pass 4 candidate spec.
+type adeclickBenchmarkVariantSpec struct {
+	Variant adeclickBenchmarkVariant
+	Spec    string
+}
+
+// buildAdeclickBenchmarkVariantSpec builds the Pass 4 candidate filter graph for a
+// single variant. The base chain is the production-derived loudnorm clause and
+// limiter prefix taken from the supplied loudnorm setup; only the adeclick segment
+// between loudnorm and the metric tail varies between variants.
+func buildAdeclickBenchmarkVariantSpec(loudnorm *fullbenchLoudnormSetup, variant adeclickBenchmarkVariant) string {
+	if loudnorm == nil || loudnorm.EffectiveConfig == nil || loudnorm.Measurement == nil {
+		return ""
+	}
+
+	parts := make([]string, 0, 5)
+	if loudnorm.Pass3FilterPrefix != "" {
+		parts = append(parts, loudnorm.Pass3FilterPrefix)
+	}
+	parts = append(parts, buildFullbenchLoudnormClause(loudnorm.EffectiveConfig, loudnorm.Measurement))
+	if clause := variant.Params.Clause(); clause != "" {
+		parts = append(parts, clause)
+	}
+	if analysis := buildFullbenchPass4OutputAnalysisFilters(loudnorm.EffectiveConfig, loudnorm.Measurement); analysis != "" {
+		parts = append(parts, analysis)
+	}
+	parts = append(parts, buildFullbenchPass4ResampleFilter(loudnorm.EffectiveConfig))
+
+	return strings.Join(parts, ",")
+}
+
+// buildAdeclickBenchmarkVariantSpecs builds candidate Pass 4 specs for the entire
+// manifest, asserting via tb that each spec is non-empty and contains the shared
+// final metric and resample tail.
+func buildAdeclickBenchmarkVariantSpecs(tb testing.TB, loudnorm *fullbenchLoudnormSetup) []adeclickBenchmarkVariantSpec {
+	tb.Helper()
+
+	if loudnorm == nil || loudnorm.EffectiveConfig == nil || loudnorm.Measurement == nil {
+		tb.Fatal("adeclick benchmark variant specs require a loudnorm setup")
+	}
+
+	variants := adeclickBenchmarkVariants()
+	specs := make([]adeclickBenchmarkVariantSpec, 0, len(variants))
+	for _, variant := range variants {
+		spec := buildAdeclickBenchmarkVariantSpec(loudnorm, variant)
+		if spec == "" {
+			tb.Fatalf("adeclick benchmark variant %q produced empty filter spec", variant.Name)
+		}
+		if !strings.Contains(spec, "loudnorm=") {
+			tb.Fatalf("adeclick benchmark variant %q missing loudnorm clause\nSpec: %s", variant.Name, spec)
+		}
+		specs = append(specs, adeclickBenchmarkVariantSpec{Variant: variant, Spec: spec})
+	}
+
+	return specs
+}
+
+// findAdeclickBenchmarkVariant returns the named variant from the manifest, or
+// fails the test if it is absent.
+func findAdeclickBenchmarkVariant(tb testing.TB, name string) adeclickBenchmarkVariant {
+	tb.Helper()
+
+	for _, variant := range adeclickBenchmarkVariants() {
+		if variant.Name == name {
+			return variant
+		}
+	}
+	tb.Fatalf("missing adeclick benchmark variant %q", name)
+	return adeclickBenchmarkVariant{}
+}
+
+// newAdeclickBenchmarkLoudnormSetup creates a synthetic loudnorm setup suitable
+// for spec-shape tests that do not require a real fixture.
+func newAdeclickBenchmarkLoudnormSetup(includeLimiterPrefix bool) *fullbenchLoudnormSetup {
+	config := newTestConfig()
+	config.AdeclickEnabled = true
+	config.ResampleEnabled = false
+	measurement := &LoudnormMeasurement{
+		InputI:       -24.0,
+		InputTP:      -6.0,
+		InputLRA:     7.0,
+		InputThresh:  -34.0,
+		TargetOffset: -1.0,
+	}
+
+	setup := &fullbenchLoudnormSetup{
+		Measurement:     measurement,
+		EffectiveConfig: config,
+	}
+	if includeLimiterPrefix {
+		setup.Pass3FilterPrefix = buildPreLimiterPrefix(0, -12.0, true)
+		setup.LimiterNeeded = true
+		setup.LimiterCeiling = -12.0
+	}
+	return setup
+}
+
+// =============================================================================
+// Phase 1 tests
+// =============================================================================
+
+func TestAdeclickBenchmarkVariantManifest(t *testing.T) {
+	variants := adeclickBenchmarkVariants()
+	expectedNames := []string{
+		"without_adeclick",
+		"adeclick_current_t_2_0_w_55_o_50_m_s",
+		"adeclick_t_2_0_w_55_o_75",
+		"adeclick_t_2_0_w_55_o_50",
+		"adeclick_t_2_0_w_30_o_50",
+	}
+
+	if len(variants) != len(expectedNames) {
+		t.Fatalf("got %d adeclick benchmark variants, want %d", len(variants), len(expectedNames))
+	}
+
+	for i, want := range expectedNames {
+		if variants[i].Name != want {
+			t.Fatalf("variants[%d].Name = %q, want %q", i, variants[i].Name, want)
+		}
+		if variants[i].ParameterIntent == "" {
+			t.Fatalf("variant %q missing parameter intent", variants[i].Name)
+		}
+		if variants[i].ValidationPriority == "" {
+			t.Fatalf("variant %q missing validation priority", variants[i].Name)
+		}
+	}
+
+	current := findAdeclickBenchmarkVariant(t, "adeclick_current_t_2_0_w_55_o_50_m_s")
+	if !current.Params.Enabled {
+		t.Fatal("adeclick_current_t_2_0_w_55_o_50_m_s must enable adeclick")
+	}
+	if current.Params.Threshold != 2.0 || current.Params.Window != 55.0 || current.Params.Overlap != 50.0 {
+		t.Fatalf("adeclick_current_t_2_0_w_55_o_50_m_s params = %+v, want t=2.0 w=55 o=50", current.Params)
+	}
+	if current.Params.Method != "s" {
+		t.Fatalf("adeclick_current_t_2_0_w_55_o_50_m_s method = %q, want %q", current.Params.Method, "s")
+	}
+
+	none := findAdeclickBenchmarkVariant(t, "without_adeclick")
+	if none.Params.Enabled {
+		t.Fatal("without_adeclick must disable adeclick")
+	}
+	if clause := none.Params.Clause(); clause != "" {
+		t.Fatalf("without_adeclick clause = %q, want empty", clause)
+	}
+}
+
+func TestAdeclickBenchmarkVariantParamClauses(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantClause string
+	}{
+		{"without_adeclick", ""},
+		{"adeclick_current_t_2_0_w_55_o_50_m_s", "adeclick=t=2.0:w=55:o=50:m=s"},
+		{"adeclick_t_2_0_w_55_o_75", "adeclick=t=2.0:w=55:o=75"},
+		{"adeclick_t_2_0_w_55_o_50", "adeclick=t=2.0:w=55:o=50"},
+		{"adeclick_t_2_0_w_30_o_50", "adeclick=t=2.0:w=30:o=50"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variant := findAdeclickBenchmarkVariant(t, tt.name)
+			if got := variant.Params.Clause(); got != tt.wantClause {
+				t.Fatalf("clause = %q, want %q", got, tt.wantClause)
+			}
+		})
+	}
+}
+
+func TestAdeclickBenchmarkVariantSpecsContainCommonTail(t *testing.T) {
+	loudnorm := newAdeclickBenchmarkLoudnormSetup(false)
+	specs := buildAdeclickBenchmarkVariantSpecs(t, loudnorm)
+	if len(specs) != len(adeclickBenchmarkVariants()) {
+		t.Fatalf("got %d specs, want %d", len(specs), len(adeclickBenchmarkVariants()))
+	}
+
+	for _, vs := range specs {
+		t.Run(vs.Variant.Name, func(t *testing.T) {
+			assertFullbenchSpecContains(t, vs.Spec, []string{
+				"loudnorm=",
+				"astats=",
+				"aspectralstats=",
+				"ebur128=",
+				"aformat=sample_rates=44100",
+				"asetnsamples=",
+			})
+			assertFullbenchSpecOrder(t, vs.Spec, []string{
+				"loudnorm=",
+				"astats=",
+				"aspectralstats=",
+				"ebur128=",
+				"aformat=sample_rates=44100",
+				"asetnsamples=",
+			})
+		})
+	}
+}
+
+func TestAdeclickBenchmarkCurrentVariantPlacement(t *testing.T) {
+	loudnorm := newAdeclickBenchmarkLoudnormSetup(false)
+	current := findAdeclickBenchmarkVariant(t, "adeclick_current_t_2_0_w_55_o_50_m_s")
+	spec := buildAdeclickBenchmarkVariantSpec(loudnorm, current)
+
+	if !strings.Contains(spec, "adeclick=t=2.0:w=55:o=50:m=s") {
+		t.Fatalf("current variant missing production adeclick clause\nSpec: %s", spec)
+	}
+	assertFullbenchSpecOrder(t, spec, []string{
+		"loudnorm=",
+		"adeclick=t=2.0:w=55:o=50:m=s",
+		"astats=",
+		"aspectralstats=",
+		"ebur128=",
+		"aformat=sample_rates=44100",
+		"asetnsamples=",
+	})
+}
+
+func TestAdeclickBenchmarkWithoutAdeclickOmitsClause(t *testing.T) {
+	loudnorm := newAdeclickBenchmarkLoudnormSetup(false)
+	variant := findAdeclickBenchmarkVariant(t, "without_adeclick")
+	spec := buildAdeclickBenchmarkVariantSpec(loudnorm, variant)
+
+	assertFullbenchSpecExcludes(t, spec, []string{"adeclick="})
+	assertFullbenchSpecContains(t, spec, []string{
+		"loudnorm=",
+		"astats=",
+		"aspectralstats=",
+		"ebur128=",
+		"aformat=sample_rates=44100",
+		"asetnsamples=",
+	})
+}
+
+func TestAdeclickBenchmarkLimiterPrefixSharedAcrossVariants(t *testing.T) {
+	loudnorm := newAdeclickBenchmarkLoudnormSetup(true)
+	if loudnorm.Pass3FilterPrefix == "" {
+		t.Fatal("synthetic loudnorm setup missing limiter prefix")
+	}
+	specs := buildAdeclickBenchmarkVariantSpecs(t, loudnorm)
+
+	// Each variant must start with the limiter prefix and end with the loudnorm
+	// clause before any adeclick/metric segment.
+	for _, vs := range specs {
+		t.Run(vs.Variant.Name, func(t *testing.T) {
+			if !strings.HasPrefix(vs.Spec, loudnorm.Pass3FilterPrefix+",") {
+				t.Fatalf("variant %q missing or misplaced limiter prefix\nSpec: %s", vs.Variant.Name, vs.Spec)
+			}
+			limiterIdx := strings.Index(vs.Spec, "alimiter=")
+			loudnormIdx := strings.Index(vs.Spec, "loudnorm=")
+			if limiterIdx == -1 {
+				t.Fatalf("variant %q missing alimiter clause\nSpec: %s", vs.Variant.Name, vs.Spec)
+			}
+			if loudnormIdx == -1 || loudnormIdx <= limiterIdx {
+				t.Fatalf("variant %q has alimiter=/loudnorm= out of order\nSpec: %s", vs.Variant.Name, vs.Spec)
+			}
+		})
+	}
+}
+
+func TestAdeclickBenchmarkOnlyAdeclickClauseDiffers(t *testing.T) {
+	loudnorm := newAdeclickBenchmarkLoudnormSetup(true)
+	specs := buildAdeclickBenchmarkVariantSpecs(t, loudnorm)
+
+	stripAdeclick := func(spec string) string {
+		clauses := strings.Split(spec, ",")
+		filtered := clauses[:0]
+		for _, clause := range clauses {
+			if strings.HasPrefix(clause, "adeclick=") {
+				continue
+			}
+			filtered = append(filtered, clause)
+		}
+		return strings.Join(filtered, ",")
+	}
+
+	baseline := stripAdeclick(specs[0].Spec)
+	for _, vs := range specs[1:] {
+		if got := stripAdeclick(vs.Spec); got != baseline {
+			t.Fatalf("non-adeclick segments drifted for %q\nbaseline: %s\ncandidate: %s", vs.Variant.Name, baseline, got)
+		}
+	}
+}
+
+func TestAdeclickBenchmarkProductionDefaultsUnchanged(t *testing.T) {
+	config := DefaultFilterConfig()
+
+	if !config.AdeclickEnabled {
+		t.Fatal("DefaultFilterConfig().AdeclickEnabled = false, want true")
+	}
+	if config.AdeclickThreshold != 2.0 {
+		t.Fatalf("DefaultFilterConfig().AdeclickThreshold = %.2f, want 2.0", config.AdeclickThreshold)
+	}
+	if config.AdeclickWindow != 55.0 {
+		t.Fatalf("DefaultFilterConfig().AdeclickWindow = %.2f, want 55.0", config.AdeclickWindow)
+	}
+	if config.AdeclickOverlap != 50.0 {
+		t.Fatalf("DefaultFilterConfig().AdeclickOverlap = %.2f, want 50.0", config.AdeclickOverlap)
+	}
+	if config.AdeclickMethod != "s" {
+		t.Fatalf("DefaultFilterConfig().AdeclickMethod = %q, want %q", config.AdeclickMethod, "s")
+	}
+}
+
+// =============================================================================
+// Phase 2 - benchmark execution and synthetic coverage
+// =============================================================================
+
+// BenchmarkAdeclickVariants benchmarks each Pass 4 candidate filter graph
+// against the same Pass 2 seed. Pass 1, adapted Pass 2, and Pass 3 loudnorm
+// measurement run once before the variant loop, so the per-variant timing
+// measures only the candidate Pass 4 graph execution.
+func BenchmarkAdeclickVariants(b *testing.B) {
+	inputPath := resolveFullbenchFixture(b)
+	seed := setupFullbenchPass4Seed(b, inputPath)
+	if seed == nil || seed.Pass2Seed == nil || seed.Loudnorm == nil {
+		b.Fatal("adeclick benchmark setup returned incomplete seed")
+	}
+
+	variantSpecs := buildAdeclickBenchmarkVariantSpecs(b, seed.Loudnorm)
+
+	if root, ok := resolveAdeclickBenchmarkCaptureRoot(); ok {
+		captureAdeclickBenchmarkArtifacts(b, inputPath, seed, variantSpecs, root)
+	}
+
+	for _, vs := range variantSpecs {
+		b.Run(vs.Variant.Name, func(b *testing.B) {
+			outputDir := b.TempDir()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				outputPath := filepath.Join(outputDir, fmt.Sprintf("%s-%d.flac", vs.Variant.Name, i))
+				_, outputMeasurements := runFullbenchFilterSpec(b, seed.Pass2Seed.OutputPath, outputPath, vs.Spec, true)
+				if outputMeasurements == nil {
+					b.Fatalf("expected output measurements for adeclick variant %q", vs.Variant.Name)
+				}
+
+				b.StopTimer()
+				if err := os.Remove(outputPath); err != nil {
+					b.Fatalf("failed to remove adeclick benchmark output: %v", err)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// TestAdeclickBenchmarkSyntheticSmoke exercises a representative subset of the
+// matrix against synthetic audio so contributors without the real fixture can
+// still validate the candidate Pass 4 graph executes and produces measurements.
+func TestAdeclickBenchmarkSyntheticSmoke(t *testing.T) {
+	inputPath := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 2.0,
+		SampleRate:   44100,
+		ToneFreq:     180.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -58.0,
+		Dir:          t.TempDir(),
+	})
+	defer cleanupTestAudio(t, inputPath)
+
+	seed := setupFullbenchPass4Seed(t, inputPath)
+	if seed == nil || seed.Pass2Seed == nil || seed.Loudnorm == nil {
+		t.Fatal("synthetic Pass 4 seed setup returned incomplete result")
+	}
+
+	smokeNames := []string{
+		"without_adeclick",
+		"adeclick_current_t_2_0_w_55_o_50_m_s",
+	}
+	for _, name := range smokeNames {
+		t.Run(name, func(t *testing.T) {
+			variant := findAdeclickBenchmarkVariant(t, name)
+			spec := buildAdeclickBenchmarkVariantSpec(seed.Loudnorm, variant)
+			if spec == "" {
+				t.Fatalf("variant %q produced empty spec", name)
+			}
+
+			outputPath := filepath.Join(t.TempDir(), name+".flac")
+			result := runFullbenchFilterSpecResult(t, seed.Pass2Seed.OutputPath, outputPath, spec)
+			if result.OutputMeasurements == nil {
+				t.Fatalf("variant %q produced no output measurements", name)
+			}
+			if result.OutputMetadata == nil {
+				t.Fatalf("variant %q produced no output metadata", name)
+			}
+			assertFullbenchFLACOutput(t, outputPath)
+
+			// Sanity: ebur128 inside the candidate graph must have populated OutputI.
+			if result.OutputMeasurements.OutputI == 0 {
+				t.Fatalf("variant %q has zero OutputI; candidate metric chain may be inactive", name)
+			}
+		})
+	}
+}
+
+// TestAdeclickBenchmarkExtractMeasurementsRequired guards the contract that
+// candidate Pass 4 specs always request output measurements when run via the
+// benchmark; the candidate graph terminates in astats/aspectralstats/ebur128
+// and the snapshot capture relies on those measurements.
+func TestAdeclickBenchmarkExtractMeasurementsRequired(t *testing.T) {
+	inputPath := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 1.5,
+		SampleRate:   44100,
+		ToneFreq:     220.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -58.0,
+		Dir:          t.TempDir(),
+	})
+	defer cleanupTestAudio(t, inputPath)
+
+	seed := setupFullbenchPass4Seed(t, inputPath)
+	variant := findAdeclickBenchmarkVariant(t, "adeclick_current_t_2_0_w_55_o_50_m_s")
+	spec := buildAdeclickBenchmarkVariantSpec(seed.Loudnorm, variant)
+
+	outputPath := filepath.Join(t.TempDir(), "measured.flac")
+	_, measured := runFullbenchFilterSpec(t, seed.Pass2Seed.OutputPath, outputPath, spec, true)
+	if measured == nil {
+		t.Fatal("candidate Pass 4 run did not produce OutputMeasurements when requested")
+	}
+}
+
+func TestAdeclickBenchmarkCurrentVariantMatchesProduction(t *testing.T) {
+	current := findAdeclickBenchmarkVariant(t, "adeclick_current_t_2_0_w_55_o_50_m_s")
+	defaults := DefaultFilterConfig()
+
+	if current.Params.Threshold != defaults.AdeclickThreshold {
+		t.Fatalf("variant threshold = %.2f, default = %.2f", current.Params.Threshold, defaults.AdeclickThreshold)
+	}
+	if current.Params.Window != defaults.AdeclickWindow {
+		t.Fatalf("variant window = %.2f, default = %.2f", current.Params.Window, defaults.AdeclickWindow)
+	}
+	if current.Params.Overlap != defaults.AdeclickOverlap {
+		t.Fatalf("variant overlap = %.2f, default = %.2f", current.Params.Overlap, defaults.AdeclickOverlap)
+	}
+	if current.Params.Method != defaults.AdeclickMethod {
+		t.Fatalf("variant method = %q, default = %q", current.Params.Method, defaults.AdeclickMethod)
+	}
+	wantClause := fmt.Sprintf("adeclick=t=%.1f:w=%.0f:o=%.0f",
+		defaults.AdeclickThreshold, defaults.AdeclickWindow, defaults.AdeclickOverlap)
+	if defaults.AdeclickMethod != "" {
+		wantClause += ":m=" + defaults.AdeclickMethod
+	}
+	if got := current.Params.Clause(); got != wantClause {
+		t.Fatalf("variant clause = %q, want %q", got, wantClause)
+	}
+
+	// The benchmark loudnorm clause must remain identical to the production
+	// loudnorm clause derived via buildLoudnormFilterSpec().
+	productionConfig := *defaults
+	productionConfig.AdeclickEnabled = false
+	measurement := &LoudnormMeasurement{
+		InputI:       -23.5,
+		InputTP:      -4.0,
+		InputLRA:     6.0,
+		InputThresh:  -33.0,
+		TargetOffset: -0.5,
+	}
+	productionClause := extractFullbenchFilterClause(
+		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false),
+		"loudnorm=",
+	)
+	benchmarkClause := buildFullbenchLoudnormClause(defaults, measurement)
+	if benchmarkClause != productionClause {
+		t.Fatalf("benchmark loudnorm clause drifted from production\nbenchmark:  %s\nproduction: %s",
+			benchmarkClause, productionClause)
+	}
+}
+
+// =============================================================================
+// Phase 3 - artefact capture
+// =============================================================================
+
+// adeclickBenchmarkAudioMetadataSnapshot captures decoded metadata for the
+// candidate Pass 4 output FLAC.
+type adeclickBenchmarkAudioMetadataSnapshot struct {
+	SampleRate    int     `json:"sample_rate"`
+	Channels      int     `json:"channels"`
+	DurationSecs  float64 `json:"duration_secs"`
+	SampleFmt     string  `json:"sample_fmt,omitempty"`
+	ChannelLayout string  `json:"channel_layout,omitempty"`
+	BitDepth      int     `json:"bit_depth,omitempty"`
+}
+
+// adeclickBenchmarkLoudnormSnapshot captures the loudnorm setup that produced
+// the candidate Pass 4 chain. These values are shared across variants because
+// only the adeclick clause changes between candidates.
+type adeclickBenchmarkLoudnormSnapshot struct {
+	InputI           float64 `json:"input_i"`
+	InputTP          float64 `json:"input_tp"`
+	InputLRA         float64 `json:"input_lra"`
+	InputThresh      float64 `json:"input_thresh"`
+	TargetOffset     float64 `json:"target_offset"`
+	RequestedTargetI float64 `json:"requested_target_i"`
+	EffectiveTargetI float64 `json:"effective_target_i"`
+	LinearModeForced bool    `json:"linear_mode_forced"`
+	LimiterEnabled   bool    `json:"limiter_enabled"`
+	LimiterCeiling   float64 `json:"limiter_ceiling"`
+	PreGainDB        float64 `json:"pre_gain_db"`
+	LimiterClamped   bool    `json:"limiter_clamped"`
+}
+
+// adeclickBenchmarkEnvironmentSnapshot captures host environment context.
+type adeclickBenchmarkEnvironmentSnapshot struct {
+	GoVersion                  string `json:"go_version"`
+	GOOS                       string `json:"goos"`
+	GOARCH                     string `json:"goarch"`
+	NumCPU                     int    `json:"num_cpu"`
+	CPUModel                   string `json:"cpu_model"`
+	BenchmarkFixturePath       string `json:"benchmark_fixture_path"`
+	FfmpegStatigoModuleVersion string `json:"ffmpeg_statigo_module_version"`
+	FfmpegStatigoModuleReplace string `json:"ffmpeg_statigo_module_replace"`
+}
+
+// adeclickBenchmarkMetricsSnapshot is the per-variant capture record persisted
+// to metrics.json. The candidate Pass 4 graph terminates in astats /
+// aspectralstats / ebur128, so final measurements come directly from the
+// candidate run rather than from a separate ApplyNormalisation() call.
+type adeclickBenchmarkMetricsSnapshot struct {
+	VariantName                 string                                 `json:"variant_name"`
+	ParameterIntent             string                                 `json:"parameter_intent"`
+	ValidationPriority          string                                 `json:"validation_priority"`
+	AdeclickEnabled             bool                                   `json:"adeclick_enabled"`
+	AdeclickThreshold           float64                                `json:"adeclick_threshold,omitempty"`
+	AdeclickWindow              float64                                `json:"adeclick_window,omitempty"`
+	AdeclickOverlap             float64                                `json:"adeclick_overlap,omitempty"`
+	AdeclickMethod              string                                 `json:"adeclick_method,omitempty"`
+	FilterSpec                  string                                 `json:"filter_spec"`
+	Pass4RuntimeMS              float64                                `json:"pass4_runtime_ms"`
+	FinalLUFS                   float64                                `json:"final_lufs"`
+	FinalTruePeak               float64                                `json:"final_true_peak"`
+	FinalLRA                    float64                                `json:"final_lra"`
+	FinalNoiseFloor             float64                                `json:"final_noise_floor"`
+	FinalSpectralCentroid       float64                                `json:"final_spectral_centroid"`
+	FinalSpectralRolloff        float64                                `json:"final_spectral_rolloff"`
+	FinalSpeechRMS              float64                                `json:"final_speech_rms"`
+	MissingSilenceProfile       bool                                   `json:"missing_silence_profile"`
+	MissingSpeechProfile        bool                                   `json:"missing_speech_profile"`
+	QualityValidationIncomplete bool                                   `json:"quality_validation_incomplete"`
+	InputMetadata               InputMetadata                          `json:"input_metadata"`
+	OutputMetadata              adeclickBenchmarkAudioMetadataSnapshot `json:"output_metadata"`
+	Environment                 adeclickBenchmarkEnvironmentSnapshot   `json:"environment"`
+	FinalMeasurements           *OutputMeasurements                    `json:"final_measurements,omitempty"`
+	FinalSilenceSample          *SilenceCandidateMetrics               `json:"final_silence_sample,omitempty"`
+	FinalSpeechSample           *SpeechCandidateMetrics                `json:"final_speech_sample,omitempty"`
+	Loudnorm                    adeclickBenchmarkLoudnormSnapshot      `json:"loudnorm"`
+	Warnings                    []string                               `json:"warnings,omitempty"`
+}
+
+// adeclickBenchmarkCaptureResult pairs a variant with its captured snapshot.
+type adeclickBenchmarkCaptureResult struct {
+	Variant  adeclickBenchmarkVariant
+	Snapshot adeclickBenchmarkMetricsSnapshot
+}
+
+// resolveAdeclickBenchmarkCaptureRoot returns the directory used to persist
+// capture artefacts when JIVETALKING_ADECLICK_BENCH_CAPTURE is truthy.
+// Defaults to repo-relative .bench/adeclick; can be overridden by
+// JIVETALKING_ADECLICK_BENCH_CAPTURE_ROOT.
+func resolveAdeclickBenchmarkCaptureRoot() (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(adeclickBenchmarkCaptureEnv))) {
+	case "", "0", "false", "no":
+		return "", false
+	default:
+		root := strings.TrimSpace(os.Getenv(adeclickBenchmarkCaptureRootEnv))
+		if root == "" {
+			root = adeclickBenchmarkCaptureRoot
+		}
+		return resolveAdeclickBenchmarkRepoPath(root), true
+	}
+}
+
+func resolveAdeclickBenchmarkRepoPath(path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, path)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return filepath.Join(cwd, path)
+		}
+		dir = parent
+	}
+}
+
+func resolveAdeclickBenchmarkFixtureMetadataPath(inputPath string) string {
+	if fixturePath := strings.TrimSpace(os.Getenv(fullbenchFixtureEnv)); fixturePath != "" {
+		return adeclickBenchmarkAbsPath(fixturePath)
+	}
+	return adeclickBenchmarkAbsPath(inputPath)
+}
+
+func adeclickBenchmarkAbsPath(path string) string {
+	if path == "" {
+		return "unavailable"
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return absPath
+}
+
+// captureAdeclickBenchmarkArtifacts runs each candidate Pass 4 graph against
+// the supplied seed, writes per-variant artefacts under root, and returns the
+// captured snapshots. ApplyNormalisation is intentionally not invoked: the
+// candidate spec is itself a Pass 4 graph and timing must measure only that
+// graph's execution. Final measurements come from the embedded
+// astats/aspectralstats/ebur128 metric tail in the candidate spec.
+func captureAdeclickBenchmarkArtifacts(
+	tb testing.TB,
+	inputPath string,
+	seed *fullbenchPass4Seed,
+	variantSpecs []adeclickBenchmarkVariantSpec,
+	root string,
+) []adeclickBenchmarkCaptureResult {
+	tb.Helper()
+
+	if seed == nil || seed.Pass2Seed == nil || seed.Loudnorm == nil {
+		tb.Fatal("adeclick artefact capture requires a full Pass 4 seed")
+	}
+	if root == "" {
+		tb.Fatal("adeclick artefact capture root must not be empty")
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		tb.Fatalf("failed to create adeclick artefact root: %v", err)
+	}
+
+	mediaCaptureEnabled := adeclickBenchmarkMediaCaptureEnabled()
+	mediaTooling := resolveAdeclickBenchmarkMediaTooling(tb, mediaCaptureEnabled)
+
+	silRegion, spRegion := extractRegionPair(seed.Pass2Seed.InputMeasurements)
+
+	results := make([]adeclickBenchmarkCaptureResult, 0, len(variantSpecs))
+	for _, vs := range variantSpecs {
+		variantDir := filepath.Join(root, vs.Variant.Name)
+		if err := os.MkdirAll(variantDir, 0o755); err != nil {
+			tb.Fatalf("failed to create adeclick artefact directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(variantDir, "filter.txt"), []byte(vs.Spec+"\n"), 0o600); err != nil {
+			tb.Fatalf("failed to write adeclick filter spec: %v", err)
+		}
+
+		outputPath := filepath.Join(variantDir, "processed.flac")
+		start := time.Now()
+		runResult := runFullbenchFilterSpecResult(tb, seed.Pass2Seed.OutputPath, outputPath, vs.Spec)
+		runtimeDur := time.Since(start)
+		if runResult.OutputMeasurements == nil {
+			tb.Fatalf("adeclick artefact capture for %s produced no final measurements", vs.Variant.Name)
+		}
+
+		// Region measurements come from re-opening the candidate output and
+		// measuring the same silence/speech regions identified in Pass 1.
+		// Skipped when the input lacked detectable profiles.
+		var silenceSample *SilenceCandidateMetrics
+		var speechSample *SpeechCandidateMetrics
+		if silRegion != nil || spRegion != nil {
+			silenceSample, speechSample = MeasureOutputRegions(outputPath, silRegion, spRegion)
+		}
+
+		snapshot := buildAdeclickBenchmarkMetricsSnapshot(
+			vs,
+			inputPath,
+			seed.Loudnorm,
+			runResult,
+			silenceSample,
+			speechSample,
+			runtimeDur,
+		)
+
+		writeAdeclickBenchmarkJSON(tb, filepath.Join(variantDir, "metrics.json"), snapshot)
+		writeAdeclickBenchmarkTiming(tb, filepath.Join(variantDir, "timing.txt"), snapshot)
+
+		if mediaCaptureEnabled {
+			captureAdeclickBenchmarkMediaArtifacts(tb, mediaTooling, outputPath, variantDir)
+		}
+
+		results = append(results, adeclickBenchmarkCaptureResult{
+			Variant:  vs.Variant,
+			Snapshot: snapshot,
+		})
+	}
+
+	baseline := findAdeclickBenchmarkCaptureResult(results, adeclickBenchmarkBaselineVariant)
+	if baseline == nil {
+		tb.Fatalf("adeclick artefact capture missing %s baseline", adeclickBenchmarkBaselineVariant)
+	}
+	for _, result := range results {
+		variantDir := filepath.Join(root, result.Variant.Name)
+		report := buildAdeclickBenchmarkValidationReport(result, *baseline)
+		if err := os.WriteFile(filepath.Join(variantDir, "validation.md"), []byte(report), 0o600); err != nil {
+			tb.Fatalf("failed to write adeclick validation report: %v", err)
+		}
+	}
+
+	return results
+}
+
+func buildAdeclickBenchmarkMetricsSnapshot(
+	vs adeclickBenchmarkVariantSpec,
+	inputPath string,
+	loudnorm *fullbenchLoudnormSetup,
+	runResult *fullbenchFilterSpecRunResult,
+	silenceSample *SilenceCandidateMetrics,
+	speechSample *SpeechCandidateMetrics,
+	runtimeDur time.Duration,
+) adeclickBenchmarkMetricsSnapshot {
+	final := runResult.OutputMeasurements
+
+	missingSilence := silenceSample == nil
+	missingSpeech := speechSample == nil
+	warnings := make([]string, 0, 2)
+	if missingSilence {
+		warnings = append(warnings, "silence sample missing for candidate Pass 4 output")
+	}
+	if missingSpeech {
+		warnings = append(warnings, "speech sample missing for candidate Pass 4 output")
+	}
+
+	finalNoiseFloor := 0.0
+	if silenceSample != nil {
+		finalNoiseFloor = silenceSample.RMSLevel
+	}
+	finalSpeechRMS := 0.0
+	if speechSample != nil {
+		finalSpeechRMS = speechSample.RMSLevel
+	}
+
+	loudnormSnapshot := adeclickBenchmarkLoudnormSnapshot{
+		InputI:           loudnorm.Measurement.InputI,
+		InputTP:          loudnorm.Measurement.InputTP,
+		InputLRA:         loudnorm.Measurement.InputLRA,
+		InputThresh:      loudnorm.Measurement.InputThresh,
+		TargetOffset:     loudnorm.Measurement.TargetOffset,
+		RequestedTargetI: NormTargetLUFS,
+		EffectiveTargetI: loudnorm.EffectiveConfig.LoudnormTargetI,
+		LinearModeForced: loudnorm.LinearModeForced,
+		LimiterEnabled:   loudnorm.LimiterNeeded,
+		LimiterCeiling:   loudnorm.LimiterCeiling,
+		PreGainDB:        loudnorm.PreGainDB,
+		LimiterClamped:   loudnorm.LimiterClamped,
+	}
+
+	outputMeta := adeclickBenchmarkAudioMetadataSnapshot{}
+	if runResult.OutputMetadata != nil {
+		outputMeta = adeclickBenchmarkAudioMetadataSnapshot{
+			SampleRate:    runResult.OutputMetadata.SampleRate,
+			Channels:      runResult.OutputMetadata.Channels,
+			DurationSecs:  runResult.OutputMetadata.Duration,
+			SampleFmt:     runResult.OutputMetadata.SampleFmt,
+			ChannelLayout: runResult.OutputMetadata.ChLayout,
+			BitDepth:      runResult.OutputMetadata.BitDepth,
+		}
+	}
+
+	return adeclickBenchmarkMetricsSnapshot{
+		VariantName:                 vs.Variant.Name,
+		ParameterIntent:             vs.Variant.ParameterIntent,
+		ValidationPriority:          vs.Variant.ValidationPriority,
+		AdeclickEnabled:             vs.Variant.Params.Enabled,
+		AdeclickThreshold:           vs.Variant.Params.Threshold,
+		AdeclickWindow:              vs.Variant.Params.Window,
+		AdeclickOverlap:             vs.Variant.Params.Overlap,
+		AdeclickMethod:              vs.Variant.Params.Method,
+		FilterSpec:                  vs.Spec,
+		Pass4RuntimeMS:              float64(runtimeDur.Microseconds()) / 1000.0,
+		FinalLUFS:                   final.OutputI,
+		FinalTruePeak:               final.OutputTP,
+		FinalLRA:                    final.OutputLRA,
+		FinalNoiseFloor:             finalNoiseFloor,
+		FinalSpectralCentroid:       final.SpectralCentroid,
+		FinalSpectralRolloff:        final.SpectralRolloff,
+		FinalSpeechRMS:              finalSpeechRMS,
+		MissingSilenceProfile:       missingSilence,
+		MissingSpeechProfile:        missingSpeech,
+		QualityValidationIncomplete: missingSilence || missingSpeech,
+		InputMetadata:               runResult.InputMetadata,
+		OutputMetadata:              outputMeta,
+		Environment:                 buildAdeclickBenchmarkEnvironmentSnapshot(inputPath),
+		FinalMeasurements:           final,
+		FinalSilenceSample:          silenceSample,
+		FinalSpeechSample:           speechSample,
+		Loudnorm:                    loudnormSnapshot,
+		Warnings:                    warnings,
+	}
+}
+
+func buildAdeclickBenchmarkEnvironmentSnapshot(inputPath string) adeclickBenchmarkEnvironmentSnapshot {
+	version, replace := ffmpegStatigoModuleInfo()
+	return adeclickBenchmarkEnvironmentSnapshot{
+		GoVersion:                  runtime.Version(),
+		GOOS:                       runtime.GOOS,
+		GOARCH:                     runtime.GOARCH,
+		NumCPU:                     runtime.NumCPU(),
+		CPUModel:                   detectAdeclickBenchmarkCPUModel(),
+		BenchmarkFixturePath:       resolveAdeclickBenchmarkFixtureMetadataPath(inputPath),
+		FfmpegStatigoModuleVersion: version,
+		FfmpegStatigoModuleReplace: replace,
+	}
+}
+
+func detectAdeclickBenchmarkCPUModel() string {
+	switch runtime.GOOS {
+	case "linux":
+		return detectAdeclickBenchmarkLinuxCPUModel()
+	case "darwin":
+		return detectAdeclickBenchmarkDarwinCPUModel()
+	default:
+		return "unavailable"
+	}
+}
+
+func detectAdeclickBenchmarkLinuxCPUModel() string {
+	data, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return "unavailable"
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "model name", "Hardware", "Processor":
+			if model := strings.TrimSpace(value); model != "" {
+				return model
+			}
+		}
+	}
+	return "unavailable"
+}
+
+func detectAdeclickBenchmarkDarwinCPUModel() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	for _, key := range []string{"machdep.cpu.brand_string", "hw.model"} {
+		output, err := exec.CommandContext(ctx, "sysctl", "-n", key).Output() // #nosec G204 -- static sysctl key allowlist for local benchmark metadata.
+		if err != nil {
+			continue
+		}
+		if model := strings.TrimSpace(string(output)); model != "" {
+			return model
+		}
+	}
+	return "unavailable"
+}
+
+func writeAdeclickBenchmarkJSON(tb testing.TB, path string, snapshot adeclickBenchmarkMetricsSnapshot) {
+	tb.Helper()
+	data, err := json.MarshalIndent(sanitizeAdeclickBenchmarkJSONValue(reflect.ValueOf(snapshot)), "", "  ")
+	if err != nil {
+		tb.Fatalf("failed to encode adeclick metrics snapshot: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		tb.Fatalf("failed to write adeclick metrics snapshot: %v", err)
+	}
+}
+
+// sanitizeAdeclickBenchmarkJSONValue walks a value tree and replaces NaN/Inf
+// floats with nil so the JSON output remains spec-compliant. Mirrors the
+// behaviour of the equivalent ANLMDN helper but is kept local to this file
+// for low blast radius.
+func sanitizeAdeclickBenchmarkJSONValue(value reflect.Value) any {
+	if !value.IsValid() {
+		return nil
+	}
+	switch value.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if value.IsNil() {
+			return nil
+		}
+		return sanitizeAdeclickBenchmarkJSONValue(value.Elem())
+	case reflect.Struct:
+		result := make(map[string]any, value.NumField())
+		valueType := value.Type()
+		for i := 0; i < value.NumField(); i++ {
+			field := valueType.Field(i)
+			if field.PkgPath != "" {
+				continue
+			}
+			if field.Anonymous && field.Tag.Get("json") == "" {
+				if nested, ok := sanitizeAdeclickBenchmarkJSONValue(value.Field(i)).(map[string]any); ok {
+					maps.Copy(result, nested)
+				}
+				continue
+			}
+			name, omitEmpty, ok := adeclickBenchmarkJSONFieldName(field)
+			if !ok {
+				continue
+			}
+			fieldValue := value.Field(i)
+			if omitEmpty && fieldValue.IsZero() {
+				continue
+			}
+			result[name] = sanitizeAdeclickBenchmarkJSONValue(fieldValue)
+		}
+		return result
+	case reflect.Slice, reflect.Array:
+		result := make([]any, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			result[i] = sanitizeAdeclickBenchmarkJSONValue(value.Index(i))
+		}
+		return result
+	case reflect.Map:
+		if value.Type().Key().Kind() != reflect.String {
+			return value.Interface()
+		}
+		result := make(map[string]any, value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			result[iter.Key().String()] = sanitizeAdeclickBenchmarkJSONValue(iter.Value())
+		}
+		return result
+	case reflect.Float32, reflect.Float64:
+		floatValue := value.Float()
+		if math.IsInf(floatValue, 0) || math.IsNaN(floatValue) {
+			return nil
+		}
+		return floatValue
+	default:
+		return value.Interface()
+	}
+}
+
+func adeclickBenchmarkJSONFieldName(field reflect.StructField) (string, bool, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return "", false, false
+	}
+	if tag == "" {
+		return field.Name, false, true
+	}
+	name, options, _ := strings.Cut(tag, ",")
+	if name == "" {
+		name = field.Name
+	}
+	return name, strings.Contains(options, "omitempty"), true
+}
+
+func writeAdeclickBenchmarkTiming(tb testing.TB, path string, snapshot adeclickBenchmarkMetricsSnapshot) {
+	tb.Helper()
+	var b strings.Builder
+	fmt.Fprintf(&b, "variant: %s\n", snapshot.VariantName)
+	fmt.Fprintf(&b, "pass4_runtime_ms: %.3f\n", snapshot.Pass4RuntimeMS)
+	fmt.Fprintf(&b, "final_lufs: %.2f\n", snapshot.FinalLUFS)
+	fmt.Fprintf(&b, "final_true_peak: %.2f\n", snapshot.FinalTruePeak)
+	fmt.Fprintf(&b, "final_lra: %.2f\n", snapshot.FinalLRA)
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		tb.Fatalf("failed to write adeclick timing capture: %v", err)
+	}
+}
+
+func findAdeclickBenchmarkCaptureResult(results []adeclickBenchmarkCaptureResult, name string) *adeclickBenchmarkCaptureResult {
+	for i := range results {
+		if results[i].Variant.Name == name {
+			return &results[i]
+		}
+	}
+	return nil
+}
+
+// buildAdeclickBenchmarkValidationReport renders an objective comparison of a
+// candidate against the production baseline. It must not recommend a
+// production setting; it lists deltas only.
+func buildAdeclickBenchmarkValidationReport(result, baseline adeclickBenchmarkCaptureResult) string {
+	snapshot := result.Snapshot
+	base := baseline.Snapshot
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", snapshot.VariantName)
+	fmt.Fprintf(&b, "Intent: %s\n\n", snapshot.ParameterIntent)
+	fmt.Fprintf(&b, "Validation priority: %s\n\n", snapshot.ValidationPriority)
+
+	b.WriteString("## Speed\n\n")
+	b.WriteString("| Metric | Candidate | " + adeclickBenchmarkBaselineVariant + " | Delta |\n")
+	b.WriteString("|--------|-----------|-----------------------------------|-------|\n")
+	writeAdeclickBenchmarkMetricRow(&b, "Pass 4 runtime ms", snapshot.Pass4RuntimeMS, base.Pass4RuntimeMS, "%.3f")
+
+	b.WriteString("\n## Objective Metrics\n\n")
+	b.WriteString("| Metric | Candidate | " + adeclickBenchmarkBaselineVariant + " | Delta |\n")
+	b.WriteString("|--------|-----------|-----------------------------------|-------|\n")
+	writeAdeclickBenchmarkMetricRow(&b, "Final LUFS", snapshot.FinalLUFS, base.FinalLUFS, "%.2f")
+	writeAdeclickBenchmarkMetricRow(&b, "True peak dBTP", snapshot.FinalTruePeak, base.FinalTruePeak, "%.2f")
+	writeAdeclickBenchmarkMetricRow(&b, "LRA LU", snapshot.FinalLRA, base.FinalLRA, "%.2f")
+	writeAdeclickBenchmarkMetricRow(&b, "Noise floor dBFS", snapshot.FinalNoiseFloor, base.FinalNoiseFloor, "%.2f")
+	writeAdeclickBenchmarkMetricRow(&b, "Spectral centroid Hz", snapshot.FinalSpectralCentroid, base.FinalSpectralCentroid, "%.1f")
+	writeAdeclickBenchmarkMetricRow(&b, "Spectral rolloff Hz", snapshot.FinalSpectralRolloff, base.FinalSpectralRolloff, "%.1f")
+	writeAdeclickBenchmarkMetricRow(&b, "Speech RMS dBFS", snapshot.FinalSpeechRMS, base.FinalSpeechRMS, "%.2f")
+
+	b.WriteString("\n## Missing Profiles\n\n")
+	fmt.Fprintf(&b, "- Missing silence sample: %t\n", snapshot.MissingSilenceProfile)
+	fmt.Fprintf(&b, "- Missing speech sample: %t\n", snapshot.MissingSpeechProfile)
+	fmt.Fprintf(&b, "- Quality validation incomplete: %t\n", snapshot.QualityValidationIncomplete)
+	if len(snapshot.Warnings) > 0 {
+		b.WriteString("\n## Warnings\n\n")
+		for _, warning := range snapshot.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+	}
+
+	b.WriteString("\n## Listening Checklist\n\n")
+	b.WriteString("- Click and pop repair across hard transients\n")
+	b.WriteString("- Sibilant integrity (no smearing of /s/ /sh/)\n")
+	b.WriteString("- Plosive transients (no softening of /p/ /b/ /t/)\n")
+	b.WriteString("- Quiet-passage stability (no ringing or warble)\n")
+	b.WriteString("- Background noise character (no pumping near clicks)\n")
+
+	return b.String()
+}
+
+func writeAdeclickBenchmarkMetricRow(b *strings.Builder, name string, value, baseline float64, format string) {
+	valueFormat := format + " | "
+	deltaFormat := "%+" + strings.TrimPrefix(format, "%") + " |\n"
+	fmt.Fprintf(b, "| %s | "+valueFormat+valueFormat+deltaFormat, name, value, baseline, value-baseline)
+}
+
+// =============================================================================
+// Phase 3.5 - optional listening / spectrogram capture
+// =============================================================================
+
+type adeclickBenchmarkMediaTooling struct {
+	Enabled      bool
+	FfmpegPath   string
+	WarnNoFfmpeg bool
+	ExcerptSecs  float64
+}
+
+func adeclickBenchmarkMediaCaptureEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(adeclickBenchmarkMediaCaptureEnv))) {
+	case "", "0", "false", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+func resolveAdeclickBenchmarkMediaTooling(tb testing.TB, enabled bool) adeclickBenchmarkMediaTooling {
+	tb.Helper()
+	if !enabled {
+		return adeclickBenchmarkMediaTooling{}
+	}
+
+	tooling := adeclickBenchmarkMediaTooling{
+		Enabled:     true,
+		ExcerptSecs: adeclickBenchmarkExcerptSecs,
+	}
+
+	path, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		tooling.WarnNoFfmpeg = true
+		tb.Logf("adeclick benchmark media capture: ffmpeg binary not found on PATH; skipping excerpt and spectrogram artefacts")
+		return tooling
+	}
+	tooling.FfmpegPath = path
+	return tooling
+}
+
+func captureAdeclickBenchmarkMediaArtifacts(tb testing.TB, tooling adeclickBenchmarkMediaTooling, processedPath, variantDir string) {
+	tb.Helper()
+	if !tooling.Enabled || tooling.FfmpegPath == "" {
+		// Tooling absent - already logged at resolve time.
+		return
+	}
+
+	excerptPath := filepath.Join(variantDir, "excerpt.flac")
+	excerptDurArg := fmt.Sprintf("%.3f", tooling.ExcerptSecs)
+	excerptCtx, excerptCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer excerptCancel()
+	excerptCmd := exec.CommandContext(excerptCtx, tooling.FfmpegPath, // #nosec G204 -- ffmpeg path resolved via LookPath; arguments are static.
+		"-y",
+		"-i", processedPath,
+		"-t", excerptDurArg,
+		"-c:a", "flac",
+		excerptPath,
+	)
+	if output, err := excerptCmd.CombinedOutput(); err != nil {
+		_ = os.Remove(excerptPath)
+		tb.Logf("adeclick benchmark media capture: failed to render excerpt for %s: %v\n%s", processedPath, err, output)
+		return
+	}
+
+	spectrogramPath := filepath.Join(variantDir, "spectrogram.png")
+	spectrogramCtx, spectrogramCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer spectrogramCancel()
+	spectrogramCmd := exec.CommandContext(spectrogramCtx, tooling.FfmpegPath, // #nosec G204 -- ffmpeg path resolved via LookPath; arguments are static.
+		"-y",
+		"-i", excerptPath,
+		"-lavfi", "showspectrumpic=s=1024x512:legend=disabled",
+		spectrogramPath,
+	)
+	if output, err := spectrogramCmd.CombinedOutput(); err != nil {
+		_ = os.Remove(spectrogramPath)
+		tb.Logf("adeclick benchmark media capture: failed to render spectrogram for %s: %v\n%s", processedPath, err, output)
+	}
+}
+
+// =============================================================================
+// Phase 3 tests
+// =============================================================================
+
+func TestAdeclickBenchmarkCaptureRootOptIn(t *testing.T) {
+	t.Setenv(adeclickBenchmarkCaptureEnv, "")
+	if root, ok := resolveAdeclickBenchmarkCaptureRoot(); ok || root != "" {
+		t.Fatalf("capture root enabled without %s: root=%q ok=%v", adeclickBenchmarkCaptureEnv, root, ok)
+	}
+
+	t.Setenv(adeclickBenchmarkCaptureEnv, "1")
+	root, ok := resolveAdeclickBenchmarkCaptureRoot()
+	if !ok {
+		t.Fatalf("expected capture root when %s is set", adeclickBenchmarkCaptureEnv)
+	}
+	if !filepath.IsAbs(root) {
+		t.Fatalf("capture root = %q, want absolute path", root)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(root), adeclickBenchmarkCaptureRoot) {
+		t.Fatalf("capture root = %q, want suffix %q", root, adeclickBenchmarkCaptureRoot)
+	}
+
+	overrideRoot := filepath.Join(t.TempDir(), "capture-root")
+	t.Setenv(adeclickBenchmarkCaptureRootEnv, overrideRoot)
+	root, ok = resolveAdeclickBenchmarkCaptureRoot()
+	if !ok {
+		t.Fatalf("expected capture root when %s is set", adeclickBenchmarkCaptureEnv)
+	}
+	if root != overrideRoot {
+		t.Fatalf("capture root override = %q, want %q", root, overrideRoot)
+	}
+
+	t.Setenv(adeclickBenchmarkCaptureEnv, "false")
+	if root, ok := resolveAdeclickBenchmarkCaptureRoot(); ok || root != "" {
+		t.Fatalf("capture root enabled for false value: root=%q ok=%v", root, ok)
+	}
+}
+
+func TestAdeclickBenchmarkJSONSanitisesNonFinite(t *testing.T) {
+	snapshot := adeclickBenchmarkMetricsSnapshot{
+		VariantName: "test",
+		FilterSpec:  "loudnorm=,asetnsamples=n=4096",
+		FinalLUFS:   math.NaN(),
+		FinalLRA:    math.Inf(1),
+	}
+
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	writeAdeclickBenchmarkJSON(t, path, snapshot)
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read sanitised metrics: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("sanitised metrics did not decode as JSON: %v\n%s", err, raw)
+	}
+	if decoded["final_lufs"] != nil {
+		t.Fatalf("expected final_lufs to be nil after NaN sanitisation, got %v", decoded["final_lufs"])
+	}
+	if decoded["final_lra"] != nil {
+		t.Fatalf("expected final_lra to be nil after Inf sanitisation, got %v", decoded["final_lra"])
+	}
+	if decoded["variant_name"] != "test" {
+		t.Fatalf("variant_name lost during sanitisation: %v", decoded["variant_name"])
+	}
+}
+
+func TestAdeclickBenchmarkTimingFile(t *testing.T) {
+	snapshot := adeclickBenchmarkMetricsSnapshot{
+		VariantName:    "adeclick_current_t_2_0_w_55_o_50_m_s",
+		Pass4RuntimeMS: 12.345,
+		FinalLUFS:      -16.05,
+		FinalTruePeak:  -1.2,
+		FinalLRA:       7.5,
+	}
+	path := filepath.Join(t.TempDir(), "timing.txt")
+	writeAdeclickBenchmarkTiming(t, path, snapshot)
+
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read timing capture: %v", err)
+	}
+	body := string(bytes)
+	for _, want := range []string{
+		"variant: adeclick_current_t_2_0_w_55_o_50_m_s",
+		"pass4_runtime_ms: 12.345",
+		"final_lufs: -16.05",
+		"final_true_peak: -1.20",
+		"final_lra: 7.50",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("timing file missing %q\n%s", want, body)
+		}
+	}
+}
+
+func TestAdeclickBenchmarkArtifactCaptureSyntheticSmoke(t *testing.T) {
+	inputPath := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 4.0,
+		SampleRate:   44100,
+		ToneFreq:     180.0,
+		ToneLevel:    -20.0,
+		NoiseLevel:   -58.0,
+		Dir:          t.TempDir(),
+		SilenceGap: struct {
+			Start    float64
+			Duration float64
+		}{
+			Start:    1.25,
+			Duration: 0.75,
+		},
+	})
+	defer cleanupTestAudio(t, inputPath)
+
+	seed := setupFullbenchPass4Seed(t, inputPath)
+	if seed.Pass2Seed == nil || seed.Loudnorm == nil {
+		t.Fatal("synthetic Pass 4 seed setup returned incomplete result")
+	}
+	specs := buildAdeclickBenchmarkVariantSpecs(t, seed.Loudnorm)
+
+	// Trim to two representative variants to keep the smoke test fast.
+	subset := []adeclickBenchmarkVariantSpec{}
+	for _, vs := range specs {
+		switch vs.Variant.Name {
+		case "without_adeclick", adeclickBenchmarkBaselineVariant:
+			subset = append(subset, vs)
+		}
+	}
+	if len(subset) != 2 {
+		t.Fatalf("synthetic smoke expected 2 variants, got %d", len(subset))
+	}
+
+	root := filepath.Join(t.TempDir(), "adeclick")
+	results := captureAdeclickBenchmarkArtifacts(t, inputPath, seed, subset, root)
+	if len(results) != len(subset) {
+		t.Fatalf("capture result count = %d, want %d", len(results), len(subset))
+	}
+
+	for _, vs := range subset {
+		variantDir := filepath.Join(root, vs.Variant.Name)
+		for _, name := range []string{"processed.flac", "filter.txt", "metrics.json", "validation.md", "timing.txt"} {
+			path := filepath.Join(variantDir, name)
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("expected artefact %s: %v", path, err)
+			}
+		}
+		assertFullbenchFLACOutput(t, filepath.Join(variantDir, "processed.flac"))
+
+		filterBytes, err := os.ReadFile(filepath.Join(variantDir, "filter.txt"))
+		if err != nil {
+			t.Fatalf("failed to read filter artefact: %v", err)
+		}
+		if !strings.Contains(string(filterBytes), "loudnorm=") {
+			t.Fatalf("filter artefact missing loudnorm clause: %s", filterBytes)
+		}
+		if vs.Variant.Params.Enabled && !strings.Contains(string(filterBytes), "adeclick=") {
+			t.Fatalf("filter artefact missing adeclick clause for %s: %s", vs.Variant.Name, filterBytes)
+		}
+
+		metricsBytes, err := os.ReadFile(filepath.Join(variantDir, "metrics.json"))
+		if err != nil {
+			t.Fatalf("failed to read metrics artefact: %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(metricsBytes, &decoded); err != nil {
+			t.Fatalf("failed to decode metrics artefact: %v", err)
+		}
+		for _, key := range []string{
+			"variant_name",
+			"filter_spec",
+			"pass4_runtime_ms",
+			"final_lufs",
+			"final_true_peak",
+			"final_lra",
+			"final_spectral_centroid",
+			"final_spectral_rolloff",
+			"output_metadata",
+			"loudnorm",
+			"environment",
+		} {
+			if _, ok := decoded[key]; !ok {
+				t.Fatalf("metrics.json missing key %q for %s", key, vs.Variant.Name)
+			}
+		}
+		if got, ok := decoded["variant_name"].(string); !ok || got != vs.Variant.Name {
+			t.Fatalf("metrics.json variant_name = %v, want %s", decoded["variant_name"], vs.Variant.Name)
+		}
+		if runtimeMS, ok := decoded["pass4_runtime_ms"].(float64); !ok || runtimeMS <= 0 {
+			t.Fatalf("metrics.json pass4_runtime_ms = %v, want positive number", decoded["pass4_runtime_ms"])
+		}
+
+		reportBytes, err := os.ReadFile(filepath.Join(variantDir, "validation.md"))
+		if err != nil {
+			t.Fatalf("failed to read validation report: %v", err)
+		}
+		report := string(reportBytes)
+		for _, want := range []string{
+			"Pass 4 runtime ms",
+			"Final LUFS",
+			"True peak dBTP",
+			"LRA LU",
+			"Noise floor dBFS",
+			"Spectral centroid Hz",
+			"Spectral rolloff Hz",
+			"Speech RMS dBFS",
+			"Click and pop repair",
+		} {
+			if !strings.Contains(report, want) {
+				t.Fatalf("validation report missing %q for %s:\n%s", want, vs.Variant.Name, report)
+			}
+		}
+	}
+}
+
+func TestAdeclickBenchmarkMediaCaptureSkipsWithoutFfmpeg(t *testing.T) {
+	t.Setenv(adeclickBenchmarkMediaCaptureEnv, "1")
+	t.Setenv("PATH", t.TempDir()) // empty PATH -> ffmpeg cannot be found
+
+	tooling := resolveAdeclickBenchmarkMediaTooling(t, true)
+	if !tooling.Enabled {
+		t.Fatal("expected media tooling to be enabled when env var is set")
+	}
+	if tooling.FfmpegPath != "" {
+		t.Fatalf("expected empty FfmpegPath when ffmpeg is missing, got %q", tooling.FfmpegPath)
+	}
+	if !tooling.WarnNoFfmpeg {
+		t.Fatal("expected WarnNoFfmpeg flag when ffmpeg is missing")
+	}
+
+	// Capture must not write artefacts when tooling unavailable.
+	variantDir := t.TempDir()
+	captureAdeclickBenchmarkMediaArtifacts(t, tooling, filepath.Join(variantDir, "missing.flac"), variantDir)
+	if _, err := os.Stat(filepath.Join(variantDir, "excerpt.flac")); err == nil {
+		t.Fatal("excerpt.flac written when ffmpeg unavailable")
+	}
+	if _, err := os.Stat(filepath.Join(variantDir, "spectrogram.png")); err == nil {
+		t.Fatal("spectrogram.png written when ffmpeg unavailable")
+	}
+}
+
+// audioMetadataAlias is unused locally but kept as a guard against drift in
+// the imported audio package; if its symbols change, the imports above flag
+// the regression.
+var _ = audio.Metadata{}

--- a/internal/processor/anlmdn_benchmark_test.go
+++ b/internal/processor/anlmdn_benchmark_test.go
@@ -1,0 +1,1218 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linuxmatters/jivetalking/internal/audio"
+)
+
+const (
+	anlmdnBenchmarkCaptureEnv       = "JIVETALKING_ANLMDN_BENCH_CAPTURE"
+	anlmdnBenchmarkCaptureRootEnv   = "JIVETALKING_ANLMDN_BENCH_CAPTURE_ROOT"
+	anlmdnBenchmarkCaptureRoot      = ".bench/anlmdn"
+	anlmdnBenchmarkPatchAdjustedSec = 0.0050
+	anlmdnBenchmarkFirstRunBestRSec = 0.0045
+	ffmpegStatigoModulePath         = "github.com/linuxmatters/ffmpeg-statigo"
+)
+
+type anlmdnBenchmarkParams struct {
+	Strength    float64
+	PatchSec    float64
+	ResearchSec float64
+	Smooth      float64
+}
+
+type anlmdnBenchmarkVariant struct {
+	Name                string
+	ParameterIntent     string
+	ValidationPriority  string
+	PreAnlmdnSampleRate int
+	Params              anlmdnBenchmarkParams
+}
+
+func anlmdnBenchmarkVariants() []anlmdnBenchmarkVariant {
+	legacyDefault := anlmdnBenchmarkParams{
+		Strength:    noiseRemoveLegacyStrength,
+		PatchSec:    noiseRemoveLegacyPatchSec,
+		ResearchSec: noiseRemoveLegacyResearchSec,
+		Smooth:      noiseRemoveLegacySmooth,
+	}
+	productionDefault := anlmdnBenchmarkParams{
+		Strength:    noiseRemoveProductionStrength,
+		PatchSec:    noiseRemoveProductionPatchSec,
+		ResearchSec: noiseRemoveProductionResearchSec,
+		Smooth:      noiseRemoveProductionSmooth,
+	}
+
+	return []anlmdnBenchmarkVariant{
+		{
+			Name:               "anlmdn_legacy_default",
+			ParameterIntent:    "Legacy production baseline before the 32 kHz lower-r default.",
+			ValidationPriority: "baseline",
+			Params:             legacyDefault,
+		},
+		{
+			Name:               "anlmdn_r_5_0",
+			ParameterIntent:    "Conservative lower research radius candidate.",
+			ValidationPriority: "tier1-conservative",
+			Params: anlmdnBenchmarkParams{
+				Strength:    legacyDefault.Strength,
+				PatchSec:    legacyDefault.PatchSec,
+				ResearchSec: 0.0050,
+				Smooth:      legacyDefault.Smooth,
+			},
+		},
+		{
+			Name:               "anlmdn_r_4_5",
+			ParameterIntent:    "Stronger lower research radius candidate.",
+			ValidationPriority: "tier1-balanced",
+			Params: anlmdnBenchmarkParams{
+				Strength:    legacyDefault.Strength,
+				PatchSec:    legacyDefault.PatchSec,
+				ResearchSec: 0.0045,
+				Smooth:      legacyDefault.Smooth,
+			},
+		},
+		{
+			Name:               "anlmdn_r_4_0",
+			ParameterIntent:    "Aggressive lower research radius candidate.",
+			ValidationPriority: "tier1-aggressive",
+			Params: anlmdnBenchmarkParams{
+				Strength:    legacyDefault.Strength,
+				PatchSec:    legacyDefault.PatchSec,
+				ResearchSec: 0.0040,
+				Smooth:      legacyDefault.Smooth,
+			},
+		},
+		{
+			Name:               "anlmdn_r_patch_adjusted",
+			ParameterIntent:    "Lower research radius plus source-supported smaller patch check.",
+			ValidationPriority: "tier3-patch-check",
+			Params: anlmdnBenchmarkParams{
+				Strength:    legacyDefault.Strength,
+				PatchSec:    anlmdnBenchmarkPatchAdjustedSec,
+				ResearchSec: anlmdnBenchmarkFirstRunBestRSec,
+				Smooth:      legacyDefault.Smooth,
+			},
+		},
+		{
+			Name:                "anlmdn_sr_32000",
+			ParameterIntent:     "32 kHz pre-anlmdn sample-rate cap with legacy anlmdn parameters.",
+			ValidationPriority:  "tier2-sample-rate-baseline-r",
+			PreAnlmdnSampleRate: noiseRemoveProductionPreSampleRate,
+			Params:              legacyDefault,
+		},
+		{
+			Name:                "anlmdn_sr_32000_best_r",
+			ParameterIntent:     "Production default: 32 kHz pre-anlmdn sample-rate cap with the selected lower-r candidate.",
+			ValidationPriority:  "production-default",
+			PreAnlmdnSampleRate: noiseRemoveProductionPreSampleRate,
+			Params:              productionDefault,
+		},
+	}
+}
+
+func buildAnlmdnBenchmarkVariantConfig(base *FilterChainConfig, variant anlmdnBenchmarkVariant) *FilterChainConfig {
+	if base == nil {
+		return nil
+	}
+
+	config := *base
+	config.Pass = PassProcessing
+	config.FilterOrder = Pass2FilterOrder
+	config.NoiseRemoveEnabled = true
+	config.NoiseRemovePreSampleRate = variant.PreAnlmdnSampleRate
+	config.NoiseRemoveStrength = variant.Params.Strength
+	config.NoiseRemovePatchSec = variant.Params.PatchSec
+	config.NoiseRemoveResearchSec = variant.Params.ResearchSec
+	config.NoiseRemoveSmooth = variant.Params.Smooth
+	return &config
+}
+
+func buildAnlmdnBenchmarkVariantSpec(base *FilterChainConfig, variant anlmdnBenchmarkVariant) string {
+	config := buildAnlmdnBenchmarkVariantConfig(base, variant)
+	if config == nil {
+		return ""
+	}
+
+	return config.BuildFilterSpec()
+}
+
+type anlmdnBenchmarkVariantSpec struct {
+	Variant anlmdnBenchmarkVariant
+	Spec    string
+}
+
+type anlmdnBenchmarkCaptureResult struct {
+	Variant  anlmdnBenchmarkVariant
+	Snapshot anlmdnBenchmarkMetricsSnapshot
+}
+
+type anlmdnBenchmarkAudioMetadataSnapshot struct {
+	SampleRate    int     `json:"sample_rate"`
+	Channels      int     `json:"channels"`
+	DurationSecs  float64 `json:"duration_secs"`
+	SampleFmt     string  `json:"sample_fmt,omitempty"`
+	ChannelLayout string  `json:"channel_layout,omitempty"`
+	BitDepth      int     `json:"bit_depth,omitempty"`
+}
+
+type anlmdnBenchmarkNormalisationSnapshot struct {
+	InputLUFS        float64 `json:"input_lufs"`
+	InputTP          float64 `json:"input_tp"`
+	OutputLUFS       float64 `json:"output_lufs"`
+	OutputTP         float64 `json:"output_tp"`
+	GainApplied      float64 `json:"gain_applied"`
+	WithinTarget     bool    `json:"within_target"`
+	RequestedTargetI float64 `json:"requested_target_i"`
+	EffectiveTargetI float64 `json:"effective_target_i"`
+	LinearModeForced bool    `json:"linear_mode_forced"`
+	LimiterEnabled   bool    `json:"limiter_enabled"`
+	LimiterCeiling   float64 `json:"limiter_ceiling"`
+	PreGainDB        float64 `json:"pre_gain_db"`
+	LimiterClamped   bool    `json:"limiter_clamped"`
+}
+
+type anlmdnBenchmarkEnvironmentSnapshot struct {
+	GoVersion                  string `json:"go_version"`
+	GOOS                       string `json:"goos"`
+	GOARCH                     string `json:"goarch"`
+	NumCPU                     int    `json:"num_cpu"`
+	CPUModel                   string `json:"cpu_model"`
+	BenchmarkFixturePath       string `json:"benchmark_fixture_path"`
+	FfmpegStatigoModuleVersion string `json:"ffmpeg_statigo_module_version"`
+	FfmpegStatigoModuleReplace string `json:"ffmpeg_statigo_module_replace"`
+}
+
+type anlmdnBenchmarkMetricsSnapshot struct {
+	VariantName                 string                               `json:"variant_name"`
+	ParameterIntent             string                               `json:"parameter_intent"`
+	ValidationPriority          string                               `json:"validation_priority"`
+	PreAnlmdnSampleRate         int                                  `json:"pre_anlmdn_sample_rate,omitempty"`
+	FilterSpec                  string                               `json:"filter_spec"`
+	Pass2RuntimeMS              float64                              `json:"pass2_runtime_ms"`
+	FinalLUFS                   float64                              `json:"final_lufs"`
+	FinalTruePeak               float64                              `json:"final_true_peak"`
+	FinalLRA                    float64                              `json:"final_lra"`
+	FinalNoiseFloor             float64                              `json:"final_noise_floor"`
+	FinalSpectralCentroid       float64                              `json:"final_spectral_centroid"`
+	FinalSpectralRolloff        float64                              `json:"final_spectral_rolloff"`
+	FinalSpeechRMS              float64                              `json:"final_speech_rms"`
+	MissingSilenceProfile       bool                                 `json:"missing_silence_profile"`
+	MissingSpeechProfile        bool                                 `json:"missing_speech_profile"`
+	QualityValidationIncomplete bool                                 `json:"quality_validation_incomplete"`
+	InputNoiseFloor             float64                              `json:"input_noise_floor"`
+	InputNoiseFloorSource       string                               `json:"input_noise_floor_source"`
+	InputMetadata               InputMetadata                        `json:"input_metadata"`
+	OutputMetadata              anlmdnBenchmarkAudioMetadataSnapshot `json:"output_metadata"`
+	Environment                 anlmdnBenchmarkEnvironmentSnapshot   `json:"environment"`
+	Pass2Measurements           *OutputMeasurements                  `json:"pass2_measurements,omitempty"`
+	FinalMeasurements           *OutputMeasurements                  `json:"final_measurements,omitempty"`
+	InputNoiseProfile           *NoiseProfile                        `json:"input_noise_profile,omitempty"`
+	InputSpeechProfile          *SpeechCandidateMetrics              `json:"input_speech_profile,omitempty"`
+	FinalSilenceSample          *SilenceCandidateMetrics             `json:"final_silence_sample,omitempty"`
+	FinalSpeechSample           *SpeechCandidateMetrics              `json:"final_speech_sample,omitempty"`
+	Normalisation               anlmdnBenchmarkNormalisationSnapshot `json:"normalisation"`
+	Warnings                    []string                             `json:"warnings,omitempty"`
+}
+
+func buildAnlmdnBenchmarkVariantSpecs(tb testing.TB, base *FilterChainConfig) []anlmdnBenchmarkVariantSpec {
+	tb.Helper()
+
+	variants := anlmdnBenchmarkVariants()
+	specs := make([]anlmdnBenchmarkVariantSpec, 0, len(variants))
+	for _, variant := range variants {
+		spec := buildAnlmdnBenchmarkVariantSpec(base, variant)
+		if spec == "" {
+			tb.Fatalf("anlmdn benchmark variant %q produced empty filter spec", variant.Name)
+		}
+		if !strings.Contains(spec, "anlmdn=") {
+			tb.Fatalf("anlmdn benchmark variant %q omitted anlmdn\nSpec: %s", variant.Name, spec)
+		}
+		specs = append(specs, anlmdnBenchmarkVariantSpec{
+			Variant: variant,
+			Spec:    spec,
+		})
+	}
+
+	return specs
+}
+
+func BenchmarkAnlmdnVariants(b *testing.B) {
+	inputPath := resolveFullbenchFixture(b)
+	adapted := setupFullbenchAdaptedConfig(b, inputPath)
+	variantSpecs := buildAnlmdnBenchmarkVariantSpecs(b, adapted.Config)
+
+	if root, ok := resolveAnlmdnBenchmarkCaptureRoot(); ok {
+		captureAnlmdnBenchmarkArtifacts(b, inputPath, adapted, variantSpecs, root)
+	}
+
+	for _, variantSpec := range variantSpecs {
+		b.Run(variantSpec.Variant.Name, func(b *testing.B) {
+			outputDir := b.TempDir()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				outputPath := filepath.Join(outputDir, fmt.Sprintf("%s-%d.flac", variantSpec.Variant.Name, i))
+				_, outputMeasurements := runFullbenchFilterSpec(b, inputPath, outputPath, variantSpec.Spec, true)
+				if outputMeasurements == nil {
+					b.Fatal("expected output measurements for anlmdn benchmark variant")
+				}
+
+				b.StopTimer()
+				if err := os.Remove(outputPath); err != nil {
+					b.Fatalf("failed to remove anlmdn benchmark output: %v", err)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func resolveAnlmdnBenchmarkCaptureRoot() (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(anlmdnBenchmarkCaptureEnv))) {
+	case "", "0", "false", "no":
+		return "", false
+	default:
+		root := strings.TrimSpace(os.Getenv(anlmdnBenchmarkCaptureRootEnv))
+		if root == "" {
+			root = anlmdnBenchmarkCaptureRoot
+		}
+		return resolveAnlmdnBenchmarkRepoPath(root), true
+	}
+}
+
+func resolveAnlmdnBenchmarkRepoPath(path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, path)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return filepath.Join(cwd, path)
+		}
+		dir = parent
+	}
+}
+
+func captureAnlmdnBenchmarkArtifacts(
+	tb testing.TB,
+	inputPath string,
+	adapted *fullbenchAdaptedSetup,
+	variantSpecs []anlmdnBenchmarkVariantSpec,
+	root string,
+) []anlmdnBenchmarkCaptureResult {
+	tb.Helper()
+
+	if adapted == nil || adapted.Config == nil || adapted.Measurements == nil {
+		tb.Fatal("anlmdn artefact capture requires adapted config and measurements")
+	}
+	if root == "" {
+		tb.Fatal("anlmdn artefact capture root must not be empty")
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		tb.Fatalf("failed to create anlmdn artefact root: %v", err)
+	}
+
+	results := make([]anlmdnBenchmarkCaptureResult, 0, len(variantSpecs))
+	for _, variantSpec := range variantSpecs {
+		variantDir := filepath.Join(root, variantSpec.Variant.Name)
+		if err := os.MkdirAll(variantDir, 0o755); err != nil {
+			tb.Fatalf("failed to create anlmdn artefact directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(variantDir, "filter.txt"), []byte(variantSpec.Spec+"\n"), 0o600); err != nil {
+			tb.Fatalf("failed to write anlmdn filter spec: %v", err)
+		}
+
+		outputPath := filepath.Join(variantDir, "processed.flac")
+		start := time.Now()
+		runResult := runFullbenchFilterSpecResult(tb, inputPath, outputPath, variantSpec.Spec, true)
+		pass2Runtime := time.Since(start)
+		if runResult.OutputMeasurements == nil {
+			tb.Fatalf("anlmdn artefact capture for %s produced no Pass 2 measurements", variantSpec.Variant.Name)
+		}
+
+		config := buildAnlmdnBenchmarkVariantConfig(adapted.Config, variantSpec.Variant)
+		normResult, err := ApplyNormalisation(outputPath, config, runResult.OutputMeasurements, adapted.Measurements, nil)
+		if err != nil {
+			tb.Fatalf("failed to normalise anlmdn artefact for %s: %v", variantSpec.Variant.Name, err)
+		}
+		if normResult == nil || normResult.FinalMeasurements == nil {
+			tb.Fatalf("anlmdn artefact capture for %s produced no final measurements", variantSpec.Variant.Name)
+		}
+
+		outputMetadata := readFullbenchOutputMetadata(tb, outputPath)
+		snapshot := buildAnlmdnBenchmarkMetricsSnapshot(
+			variantSpec,
+			inputPath,
+			adapted.Measurements,
+			runResult,
+			outputMetadata,
+			normResult,
+			pass2Runtime,
+		)
+
+		writeAnlmdnBenchmarkJSON(tb, filepath.Join(variantDir, "metrics.json"), snapshot)
+		writeAnlmdnBenchmarkTiming(tb, filepath.Join(variantDir, "timing.txt"), snapshot)
+
+		results = append(results, anlmdnBenchmarkCaptureResult{
+			Variant:  variantSpec.Variant,
+			Snapshot: snapshot,
+		})
+	}
+
+	baseline := findAnlmdnBenchmarkCaptureResult(results, "anlmdn_legacy_default")
+	if baseline == nil {
+		tb.Fatal("anlmdn artefact capture missing anlmdn_legacy_default baseline")
+	}
+	for _, result := range results {
+		variantDir := filepath.Join(root, result.Variant.Name)
+		report := buildAnlmdnBenchmarkValidationReport(result, *baseline)
+		if err := os.WriteFile(filepath.Join(variantDir, "validation.md"), []byte(report), 0o600); err != nil {
+			tb.Fatalf("failed to write anlmdn validation report: %v", err)
+		}
+	}
+
+	return results
+}
+
+func buildAnlmdnBenchmarkMetricsSnapshot(
+	variantSpec anlmdnBenchmarkVariantSpec,
+	inputPath string,
+	inputMeasurements *AudioMeasurements,
+	runResult *fullbenchFilterSpecRunResult,
+	outputMetadata *audio.Metadata,
+	normResult *NormalisationResult,
+	pass2Runtime time.Duration,
+) anlmdnBenchmarkMetricsSnapshot {
+	final := normResult.FinalMeasurements
+	missingSilence := inputMeasurements == nil || inputMeasurements.NoiseProfile == nil || final.SilenceSample == nil
+	missingSpeech := inputMeasurements == nil || inputMeasurements.SpeechProfile == nil || final.SpeechSample == nil
+	warnings := make([]string, 0, 2)
+	if missingSilence {
+		warnings = append(warnings, "silence profile or final silence sample missing")
+	}
+	if missingSpeech {
+		warnings = append(warnings, "speech profile or final speech sample missing")
+	}
+
+	var inputNoiseFloor float64
+	var inputNoiseFloorSource string
+	var inputNoiseProfile *NoiseProfile
+	var inputSpeechProfile *SpeechCandidateMetrics
+	if inputMeasurements != nil {
+		inputNoiseFloor = inputMeasurements.NoiseFloor
+		inputNoiseFloorSource = inputMeasurements.NoiseFloorSource
+		inputNoiseProfile = inputMeasurements.NoiseProfile
+		inputSpeechProfile = inputMeasurements.SpeechProfile
+	}
+
+	finalNoiseFloor := 0.0
+	if final.SilenceSample != nil {
+		finalNoiseFloor = final.SilenceSample.RMSLevel
+	}
+	finalSpeechRMS := 0.0
+	if final.SpeechSample != nil {
+		finalSpeechRMS = final.SpeechSample.RMSLevel
+	}
+
+	return anlmdnBenchmarkMetricsSnapshot{
+		VariantName:                 variantSpec.Variant.Name,
+		ParameterIntent:             variantSpec.Variant.ParameterIntent,
+		ValidationPriority:          variantSpec.Variant.ValidationPriority,
+		PreAnlmdnSampleRate:         variantSpec.Variant.PreAnlmdnSampleRate,
+		FilterSpec:                  variantSpec.Spec,
+		Pass2RuntimeMS:              float64(pass2Runtime.Microseconds()) / 1000.0,
+		FinalLUFS:                   normResult.OutputLUFS,
+		FinalTruePeak:               normResult.OutputTP,
+		FinalLRA:                    final.OutputLRA,
+		FinalNoiseFloor:             finalNoiseFloor,
+		FinalSpectralCentroid:       final.SpectralCentroid,
+		FinalSpectralRolloff:        final.SpectralRolloff,
+		FinalSpeechRMS:              finalSpeechRMS,
+		MissingSilenceProfile:       missingSilence,
+		MissingSpeechProfile:        missingSpeech,
+		QualityValidationIncomplete: missingSilence || missingSpeech,
+		InputNoiseFloor:             inputNoiseFloor,
+		InputNoiseFloorSource:       inputNoiseFloorSource,
+		InputMetadata:               runResult.InputMetadata,
+		OutputMetadata: anlmdnBenchmarkAudioMetadataSnapshot{
+			SampleRate:    outputMetadata.SampleRate,
+			Channels:      outputMetadata.Channels,
+			DurationSecs:  outputMetadata.Duration,
+			SampleFmt:     outputMetadata.SampleFmt,
+			ChannelLayout: outputMetadata.ChLayout,
+			BitDepth:      outputMetadata.BitDepth,
+		},
+		Environment:        buildAnlmdnBenchmarkEnvironmentSnapshot(inputPath),
+		Pass2Measurements:  runResult.OutputMeasurements,
+		FinalMeasurements:  final,
+		InputNoiseProfile:  inputNoiseProfile,
+		InputSpeechProfile: inputSpeechProfile,
+		FinalSilenceSample: final.SilenceSample,
+		FinalSpeechSample:  final.SpeechSample,
+		Normalisation: anlmdnBenchmarkNormalisationSnapshot{
+			InputLUFS:        normResult.InputLUFS,
+			InputTP:          normResult.InputTP,
+			OutputLUFS:       normResult.OutputLUFS,
+			OutputTP:         normResult.OutputTP,
+			GainApplied:      normResult.GainApplied,
+			WithinTarget:     normResult.WithinTarget,
+			RequestedTargetI: normResult.RequestedTargetI,
+			EffectiveTargetI: normResult.EffectiveTargetI,
+			LinearModeForced: normResult.LinearModeForced,
+			LimiterEnabled:   normResult.LimiterEnabled,
+			LimiterCeiling:   normResult.LimiterCeiling,
+			PreGainDB:        normResult.PreGainDB,
+			LimiterClamped:   normResult.LimiterClamped,
+		},
+		Warnings: warnings,
+	}
+}
+
+func buildAnlmdnBenchmarkEnvironmentSnapshot(inputPath string) anlmdnBenchmarkEnvironmentSnapshot {
+	version, replace := ffmpegStatigoModuleInfo()
+
+	return anlmdnBenchmarkEnvironmentSnapshot{
+		GoVersion:                  runtime.Version(),
+		GOOS:                       runtime.GOOS,
+		GOARCH:                     runtime.GOARCH,
+		NumCPU:                     runtime.NumCPU(),
+		CPUModel:                   detectAnlmdnBenchmarkCPUModel(),
+		BenchmarkFixturePath:       resolveAnlmdnBenchmarkFixtureMetadataPath(inputPath),
+		FfmpegStatigoModuleVersion: version,
+		FfmpegStatigoModuleReplace: replace,
+	}
+}
+
+func resolveAnlmdnBenchmarkFixtureMetadataPath(inputPath string) string {
+	if fixturePath := strings.TrimSpace(os.Getenv(fullbenchFixtureEnv)); fixturePath != "" {
+		return absOrOriginalPath(fixturePath)
+	}
+	return absOrOriginalPath(inputPath)
+}
+
+func absOrOriginalPath(path string) string {
+	if path == "" {
+		return "unavailable"
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return absPath
+}
+
+func ffmpegStatigoModuleInfo() (string, string) {
+	version := "unavailable"
+	replace := "unavailable"
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, dep := range buildInfo.Deps {
+			if dep.Path != ffmpegStatigoModulePath {
+				continue
+			}
+			if dep.Version != "" {
+				version = dep.Version
+			}
+			if dep.Replace != nil {
+				replace = dep.Replace.Path
+				if dep.Replace.Version != "" {
+					replace += " " + dep.Replace.Version
+				}
+			}
+			return version, replace
+		}
+	}
+
+	return ffmpegStatigoModuleInfoFromGoList(version, replace)
+}
+
+func ffmpegStatigoModuleInfoFromGoList(defaultVersion, defaultReplace string) (string, string) {
+	const moduleFormat = "{{.Version}}{{if .Replace}} => {{.Replace.Path}}{{if .Replace.Version}} {{.Replace.Version}}{{end}}{{end}}"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	output, err := exec.CommandContext(ctx, "go", "list", "-m", "-f", moduleFormat, ffmpegStatigoModulePath).Output() // #nosec G204 -- static local metadata command for benchmark artefacts.
+	if err != nil {
+		return defaultVersion, defaultReplace
+	}
+
+	moduleInfo := strings.TrimSpace(string(output))
+	if moduleInfo == "" {
+		return defaultVersion, defaultReplace
+	}
+
+	version, replace, hasReplace := strings.Cut(moduleInfo, " => ")
+	if strings.TrimSpace(version) == "" {
+		version = defaultVersion
+	}
+	if !hasReplace || strings.TrimSpace(replace) == "" {
+		replace = defaultReplace
+	}
+
+	return strings.TrimSpace(version), strings.TrimSpace(replace)
+}
+
+func detectAnlmdnBenchmarkCPUModel() string {
+	switch runtime.GOOS {
+	case "linux":
+		return detectLinuxCPUModel()
+	case "darwin":
+		return detectDarwinCPUModel()
+	default:
+		return "unavailable"
+	}
+}
+
+func detectLinuxCPUModel() string {
+	data, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return "unavailable"
+	}
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "model name", "Hardware", "Processor":
+			if model := strings.TrimSpace(value); model != "" {
+				return model
+			}
+		}
+	}
+
+	return "unavailable"
+}
+
+func detectDarwinCPUModel() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	for _, key := range []string{"machdep.cpu.brand_string", "hw.model"} {
+		output, err := exec.CommandContext(ctx, "sysctl", "-n", key).Output() // #nosec G204 -- static sysctl key allowlist for local benchmark metadata.
+		if err != nil {
+			continue
+		}
+		if model := strings.TrimSpace(string(output)); model != "" {
+			return model
+		}
+	}
+
+	return "unavailable"
+}
+
+func writeAnlmdnBenchmarkJSON(tb testing.TB, path string, snapshot anlmdnBenchmarkMetricsSnapshot) {
+	tb.Helper()
+
+	data, err := json.MarshalIndent(sanitizeAnlmdnBenchmarkJSONValue(reflect.ValueOf(snapshot)), "", "  ")
+	if err != nil {
+		tb.Fatalf("failed to encode anlmdn metrics snapshot: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		tb.Fatalf("failed to write anlmdn metrics snapshot: %v", err)
+	}
+}
+
+func sanitizeAnlmdnBenchmarkJSONValue(value reflect.Value) any {
+	if !value.IsValid() {
+		return nil
+	}
+
+	switch value.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if value.IsNil() {
+			return nil
+		}
+		return sanitizeAnlmdnBenchmarkJSONValue(value.Elem())
+	case reflect.Struct:
+		result := make(map[string]any, value.NumField())
+		valueType := value.Type()
+		for i := 0; i < value.NumField(); i++ {
+			field := valueType.Field(i)
+			if field.PkgPath != "" {
+				continue
+			}
+			if field.Anonymous && field.Tag.Get("json") == "" {
+				if nested, ok := sanitizeAnlmdnBenchmarkJSONValue(value.Field(i)).(map[string]any); ok {
+					maps.Copy(result, nested)
+				}
+				continue
+			}
+
+			name, omitEmpty, ok := anlmdnBenchmarkJSONFieldName(field)
+			if !ok {
+				continue
+			}
+			fieldValue := value.Field(i)
+			if omitEmpty && fieldValue.IsZero() {
+				continue
+			}
+			result[name] = sanitizeAnlmdnBenchmarkJSONValue(fieldValue)
+		}
+		return result
+	case reflect.Slice, reflect.Array:
+		result := make([]any, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			result[i] = sanitizeAnlmdnBenchmarkJSONValue(value.Index(i))
+		}
+		return result
+	case reflect.Map:
+		if value.Type().Key().Kind() != reflect.String {
+			return value.Interface()
+		}
+		result := make(map[string]any, value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			result[iter.Key().String()] = sanitizeAnlmdnBenchmarkJSONValue(iter.Value())
+		}
+		return result
+	case reflect.Float32, reflect.Float64:
+		floatValue := value.Float()
+		if math.IsInf(floatValue, 0) || math.IsNaN(floatValue) {
+			return nil
+		}
+		return floatValue
+	default:
+		return value.Interface()
+	}
+}
+
+func anlmdnBenchmarkJSONFieldName(field reflect.StructField) (string, bool, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return "", false, false
+	}
+	if tag == "" {
+		return field.Name, false, true
+	}
+
+	name, options, _ := strings.Cut(tag, ",")
+	if name == "" {
+		name = field.Name
+	}
+	return name, strings.Contains(options, "omitempty"), true
+}
+
+func writeAnlmdnBenchmarkTiming(tb testing.TB, path string, snapshot anlmdnBenchmarkMetricsSnapshot) {
+	tb.Helper()
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "variant: %s\n", snapshot.VariantName)
+	fmt.Fprintf(&builder, "pass2_runtime_ms: %.3f\n", snapshot.Pass2RuntimeMS)
+	fmt.Fprintf(&builder, "final_lufs: %.2f\n", snapshot.FinalLUFS)
+	fmt.Fprintf(&builder, "final_true_peak: %.2f\n", snapshot.FinalTruePeak)
+	if err := os.WriteFile(path, []byte(builder.String()), 0o600); err != nil {
+		tb.Fatalf("failed to write anlmdn timing capture: %v", err)
+	}
+}
+
+func findAnlmdnBenchmarkCaptureResult(results []anlmdnBenchmarkCaptureResult, name string) *anlmdnBenchmarkCaptureResult {
+	for i := range results {
+		if results[i].Variant.Name == name {
+			return &results[i]
+		}
+	}
+	return nil
+}
+
+func buildAnlmdnBenchmarkValidationReport(result, baseline anlmdnBenchmarkCaptureResult) string {
+	snapshot := result.Snapshot
+	base := baseline.Snapshot
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# %s\n\n", snapshot.VariantName)
+	fmt.Fprintf(&builder, "Intent: %s\n\n", snapshot.ParameterIntent)
+	fmt.Fprintf(&builder, "Validation priority: %s\n\n", snapshot.ValidationPriority)
+
+	builder.WriteString("## Speed\n\n")
+	builder.WriteString("| Metric | Candidate | anlmdn_legacy_default | Delta |\n")
+	builder.WriteString("|--------|-----------|----------------|-------|\n")
+	writeAnlmdnBenchmarkMetricRow(&builder, "Pass 2 runtime ms", snapshot.Pass2RuntimeMS, base.Pass2RuntimeMS, "%.3f")
+
+	builder.WriteString("\n## Objective Metrics\n\n")
+	builder.WriteString("| Metric | Candidate | anlmdn_legacy_default | Delta |\n")
+	builder.WriteString("|--------|-----------|----------------|-------|\n")
+	writeAnlmdnBenchmarkMetricRow(&builder, "Final LUFS", snapshot.FinalLUFS, base.FinalLUFS, "%.2f")
+	writeAnlmdnBenchmarkMetricRow(&builder, "True peak dBTP", snapshot.FinalTruePeak, base.FinalTruePeak, "%.2f")
+	writeAnlmdnBenchmarkMetricRow(&builder, "LRA LU", snapshot.FinalLRA, base.FinalLRA, "%.2f")
+	writeAnlmdnBenchmarkMetricRow(&builder, "Noise floor dBFS", snapshot.FinalNoiseFloor, base.FinalNoiseFloor, "%.2f")
+	writeAnlmdnBenchmarkMetricRow(&builder, "Spectral centroid Hz", snapshot.FinalSpectralCentroid, base.FinalSpectralCentroid, "%.1f")
+	writeAnlmdnBenchmarkMetricRow(&builder, "Spectral rolloff Hz", snapshot.FinalSpectralRolloff, base.FinalSpectralRolloff, "%.1f")
+	writeAnlmdnBenchmarkMetricRow(&builder, "Speech RMS dBFS", snapshot.FinalSpeechRMS, base.FinalSpeechRMS, "%.2f")
+
+	builder.WriteString("\n## Missing Profiles\n\n")
+	fmt.Fprintf(&builder, "- Missing silence profile or sample: %t\n", snapshot.MissingSilenceProfile)
+	fmt.Fprintf(&builder, "- Missing speech profile or sample: %t\n", snapshot.MissingSpeechProfile)
+	fmt.Fprintf(&builder, "- Quality validation incomplete: %t\n", snapshot.QualityValidationIncomplete)
+	if len(snapshot.Warnings) > 0 {
+		builder.WriteString("\n## Warnings\n\n")
+		for _, warning := range snapshot.Warnings {
+			fmt.Fprintf(&builder, "- %s\n", warning)
+		}
+	}
+
+	builder.WriteString("\n## Listening Checklist\n\n")
+	builder.WriteString("- Room noise reduction\n")
+	builder.WriteString("- Watery artefacts\n")
+	builder.WriteString("- Breath tails\n")
+	builder.WriteString("- Consonant smearing\n")
+	builder.WriteString("- Hollow tone\n")
+	builder.WriteString("- Noise pumping between phrases\n")
+
+	return builder.String()
+}
+
+func writeAnlmdnBenchmarkMetricRow(builder *strings.Builder, name string, value, baseline float64, format string) {
+	valueFormat := format + " | "
+	deltaFormat := "%+" + strings.TrimPrefix(format, "%") + " |\n"
+	fmt.Fprintf(builder, "| %s | "+valueFormat+valueFormat+deltaFormat, name, value, baseline, value-baseline)
+}
+
+func newAnlmdnBenchmarkTestConfig() *FilterChainConfig {
+	config := newTestConfig()
+	config.DownmixEnabled = true
+	config.DS201HPEnabled = true
+	config.DS201LPEnabled = true
+	config.NoiseRemoveEnabled = true
+	config.NoiseRemoveCompandEnabled = true
+	config.DS201GateEnabled = true
+	config.LA2AEnabled = true
+	config.DeessEnabled = true
+	config.DeessIntensity = 0.5
+	config.AnalysisEnabled = true
+	config.OutputAnalysisEnabled = true
+	config.ResampleEnabled = true
+	config.FilterOrder = Pass2FilterOrder
+	return config
+}
+
+func TestAnlmdnBenchmarkVariantManifest(t *testing.T) {
+	variants := anlmdnBenchmarkVariants()
+	expectedNames := []string{
+		"anlmdn_legacy_default",
+		"anlmdn_r_5_0",
+		"anlmdn_r_4_5",
+		"anlmdn_r_4_0",
+		"anlmdn_r_patch_adjusted",
+		"anlmdn_sr_32000",
+		"anlmdn_sr_32000_best_r",
+	}
+
+	if len(variants) != len(expectedNames) {
+		t.Fatalf("got %d anlmdn benchmark variants, want %d", len(variants), len(expectedNames))
+	}
+
+	variantByName := make(map[string]anlmdnBenchmarkVariant, len(variants))
+	for _, variant := range variants {
+		variantByName[variant.Name] = variant
+		if variant.ParameterIntent == "" {
+			t.Fatalf("variant %q missing parameter intent", variant.Name)
+		}
+		if variant.ValidationPriority == "" {
+			t.Fatalf("variant %q missing validation priority", variant.Name)
+		}
+	}
+
+	for _, name := range expectedNames {
+		if _, ok := variantByName[name]; !ok {
+			t.Fatalf("missing anlmdn benchmark variant %q", name)
+		}
+	}
+
+	for _, name := range []string{"anlmdn_sr_32000", "anlmdn_sr_32000_best_r"} {
+		if variantByName[name].PreAnlmdnSampleRate != noiseRemoveProductionPreSampleRate {
+			t.Fatalf("%s PreAnlmdnSampleRate = %d, want %d",
+				name, variantByName[name].PreAnlmdnSampleRate, noiseRemoveProductionPreSampleRate)
+		}
+	}
+	for _, name := range []string{"anlmdn_legacy_default", "anlmdn_r_5_0", "anlmdn_r_4_5", "anlmdn_r_4_0", "anlmdn_r_patch_adjusted"} {
+		if variantByName[name].PreAnlmdnSampleRate != 0 {
+			t.Fatalf("%s should not use a pre-anlmdn sample-rate cap", name)
+		}
+	}
+
+	if got := variantByName["anlmdn_sr_32000_best_r"].Params.ResearchSec; got != noiseRemoveProductionResearchSec {
+		t.Fatalf("anlmdn_sr_32000_best_r research radius = %.4f, want production default %.4f",
+			got, noiseRemoveProductionResearchSec)
+	}
+}
+
+func TestAnlmdnBenchmarkParameterOnlySpecs(t *testing.T) {
+	base := newAnlmdnBenchmarkTestConfig()
+	base.NoiseRemoveCompandThreshold = -47.0
+	base.NoiseRemoveCompandExpansion = 9.0
+
+	tests := []struct {
+		name     string
+		wantSpec string
+	}{
+		{name: "anlmdn_legacy_default", wantSpec: "anlmdn=s=0.00001:p=0.0060:r=0.0058:m=11"},
+		{name: "anlmdn_r_5_0", wantSpec: "anlmdn=s=0.00001:p=0.0060:r=0.0050:m=11"},
+		{name: "anlmdn_r_4_5", wantSpec: "anlmdn=s=0.00001:p=0.0060:r=0.0045:m=11"},
+		{name: "anlmdn_r_4_0", wantSpec: "anlmdn=s=0.00001:p=0.0060:r=0.0040:m=11"},
+		{name: "anlmdn_r_patch_adjusted", wantSpec: "anlmdn=s=0.00001:p=0.0050:r=0.0045:m=11"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variant := findAnlmdnBenchmarkVariant(t, tt.name)
+			config := buildAnlmdnBenchmarkVariantConfig(base, variant)
+			spec := buildAnlmdnBenchmarkVariantSpec(base, variant)
+
+			if !config.NoiseRemoveEnabled {
+				t.Fatal("parameter-only variant disabled NoiseRemove")
+			}
+			if config.NoiseRemoveCompandEnabled != base.NoiseRemoveCompandEnabled {
+				t.Fatalf("NoiseRemoveCompandEnabled = %v, want preserved %v",
+					config.NoiseRemoveCompandEnabled, base.NoiseRemoveCompandEnabled)
+			}
+			if config.NoiseRemoveCompandThreshold != base.NoiseRemoveCompandThreshold {
+				t.Fatalf("compand threshold changed: got %.1f, want %.1f",
+					config.NoiseRemoveCompandThreshold, base.NoiseRemoveCompandThreshold)
+			}
+			if config.NoiseRemoveCompandExpansion != base.NoiseRemoveCompandExpansion {
+				t.Fatalf("compand expansion changed: got %.1f, want %.1f",
+					config.NoiseRemoveCompandExpansion, base.NoiseRemoveCompandExpansion)
+			}
+			assertFullbenchSpecContains(t, spec, []string{tt.wantSpec, "anlmdn=", "compand="})
+			assertFullbenchSpecExcludes(t, spec, []string{"aformat=sample_rates=32000"})
+		})
+	}
+
+	assertBaseLegacyAnlmdnConfigUnchanged(t, base)
+}
+
+func TestAnlmdnBenchmarkPreSampleRateSpecs(t *testing.T) {
+	base := newAnlmdnBenchmarkTestConfig()
+
+	tests := []struct {
+		name     string
+		wantSpec string
+	}{
+		{name: "anlmdn_sr_32000", wantSpec: "anlmdn=s=0.00001:p=0.0060:r=0.0058:m=11"},
+		{name: "anlmdn_sr_32000_best_r", wantSpec: "anlmdn=s=0.00001:p=0.0060:r=0.0045:m=11"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variant := findAnlmdnBenchmarkVariant(t, tt.name)
+			spec := buildAnlmdnBenchmarkVariantSpec(base, variant)
+
+			assertFullbenchSpecContains(t, spec, []string{
+				"aformat=sample_rates=32000:channel_layouts=mono:sample_fmts=fltp",
+				tt.wantSpec,
+				"anlmdn=",
+				"compand=",
+				"aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16",
+				"asetnsamples=n=4096",
+			})
+			assertFullbenchSpecOrder(t, spec, []string{
+				"aformat=channel_layouts=mono",
+				"highpass=",
+				"lowpass=",
+				"aformat=sample_rates=32000:channel_layouts=mono:sample_fmts=fltp",
+				"anlmdn=",
+				"compand=",
+				"agate=",
+				"acompressor=",
+				"deesser=",
+				"astats=",
+				"aspectralstats=",
+				"ebur128=",
+				"aformat=sample_rates=44100",
+				"asetnsamples=",
+			})
+		})
+	}
+}
+
+func TestAnlmdnBenchmarkVariantSpecsPreservePass2Ordering(t *testing.T) {
+	base := newAnlmdnBenchmarkTestConfig()
+
+	for _, variant := range anlmdnBenchmarkVariants() {
+		t.Run(variant.Name, func(t *testing.T) {
+			spec := buildAnlmdnBenchmarkVariantSpec(base, variant)
+			if spec == "" {
+				t.Fatal("variant produced empty filter spec")
+			}
+
+			assertFullbenchSpecContains(t, spec, []string{
+				"anlmdn=",
+				"compand=",
+				"aformat=sample_rates=44100",
+				"asetnsamples=",
+			})
+			assertFullbenchSpecOrder(t, spec, []string{
+				"aformat=channel_layouts=mono",
+				"highpass=",
+				"lowpass=",
+				"anlmdn=",
+				"compand=",
+				"agate=",
+				"acompressor=",
+				"deesser=",
+				"astats=",
+				"aspectralstats=",
+				"ebur128=",
+				"aformat=sample_rates=44100",
+				"asetnsamples=",
+			})
+		})
+	}
+}
+
+func TestAnlmdnBenchmarkProductionDefaultsMatchFastVariant(t *testing.T) {
+	config := DefaultFilterConfig()
+
+	if !config.NoiseRemoveEnabled {
+		t.Fatal("production NoiseRemoveEnabled changed")
+	}
+	if config.NoiseRemovePreSampleRate != noiseRemoveProductionPreSampleRate {
+		t.Fatalf("production NoiseRemovePreSampleRate = %d, want %d",
+			config.NoiseRemovePreSampleRate, noiseRemoveProductionPreSampleRate)
+	}
+	if config.NoiseRemoveStrength != noiseRemoveProductionStrength {
+		t.Fatalf("production NoiseRemoveStrength = %.5f, want %.5f",
+			config.NoiseRemoveStrength, noiseRemoveProductionStrength)
+	}
+	if config.NoiseRemovePatchSec != noiseRemoveProductionPatchSec {
+		t.Fatalf("production NoiseRemovePatchSec = %.4f, want %.4f",
+			config.NoiseRemovePatchSec, noiseRemoveProductionPatchSec)
+	}
+	if config.NoiseRemoveResearchSec != noiseRemoveProductionResearchSec {
+		t.Fatalf("production NoiseRemoveResearchSec = %.4f, want %.4f",
+			config.NoiseRemoveResearchSec, noiseRemoveProductionResearchSec)
+	}
+	if config.NoiseRemoveSmooth != noiseRemoveProductionSmooth {
+		t.Fatalf("production NoiseRemoveSmooth = %.0f, want %.0f",
+			config.NoiseRemoveSmooth, noiseRemoveProductionSmooth)
+	}
+
+	fastVariant := findAnlmdnBenchmarkVariant(t, "anlmdn_sr_32000_best_r")
+	if got, want := buildAnlmdnBenchmarkVariantSpec(config, fastVariant), config.BuildFilterSpec(); got != want {
+		t.Fatalf("production filter spec drifted from anlmdn_sr_32000_best_r\nvariant:    %s\nproduction: %s", got, want)
+	}
+
+	expectedOrder := []FilterID{
+		FilterDownmix,
+		FilterDS201HighPass,
+		FilterDS201LowPass,
+		FilterNoiseRemove,
+		FilterDS201Gate,
+		FilterLA2ACompressor,
+		FilterDeesser,
+		FilterAnalysis,
+		FilterResample,
+	}
+	if len(Pass2FilterOrder) != len(expectedOrder) {
+		t.Fatalf("Pass2FilterOrder length = %d, want %d", len(Pass2FilterOrder), len(expectedOrder))
+	}
+	for i, want := range expectedOrder {
+		if Pass2FilterOrder[i] != want {
+			t.Fatalf("Pass2FilterOrder[%d] = %q, want %q", i, Pass2FilterOrder[i], want)
+		}
+	}
+}
+
+func TestAnlmdnBenchmarkCaptureRootOptIn(t *testing.T) {
+	t.Setenv(anlmdnBenchmarkCaptureEnv, "")
+	if root, ok := resolveAnlmdnBenchmarkCaptureRoot(); ok || root != "" {
+		t.Fatalf("capture root enabled without %s: root=%q ok=%v", anlmdnBenchmarkCaptureEnv, root, ok)
+	}
+
+	t.Setenv(anlmdnBenchmarkCaptureEnv, "1")
+	root, ok := resolveAnlmdnBenchmarkCaptureRoot()
+	if !ok {
+		t.Fatalf("expected capture root when %s is set", anlmdnBenchmarkCaptureEnv)
+	}
+	if !filepath.IsAbs(root) {
+		t.Fatalf("capture root = %q, want absolute path", root)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(root), anlmdnBenchmarkCaptureRoot) {
+		t.Fatalf("capture root = %q, want suffix %q", root, anlmdnBenchmarkCaptureRoot)
+	}
+
+	overrideRoot := filepath.Join(t.TempDir(), "capture-root")
+	t.Setenv(anlmdnBenchmarkCaptureRootEnv, overrideRoot)
+	root, ok = resolveAnlmdnBenchmarkCaptureRoot()
+	if !ok {
+		t.Fatalf("expected capture root when %s is set", anlmdnBenchmarkCaptureEnv)
+	}
+	if root != overrideRoot {
+		t.Fatalf("capture root override = %q, want %q", root, overrideRoot)
+	}
+
+	t.Setenv(anlmdnBenchmarkCaptureEnv, "false")
+	if root, ok := resolveAnlmdnBenchmarkCaptureRoot(); ok || root != "" {
+		t.Fatalf("capture root enabled for false value: root=%q ok=%v", root, ok)
+	}
+}
+
+func TestAnlmdnBenchmarkArtifactCaptureSyntheticSmoke(t *testing.T) {
+	inputPath := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 4.0,
+		SampleRate:   44100,
+		ToneFreq:     180.0,
+		ToneLevel:    -20.0,
+		NoiseLevel:   -58.0,
+		Dir:          t.TempDir(),
+		SilenceGap: struct {
+			Start    float64
+			Duration float64
+		}{
+			Start:    1.25,
+			Duration: 0.75,
+		},
+	})
+	defer cleanupTestAudio(t, inputPath)
+
+	adapted := setupFullbenchAdaptedConfig(t, inputPath)
+	variant := findAnlmdnBenchmarkVariant(t, "anlmdn_legacy_default")
+	specs := []anlmdnBenchmarkVariantSpec{
+		{
+			Variant: variant,
+			Spec:    buildAnlmdnBenchmarkVariantSpec(adapted.Config, variant),
+		},
+	}
+
+	root := filepath.Join(t.TempDir(), "anlmdn")
+	results := captureAnlmdnBenchmarkArtifacts(t, inputPath, adapted, specs, root)
+	if len(results) != 1 {
+		t.Fatalf("capture result count = %d, want 1", len(results))
+	}
+
+	variantDir := filepath.Join(root, "anlmdn_legacy_default")
+	for _, name := range []string{"processed.flac", "filter.txt", "metrics.json", "validation.md", "timing.txt"} {
+		path := filepath.Join(variantDir, name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected artefact %s: %v", path, err)
+		}
+	}
+	assertFullbenchFLACOutput(t, filepath.Join(variantDir, "processed.flac"))
+
+	filterBytes, err := os.ReadFile(filepath.Join(variantDir, "filter.txt"))
+	if err != nil {
+		t.Fatalf("failed to read filter artefact: %v", err)
+	}
+	if !strings.Contains(string(filterBytes), "anlmdn=") {
+		t.Fatalf("filter artefact missing anlmdn: %s", filterBytes)
+	}
+
+	metricsBytes, err := os.ReadFile(filepath.Join(variantDir, "metrics.json"))
+	if err != nil {
+		t.Fatalf("failed to read metrics artefact: %v", err)
+	}
+	var snapshot anlmdnBenchmarkMetricsSnapshot
+	if err := json.Unmarshal(metricsBytes, &snapshot); err != nil {
+		t.Fatalf("failed to decode metrics artefact: %v", err)
+	}
+	if snapshot.VariantName != "anlmdn_legacy_default" {
+		t.Fatalf("snapshot variant = %q, want anlmdn_legacy_default", snapshot.VariantName)
+	}
+	if snapshot.OutputMetadata.SampleRate != 44100 {
+		t.Fatalf("snapshot output sample rate = %d, want 44100", snapshot.OutputMetadata.SampleRate)
+	}
+	if snapshot.OutputMetadata.Channels != 1 {
+		t.Fatalf("snapshot output channels = %d, want 1", snapshot.OutputMetadata.Channels)
+	}
+	if snapshot.Pass2RuntimeMS <= 0 {
+		t.Fatalf("snapshot pass2 runtime = %.3f, want positive", snapshot.Pass2RuntimeMS)
+	}
+	if snapshot.Environment.GoVersion == "" {
+		t.Fatal("snapshot environment missing Go version")
+	}
+	if snapshot.Environment.GOOS == "" {
+		t.Fatal("snapshot environment missing GOOS")
+	}
+	if snapshot.Environment.GOARCH == "" {
+		t.Fatal("snapshot environment missing GOARCH")
+	}
+	if snapshot.Environment.BenchmarkFixturePath == "" || snapshot.Environment.BenchmarkFixturePath == "unavailable" {
+		t.Fatalf("snapshot environment fixture path = %q, want recorded path", snapshot.Environment.BenchmarkFixturePath)
+	}
+	if snapshot.Environment.FfmpegStatigoModuleVersion == "" || snapshot.Environment.FfmpegStatigoModuleVersion == "unavailable" {
+		t.Fatalf("snapshot environment ffmpeg-statigo version = %q, want recorded version", snapshot.Environment.FfmpegStatigoModuleVersion)
+	}
+
+	reportBytes, err := os.ReadFile(filepath.Join(variantDir, "validation.md"))
+	if err != nil {
+		t.Fatalf("failed to read validation report: %v", err)
+	}
+	report := string(reportBytes)
+	for _, want := range []string{
+		"Pass 2 runtime ms",
+		"Room noise reduction",
+		"Watery artefacts",
+		"Breath tails",
+		"Consonant smearing",
+		"Hollow tone",
+		"Noise pumping between phrases",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("validation report missing %q:\n%s", want, report)
+		}
+	}
+}
+
+func findAnlmdnBenchmarkVariant(tb testing.TB, name string) anlmdnBenchmarkVariant {
+	tb.Helper()
+
+	for _, variant := range anlmdnBenchmarkVariants() {
+		if variant.Name == name {
+			return variant
+		}
+	}
+	tb.Fatalf("missing anlmdn benchmark variant %q", name)
+	return anlmdnBenchmarkVariant{}
+}
+
+func assertBaseLegacyAnlmdnConfigUnchanged(tb testing.TB, config *FilterChainConfig) {
+	tb.Helper()
+
+	if !config.NoiseRemoveEnabled {
+		tb.Fatal("base config NoiseRemoveEnabled changed")
+	}
+	if config.NoiseRemovePreSampleRate != 0 {
+		tb.Fatalf("base NoiseRemovePreSampleRate changed: got %d", config.NoiseRemovePreSampleRate)
+	}
+	if config.NoiseRemoveStrength != noiseRemoveLegacyStrength {
+		tb.Fatalf("base NoiseRemoveStrength changed: got %.5f", config.NoiseRemoveStrength)
+	}
+	if config.NoiseRemovePatchSec != noiseRemoveLegacyPatchSec {
+		tb.Fatalf("base NoiseRemovePatchSec changed: got %.4f", config.NoiseRemovePatchSec)
+	}
+	if config.NoiseRemoveResearchSec != noiseRemoveLegacyResearchSec {
+		tb.Fatalf("base NoiseRemoveResearchSec changed: got %.4f", config.NoiseRemoveResearchSec)
+	}
+	if config.NoiseRemoveSmooth != noiseRemoveLegacySmooth {
+		tb.Fatalf("base NoiseRemoveSmooth changed: got %.0f", config.NoiseRemoveSmooth)
+	}
+}

--- a/internal/processor/anlmdn_benchmark_test.go
+++ b/internal/processor/anlmdn_benchmark_test.go
@@ -348,7 +348,7 @@ func captureAnlmdnBenchmarkArtifacts(
 
 		outputPath := filepath.Join(variantDir, "processed.flac")
 		start := time.Now()
-		runResult := runFullbenchFilterSpecResult(tb, inputPath, outputPath, variantSpec.Spec, true)
+		runResult := runFullbenchFilterSpecResult(tb, inputPath, outputPath, variantSpec.Spec)
 		pass2Runtime := time.Since(start)
 		if runResult.OutputMeasurements == nil {
 			tb.Fatalf("anlmdn artefact capture for %s produced no Pass 2 measurements", variantSpec.Variant.Name)

--- a/internal/processor/benchmark_test.go
+++ b/internal/processor/benchmark_test.go
@@ -1,0 +1,131 @@
+package processor
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func BenchmarkAnalyzeAudioSynthetic5m(b *testing.B) {
+	inputPath := generateBenchmarkAudio(b, b.TempDir(), 5*time.Minute)
+	defer cleanupTestAudio(b, inputPath)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		config := newTestConfig()
+		config.AnalysisEnabled = true
+		if _, err := AnalyzeAudio(inputPath, config, nil); err != nil {
+			b.Fatalf("AnalyzeAudio failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkProcessAudioDefaultSynthetic5m(b *testing.B) {
+	inputPath := generateBenchmarkAudio(b, b.TempDir(), 5*time.Minute)
+	defer cleanupTestAudio(b, inputPath)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		config := DefaultFilterConfig()
+		result, err := ProcessAudio(inputPath, config, nil)
+		if err != nil {
+			b.Fatalf("ProcessAudio failed: %v", err)
+		}
+		if result != nil && result.OutputPath != "" {
+			if err := os.Remove(result.OutputPath); err != nil && !os.IsNotExist(err) {
+				b.Fatalf("failed to remove benchmark output %s: %v", result.OutputPath, err)
+			}
+		}
+	}
+}
+
+func BenchmarkProcessAudioManualFixture(b *testing.B) {
+	fixturePath := os.Getenv("JIVETALKING_BENCH_FIXTURE")
+	if fixturePath == "" {
+		b.Skip("set JIVETALKING_BENCH_FIXTURE to benchmark a real local fixture")
+	}
+
+	inputPath := copyBenchmarkFixture(b, fixturePath, b.TempDir())
+	defer cleanupTestAudio(b, inputPath)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		config := DefaultFilterConfig()
+		result, err := ProcessAudio(inputPath, config, nil)
+		if err != nil {
+			b.Fatalf("ProcessAudio failed: %v", err)
+		}
+		if result != nil && result.OutputPath != "" {
+			if err := os.Remove(result.OutputPath); err != nil && !os.IsNotExist(err) {
+				b.Fatalf("failed to remove benchmark output %s: %v", result.OutputPath, err)
+			}
+		}
+	}
+}
+
+func BenchmarkMeasureOutputRegions(b *testing.B) {
+	inputPath := generateBenchmarkAudio(b, b.TempDir(), 5*time.Minute)
+	defer cleanupTestAudio(b, inputPath)
+
+	silenceRegion := &SilenceRegion{
+		Start:    30 * time.Second,
+		End:      31 * time.Second,
+		Duration: time.Second,
+	}
+	speechRegion := &SpeechRegion{
+		Start:    90 * time.Second,
+		End:      100 * time.Second,
+		Duration: 10 * time.Second,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		MeasureOutputRegions(inputPath, silenceRegion, speechRegion)
+	}
+}
+
+func generateBenchmarkAudio(tb testing.TB, dir string, duration time.Duration) string {
+	tb.Helper()
+
+	opts := TestAudioOptions{
+		DurationSecs: duration.Seconds(),
+		SampleRate:   44100,
+		ToneFreq:     180.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -58.0,
+		Dir:          dir,
+	}
+	opts.SilenceGap.Start = 30.0
+	opts.SilenceGap.Duration = 1.5
+
+	return generateTestAudio(tb, opts)
+}
+
+func copyBenchmarkFixture(tb testing.TB, sourcePath, dir string) string {
+	tb.Helper()
+
+	source, err := os.Open(sourcePath) // #nosec G304,G703 -- local benchmark fixture path is explicitly supplied by JIVETALKING_BENCH_FIXTURE.
+	if err != nil {
+		tb.Fatalf("failed to open benchmark fixture: %v", err)
+	}
+	defer source.Close()
+
+	destinationPath := filepath.Join(dir, filepath.Base(sourcePath))
+	destination, err := os.Create(destinationPath)
+	if err != nil {
+		tb.Fatalf("failed to create benchmark fixture copy: %v", err)
+	}
+	defer destination.Close()
+
+	if _, err := io.Copy(destination, source); err != nil {
+		tb.Fatalf("failed to copy benchmark fixture: %v", err)
+	}
+
+	return destinationPath
+}

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -1,0 +1,1044 @@
+package processor
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
+	"github.com/linuxmatters/jivetalking/internal/audio"
+)
+
+const fullbenchFixtureEnv = "JIVETALKING_BENCH_FIXTURE"
+
+type fullbenchAdaptedSetup struct {
+	Config       *FilterChainConfig
+	Measurements *AudioMeasurements
+}
+
+type fullbenchPass2Seed struct {
+	OutputPath         string
+	Config             *FilterChainConfig
+	InputMeasurements  *AudioMeasurements
+	OutputMeasurements *OutputMeasurements
+	InputMetadata      InputMetadata
+}
+
+type fullbenchLoudnormSetup struct {
+	Measurement       *LoudnormMeasurement
+	EffectiveConfig   *FilterChainConfig
+	Pass3FilterPrefix string
+	PreGainDB         float64
+	LimiterCeiling    float64
+	LimiterNeeded     bool
+	LimiterClamped    bool
+	LinearModeForced  bool
+}
+
+type fullbenchPass4Seed struct {
+	Pass2Seed *fullbenchPass2Seed
+	Loudnorm  *fullbenchLoudnormSetup
+}
+
+type fullbenchPass2AblationVariant struct {
+	Name                string
+	ExtractMeasurements bool
+	BuildSpec           func(*FilterChainConfig) string
+}
+
+type fullbenchPass4AblationVariant struct {
+	Name                string
+	RequiresLimiter     bool
+	ExtractMeasurements bool
+	BuildSpec           func(*fullbenchLoudnormSetup) string
+}
+
+func resolveFullbenchFixture(tb testing.TB) string {
+	tb.Helper()
+
+	fixturePath, ok := resolveFullbenchFixtureFromEnv(tb)
+	if !ok {
+		tb.Skipf("set %s to benchmark fullbench ablations with a real local fixture", fullbenchFixtureEnv)
+	}
+
+	return fixturePath
+}
+
+func resolveFullbenchFixtureFromEnv(tb testing.TB) (string, bool) {
+	tb.Helper()
+
+	fixturePath := os.Getenv(fullbenchFixtureEnv)
+	if fixturePath == "" {
+		return "", false
+	}
+
+	if _, err := os.Stat(fixturePath); err != nil { // #nosec G703 -- local benchmark fixture path is explicitly supplied by JIVETALKING_BENCH_FIXTURE.
+		tb.Fatalf("%s is set but cannot be accessed: %v", fullbenchFixtureEnv, err)
+	}
+	return copyBenchmarkFixture(tb, fixturePath, tb.TempDir()), true
+}
+
+func TestResolveFullbenchFixtureFromEnvSkipsWhenUnset(t *testing.T) {
+	t.Setenv(fullbenchFixtureEnv, "")
+
+	fixturePath, ok := resolveFullbenchFixtureFromEnv(t)
+	if ok {
+		t.Fatalf("expected no fixture without %s, got %q", fullbenchFixtureEnv, fixturePath)
+	}
+	if fixturePath != "" {
+		t.Fatalf("expected empty fixture path without %s, got %q", fullbenchFixtureEnv, fixturePath)
+	}
+}
+
+func TestResolveFullbenchFixtureFromEnvCopiesEnvironmentFixture(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source.flac")
+	sourceBytes := []byte("fixture")
+	if err := os.WriteFile(sourcePath, sourceBytes, 0o600); err != nil {
+		t.Fatalf("failed to write source fixture: %v", err)
+	}
+	t.Setenv(fullbenchFixtureEnv, sourcePath)
+
+	copiedPath, ok := resolveFullbenchFixtureFromEnv(t)
+	if !ok {
+		t.Fatalf("expected fixture when %s is set", fullbenchFixtureEnv)
+	}
+	if copiedPath == sourcePath {
+		t.Fatal("resolver returned source path instead of a copy")
+	}
+	if filepath.Base(copiedPath) != filepath.Base(sourcePath) {
+		t.Fatalf("copy basename mismatch: got %q, want %q", filepath.Base(copiedPath), filepath.Base(sourcePath))
+	}
+
+	copiedBytes, err := os.ReadFile(copiedPath)
+	if err != nil {
+		t.Fatalf("failed to read copied fixture: %v", err)
+	}
+	if string(copiedBytes) != string(sourceBytes) {
+		t.Fatalf("copied fixture content mismatch: got %q, want %q", copiedBytes, sourceBytes)
+	}
+
+	afterBytes, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("failed to reread source fixture: %v", err)
+	}
+	if string(afterBytes) != string(sourceBytes) {
+		t.Fatal("source fixture was modified")
+	}
+}
+
+func runFullbenchFilterSpec(tb testing.TB, inputPath, outputPath, filterSpec string, extractMeasurements bool) (InputMetadata, *OutputMeasurements) {
+	tb.Helper()
+
+	if filterSpec == "" {
+		tb.Fatal("fullbench filter spec must not be empty")
+	}
+
+	reader, metadata, err := audio.OpenAudioFile(inputPath)
+	if err != nil {
+		tb.Fatalf("failed to open input file: %v", err)
+	}
+	defer reader.Close()
+
+	inputMetadata := InputMetadata{
+		SampleRate:   metadata.SampleRate,
+		Channels:     metadata.Channels,
+		DurationSecs: metadata.Duration,
+	}
+
+	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.GetDecoderContext(), filterSpec)
+	if err != nil {
+		tb.Fatalf("failed to create fullbench filter graph: %v", err)
+	}
+	defer ffmpeg.AVFilterGraphFree(&filterGraph)
+
+	encoder, err := createOutputEncoder(outputPath, metadata, bufferSinkCtx)
+	if err != nil {
+		tb.Fatalf("failed to create fullbench output encoder: %v", err)
+	}
+	encoderClosed := false
+	defer func() {
+		if !encoderClosed {
+			_ = encoder.Close()
+		}
+	}()
+
+	var outputAcc *outputMetadataAccumulators
+	if extractMeasurements {
+		outputAcc = &outputMetadataAccumulators{}
+	}
+
+	if err := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+		OnReadError: func(err error) error {
+			return fmt.Errorf("failed to read frame: %w", err)
+		},
+		OnPushError: func(err error) error {
+			return fmt.Errorf("failed to push frame to filter: %w", err)
+		},
+		OnPullError: func(err error) error {
+			return fmt.Errorf("failed to pull frame from filter: %w", err)
+		},
+		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) (FrameAction, error) {
+			if outputAcc != nil {
+				extractOutputFrameMetadata(filteredFrame.Metadata(), outputAcc)
+			}
+
+			filteredFrame.SetTimeBase(ffmpeg.AVBuffersinkGetTimeBase(bufferSinkCtx))
+			if err := encoder.WriteFrame(filteredFrame); err != nil {
+				return FrameDiscard, fmt.Errorf("failed to write frame: %w", err)
+			}
+
+			return FrameDiscard, nil
+		},
+	}); err != nil {
+		tb.Fatalf("fullbench filter graph failed: %v", err)
+	}
+
+	if err := encoder.Flush(); err != nil {
+		tb.Fatalf("failed to flush fullbench output encoder: %v", err)
+	}
+	if err := encoder.Close(); err != nil {
+		tb.Fatalf("failed to close fullbench output encoder: %v", err)
+	}
+	encoderClosed = true
+
+	if outputAcc != nil {
+		return inputMetadata, finalizeOutputMeasurements(outputAcc)
+	}
+
+	return inputMetadata, nil
+}
+
+func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
+	return []fullbenchPass2AblationVariant{
+		{
+			Name:                "full_chain",
+			ExtractMeasurements: true,
+			BuildSpec: func(config *FilterChainConfig) string {
+				return config.BuildFilterSpec()
+			},
+		},
+		{
+			Name:                "without_output_analysis",
+			ExtractMeasurements: false,
+			BuildSpec: func(config *FilterChainConfig) string {
+				ablated := *config
+				ablated.AnalysisEnabled = false
+				ablated.OutputAnalysisEnabled = false
+				return ablated.BuildFilterSpec()
+			},
+		},
+		{
+			Name:                "without_anlmdn",
+			ExtractMeasurements: true,
+			BuildSpec:           buildFullbenchPass2WithoutAnlmdnSpec,
+		},
+		{
+			Name:                "without_compand",
+			ExtractMeasurements: true,
+			BuildSpec: func(config *FilterChainConfig) string {
+				ablated := *config
+				ablated.NoiseRemoveCompandEnabled = false
+				return ablated.BuildFilterSpec()
+			},
+		},
+		{
+			Name:                "without_gate_compressor",
+			ExtractMeasurements: true,
+			BuildSpec: func(config *FilterChainConfig) string {
+				ablated := *config
+				ablated.DS201GateEnabled = false
+				ablated.LA2AEnabled = false
+				return ablated.BuildFilterSpec()
+			},
+		},
+	}
+}
+
+func buildFullbenchPass2WithoutAnlmdnSpec(config *FilterChainConfig) string {
+	ablated := *config
+	order := ablated.FilterOrder
+	if len(order) == 0 {
+		order = Pass2FilterOrder
+	}
+
+	filters := make([]string, 0, len(order))
+	for _, id := range order {
+		if id == FilterNoiseRemove {
+			if ablated.NoiseRemoveEnabled && ablated.NoiseRemoveCompandEnabled {
+				filters = append(filters, ablated.buildNoiseRemoveCompandFilter())
+			}
+			continue
+		}
+
+		builder, ok := filterBuilders[id]
+		if !ok {
+			continue
+		}
+		if spec := builder(&ablated); spec != "" {
+			filters = append(filters, spec)
+		}
+	}
+
+	return strings.Join(filters, ",")
+}
+
+func fullbenchPass4AblationVariants() []fullbenchPass4AblationVariant {
+	return []fullbenchPass4AblationVariant{
+		{
+			Name: "loudnorm_only",
+			BuildSpec: func(loudnorm *fullbenchLoudnormSetup) string {
+				return buildFullbenchPass4AblationSpec(loudnorm, false, false)
+			},
+		},
+		{
+			Name:            "loudnorm_plus_limiter",
+			RequiresLimiter: true,
+			BuildSpec: func(loudnorm *fullbenchLoudnormSetup) string {
+				return buildFullbenchPass4AblationSpec(loudnorm, true, false)
+			},
+		},
+		{
+			Name:                "loudnorm_plus_output_analysis",
+			ExtractMeasurements: true,
+			BuildSpec: func(loudnorm *fullbenchLoudnormSetup) string {
+				return buildFullbenchPass4AblationSpec(loudnorm, false, true)
+			},
+		},
+	}
+}
+
+func buildFullbenchPass4AblationSpec(loudnorm *fullbenchLoudnormSetup, includeLimiter, includeOutputAnalysis bool) string {
+	if loudnorm == nil || loudnorm.EffectiveConfig == nil || loudnorm.Measurement == nil {
+		return ""
+	}
+
+	filters := make([]string, 0, 5)
+	if includeLimiter && loudnorm.Pass3FilterPrefix != "" {
+		filters = append(filters, loudnorm.Pass3FilterPrefix)
+	}
+
+	filters = append(filters, buildFullbenchLoudnormClause(loudnorm.EffectiveConfig, loudnorm.Measurement))
+
+	if includeOutputAnalysis {
+		if analysis := buildFullbenchPass4OutputAnalysisFilters(loudnorm.EffectiveConfig, loudnorm.Measurement); analysis != "" {
+			filters = append(filters, analysis)
+		}
+	}
+
+	filters = append(filters, buildFullbenchPass4ResampleFilter(loudnorm.EffectiveConfig))
+
+	return strings.Join(filters, ",")
+}
+
+func buildFullbenchLoudnormClause(config *FilterChainConfig, measurement *LoudnormMeasurement) string {
+	return extractFullbenchFilterClause(
+		buildFullbenchProductionPass4SpecWithoutAdeclick(config, measurement),
+		"loudnorm=",
+	)
+}
+
+func buildFullbenchPass4OutputAnalysisFilters(config *FilterChainConfig, measurement *LoudnormMeasurement) string {
+	clauses := strings.Split(buildFullbenchProductionPass4SpecWithoutAdeclick(config, measurement), ",")
+	analysisStart := -1
+	resampleStart := -1
+	for i, clause := range clauses {
+		switch {
+		case strings.HasPrefix(clause, "astats="):
+			analysisStart = i
+		case strings.HasPrefix(clause, "aformat="):
+			resampleStart = i
+		}
+	}
+	if analysisStart == -1 || resampleStart == -1 || analysisStart >= resampleStart {
+		return ""
+	}
+
+	return strings.Join(clauses[analysisStart:resampleStart], ",")
+}
+
+func buildFullbenchPass4ResampleFilter(config *FilterChainConfig) string {
+	resampleConfig := *config
+	resampleConfig.ResampleEnabled = true
+	return resampleConfig.buildResampleFilter()
+}
+
+func buildFullbenchProductionPass4SpecWithoutAdeclick(config *FilterChainConfig, measurement *LoudnormMeasurement) string {
+	pass4Config := *config
+	pass4Config.AdeclickEnabled = false
+	return buildLoudnormFilterSpec(&pass4Config, measurement, 0, 0, false)
+}
+
+func extractFullbenchFilterClause(spec, prefix string) string {
+	for clause := range strings.SplitSeq(spec, ",") {
+		if strings.HasPrefix(clause, prefix) {
+			return clause
+		}
+	}
+
+	return ""
+}
+
+func TestFullbenchPass2AblationSpecs(t *testing.T) {
+	config := newTestConfig()
+	config.DownmixEnabled = true
+	config.DS201HPEnabled = true
+	config.DS201LPEnabled = true
+	config.NoiseRemoveEnabled = true
+	config.NoiseRemoveCompandEnabled = true
+	config.DS201GateEnabled = true
+	config.LA2AEnabled = true
+	config.DeessEnabled = true
+	config.DeessIntensity = 0.5
+	config.AnalysisEnabled = true
+	config.OutputAnalysisEnabled = true
+	config.ResampleEnabled = true
+	config.FilterOrder = Pass2FilterOrder
+
+	variantByName := make(map[string]fullbenchPass2AblationVariant)
+	for _, variant := range fullbenchPass2AblationVariants() {
+		variantByName[variant.Name] = variant
+	}
+
+	expectedNames := []string{
+		"full_chain",
+		"without_output_analysis",
+		"without_anlmdn",
+		"without_compand",
+		"without_gate_compressor",
+	}
+	if len(variantByName) != len(expectedNames) {
+		t.Fatalf("got %d Pass 2 ablation variants, want %d", len(variantByName), len(expectedNames))
+	}
+	for _, name := range expectedNames {
+		if _, ok := variantByName[name]; !ok {
+			t.Fatalf("missing Pass 2 ablation variant %q", name)
+		}
+	}
+
+	tests := []struct {
+		name                string
+		wantPresent         []string
+		wantAbsent          []string
+		extractMeasurements bool
+	}{
+		{
+			name: "full_chain",
+			wantPresent: []string{
+				"anlmdn=", "compand=", "agate=", "acompressor=",
+				"astats=", "aspectralstats=", "ebur128=",
+				"aformat=sample_rates=44100", "asetnsamples=",
+			},
+			extractMeasurements: true,
+		},
+		{
+			name:        "without_output_analysis",
+			wantPresent: []string{"anlmdn=", "compand=", "agate=", "acompressor=", "aformat=sample_rates=44100", "asetnsamples="},
+			wantAbsent:  []string{"astats=", "aspectralstats=", "ebur128="},
+		},
+		{
+			name:                "without_anlmdn",
+			wantPresent:         []string{"compand=", "agate=", "acompressor=", "astats=", "aspectralstats=", "ebur128=", "aformat=sample_rates=44100", "asetnsamples="},
+			wantAbsent:          []string{"anlmdn="},
+			extractMeasurements: true,
+		},
+		{
+			name:                "without_compand",
+			wantPresent:         []string{"anlmdn=", "agate=", "acompressor=", "astats=", "aspectralstats=", "ebur128=", "aformat=sample_rates=44100", "asetnsamples="},
+			wantAbsent:          []string{"compand="},
+			extractMeasurements: true,
+		},
+		{
+			name:                "without_gate_compressor",
+			wantPresent:         []string{"anlmdn=", "compand=", "astats=", "aspectralstats=", "ebur128=", "aformat=sample_rates=44100", "asetnsamples="},
+			wantAbsent:          []string{"agate=", "acompressor="},
+			extractMeasurements: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variant := variantByName[tt.name]
+			spec := variant.BuildSpec(config)
+			assertFullbenchSpecContains(t, spec, tt.wantPresent)
+			assertFullbenchSpecExcludes(t, spec, tt.wantAbsent)
+			if variant.ExtractMeasurements != tt.extractMeasurements {
+				t.Fatalf("ExtractMeasurements = %v, want %v", variant.ExtractMeasurements, tt.extractMeasurements)
+			}
+		})
+	}
+}
+
+func TestFullbenchPass2WithoutAnlmdnPreservesOrder(t *testing.T) {
+	config := newTestConfig()
+	config.DownmixEnabled = true
+	config.DS201HPEnabled = true
+	config.DS201LPEnabled = true
+	config.NoiseRemoveEnabled = true
+	config.NoiseRemoveCompandEnabled = true
+	config.DS201GateEnabled = true
+	config.LA2AEnabled = true
+	config.DeessEnabled = true
+	config.DeessIntensity = 0.5
+	config.AnalysisEnabled = true
+	config.ResampleEnabled = true
+	config.FilterOrder = Pass2FilterOrder
+
+	spec := buildFullbenchPass2WithoutAnlmdnSpec(config)
+
+	assertFullbenchSpecExcludes(t, spec, []string{"anlmdn="})
+	assertFullbenchSpecContains(t, spec, []string{"compand="})
+	assertFullbenchSpecOrder(t, spec, []string{
+		"aformat=channel_layouts=mono",
+		"highpass=",
+		"lowpass=",
+		"compand=",
+		"agate=",
+		"acompressor=",
+		"deesser=",
+		"astats=",
+		"aspectralstats=",
+		"ebur128=",
+		"aformat=sample_rates=44100",
+		"asetnsamples=",
+	})
+}
+
+func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
+	config := newTestConfig()
+	config.AdeclickEnabled = true
+	config.LoudnormTargetI = -17.25
+	config.LoudnormTargetTP = -2.25
+	config.LoudnormTargetLRA = 9.0
+
+	measurement := &LoudnormMeasurement{
+		InputI:       -23.25,
+		InputTP:      -4.50,
+		InputLRA:     5.75,
+		InputThresh:  -34.25,
+		TargetOffset: -0.75,
+	}
+
+	productionConfig := *config
+	productionConfig.AdeclickEnabled = false
+	productionClause := extractFullbenchFilterClause(
+		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false),
+		"loudnorm=",
+	)
+	benchmarkClause := buildFullbenchLoudnormClause(config, measurement)
+
+	if benchmarkClause != productionClause {
+		t.Fatalf("benchmark loudnorm clause drifted from production\nbenchmark:  %s\nproduction: %s", benchmarkClause, productionClause)
+	}
+	assertFullbenchSpecContains(t, benchmarkClause, []string{
+		"I=-17.25",
+		"TP=-2.25",
+		"LRA=9.0",
+		"measured_I=-23.25",
+		"measured_TP=-4.50",
+		"measured_LRA=5.75",
+		"measured_thresh=-34.25",
+		"offset=-0.75",
+		"dual_mono=true",
+		"linear=true",
+		"print_format=json",
+	})
+	assertFullbenchSpecExcludes(t, benchmarkClause, []string{
+		"adeclick=", "astats=", "aspectralstats=", "ebur128=", "aformat=", "asetnsamples=",
+	})
+}
+
+func TestFullbenchPass4AblationSpecs(t *testing.T) {
+	config := newTestConfig()
+	config.AdeclickEnabled = true
+	config.ResampleEnabled = false
+	measurement := &LoudnormMeasurement{
+		InputI:       -24.0,
+		InputTP:      -6.0,
+		InputLRA:     7.0,
+		InputThresh:  -34.0,
+		TargetOffset: -1.0,
+	}
+	loudnorm := &fullbenchLoudnormSetup{
+		Measurement:       measurement,
+		EffectiveConfig:   config,
+		Pass3FilterPrefix: buildPreLimiterPrefix(0, -12.0, true),
+		LimiterNeeded:     true,
+		LimiterCeiling:    -12.0,
+	}
+
+	variantByName := make(map[string]fullbenchPass4AblationVariant)
+	for _, variant := range fullbenchPass4AblationVariants() {
+		variantByName[variant.Name] = variant
+	}
+
+	expectedNames := []string{
+		"loudnorm_only",
+		"loudnorm_plus_limiter",
+		"loudnorm_plus_output_analysis",
+	}
+	if len(variantByName) != len(expectedNames) {
+		t.Fatalf("got %d Pass 4 ablation variants, want %d", len(variantByName), len(expectedNames))
+	}
+	for _, name := range expectedNames {
+		if _, ok := variantByName[name]; !ok {
+			t.Fatalf("missing Pass 4 ablation variant %q", name)
+		}
+	}
+
+	tests := []struct {
+		name                string
+		wantPresent         []string
+		wantAbsent          []string
+		extractMeasurements bool
+		requiresLimiter     bool
+	}{
+		{
+			name:        "loudnorm_only",
+			wantPresent: []string{"loudnorm=", "aformat=sample_rates=44100", "asetnsamples="},
+			wantAbsent:  []string{"alimiter=", "astats=", "aspectralstats=", "ebur128=", "adeclick="},
+		},
+		{
+			name:            "loudnorm_plus_limiter",
+			wantPresent:     []string{"alimiter=", "loudnorm=", "aformat=sample_rates=44100", "asetnsamples="},
+			wantAbsent:      []string{"astats=", "aspectralstats=", "ebur128=", "adeclick="},
+			requiresLimiter: true,
+		},
+		{
+			name:                "loudnorm_plus_output_analysis",
+			wantPresent:         []string{"loudnorm=", "astats=", "aspectralstats=", "ebur128=", "aformat=sample_rates=44100", "asetnsamples="},
+			wantAbsent:          []string{"alimiter=", "adeclick="},
+			extractMeasurements: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variant := variantByName[tt.name]
+			spec := variant.BuildSpec(loudnorm)
+			assertFullbenchSpecContains(t, spec, tt.wantPresent)
+			assertFullbenchSpecExcludes(t, spec, tt.wantAbsent)
+			if variant.ExtractMeasurements != tt.extractMeasurements {
+				t.Fatalf("ExtractMeasurements = %v, want %v", variant.ExtractMeasurements, tt.extractMeasurements)
+			}
+			if variant.RequiresLimiter != tt.requiresLimiter {
+				t.Fatalf("RequiresLimiter = %v, want %v", variant.RequiresLimiter, tt.requiresLimiter)
+			}
+		})
+	}
+
+	limiterSpec := variantByName["loudnorm_plus_limiter"].BuildSpec(loudnorm)
+	assertFullbenchSpecOrder(t, limiterSpec, []string{"alimiter=", "loudnorm=", "aformat=", "asetnsamples="})
+
+	analysisSpec := variantByName["loudnorm_plus_output_analysis"].BuildSpec(loudnorm)
+	assertFullbenchSpecOrder(t, analysisSpec, []string{
+		"loudnorm=",
+		"astats=",
+		"aspectralstats=",
+		"ebur128=",
+		"aformat=",
+		"asetnsamples=",
+	})
+}
+
+func TestFullbenchPass4LimiterVariantOmitsInactivePrefix(t *testing.T) {
+	config := newTestConfig()
+	measurement := &LoudnormMeasurement{
+		InputI:       -20.0,
+		InputTP:      -8.0,
+		InputLRA:     5.0,
+		InputThresh:  -30.0,
+		TargetOffset: 0.0,
+	}
+	loudnorm := &fullbenchLoudnormSetup{
+		Measurement:     measurement,
+		EffectiveConfig: config,
+	}
+
+	for _, variant := range fullbenchPass4AblationVariants() {
+		if variant.Name != "loudnorm_plus_limiter" {
+			continue
+		}
+		if !variant.RequiresLimiter {
+			t.Fatal("loudnorm_plus_limiter must require an active limiter prefix")
+		}
+		spec := variant.BuildSpec(loudnorm)
+		assertFullbenchSpecContains(t, spec, []string{"loudnorm=", "aformat=sample_rates=44100", "asetnsamples="})
+		assertFullbenchSpecExcludes(t, spec, []string{"alimiter=", "volume="})
+		return
+	}
+
+	t.Fatal("missing loudnorm_plus_limiter variant")
+}
+
+func assertFullbenchSpecContains(tb testing.TB, spec string, parts []string) {
+	tb.Helper()
+
+	for _, part := range parts {
+		if !strings.Contains(spec, part) {
+			tb.Fatalf("filter spec missing %q\nSpec: %s", part, spec)
+		}
+	}
+}
+
+func assertFullbenchSpecExcludes(tb testing.TB, spec string, parts []string) {
+	tb.Helper()
+
+	for _, part := range parts {
+		if strings.Contains(spec, part) {
+			tb.Fatalf("filter spec contains unwanted %q\nSpec: %s", part, spec)
+		}
+	}
+}
+
+func assertFullbenchSpecOrder(tb testing.TB, spec string, parts []string) {
+	tb.Helper()
+
+	previous := -1
+	for _, part := range parts {
+		current := strings.Index(spec, part)
+		if current == -1 {
+			tb.Fatalf("filter spec missing %q\nSpec: %s", part, spec)
+		}
+		if current <= previous {
+			tb.Fatalf("filter spec order mismatch at %q\nSpec: %s", part, spec)
+		}
+		previous = current
+	}
+}
+
+func TestRunFullbenchFilterSpecSyntheticSmoke(t *testing.T) {
+	inputPath := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 1.0,
+		SampleRate:   44100,
+		ToneFreq:     180.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -58.0,
+		Dir:          t.TempDir(),
+	})
+	defer cleanupTestAudio(t, inputPath)
+
+	config := newTestConfig()
+	config.AnalysisEnabled = true
+	config.ResampleEnabled = true
+	config.FilterOrder = Pass2FilterOrder
+	filterSpec := config.BuildFilterSpec()
+
+	measuredOutputPath := filepath.Join(t.TempDir(), "measured.flac")
+	inputMetadata, outputMeasurements := runFullbenchFilterSpec(t, inputPath, measuredOutputPath, filterSpec, true)
+	if inputMetadata.SampleRate != 44100 {
+		t.Fatalf("input metadata sample rate mismatch: got %d, want 44100", inputMetadata.SampleRate)
+	}
+	if outputMeasurements == nil {
+		t.Fatal("expected output measurements when extraction is requested")
+	}
+	assertFullbenchFLACOutput(t, measuredOutputPath)
+
+	unmeasuredOutputPath := filepath.Join(t.TempDir(), "unmeasured.flac")
+	_, unmeasuredOutputMeasurements := runFullbenchFilterSpec(t, inputPath, unmeasuredOutputPath, filterSpec, false)
+	if unmeasuredOutputMeasurements != nil {
+		t.Fatal("did not expect output measurements when extraction is not requested")
+	}
+	assertFullbenchFLACOutput(t, unmeasuredOutputPath)
+}
+
+func BenchmarkPass2FilterAblations(b *testing.B) {
+	inputPath := resolveFullbenchFixture(b)
+	adapted := setupFullbenchAdaptedConfig(b, inputPath)
+
+	for _, variant := range fullbenchPass2AblationVariants() {
+		b.Run(variant.Name, func(b *testing.B) {
+			config := *adapted.Config
+			config.Pass = PassProcessing
+			config.FilterOrder = Pass2FilterOrder
+			spec := variant.BuildSpec(&config)
+			if spec == "" {
+				b.Fatal("Pass 2 ablation filter spec must not be empty")
+			}
+
+			outputDir := b.TempDir()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				outputPath := filepath.Join(outputDir, fmt.Sprintf("%s-%d.flac", variant.Name, i))
+				_, outputMeasurements := runFullbenchFilterSpec(b, inputPath, outputPath, spec, variant.ExtractMeasurements)
+				if variant.ExtractMeasurements && outputMeasurements == nil {
+					b.Fatal("expected output measurements for Pass 2 ablation variant")
+				}
+				if !variant.ExtractMeasurements && outputMeasurements != nil {
+					b.Fatal("did not expect output measurements for Pass 2 ablation variant")
+				}
+
+				b.StopTimer()
+				if err := os.Remove(outputPath); err != nil {
+					b.Fatalf("failed to remove Pass 2 ablation output: %v", err)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkPass4FilterAblations(b *testing.B) {
+	inputPath := resolveFullbenchFixture(b)
+	seed := setupFullbenchPass4Seed(b, inputPath)
+	if seed.Pass2Seed == nil || seed.Loudnorm == nil {
+		b.Fatal("Pass 4 ablation setup returned incomplete seed")
+	}
+
+	for _, variant := range fullbenchPass4AblationVariants() {
+		b.Run(variant.Name, func(b *testing.B) {
+			if variant.RequiresLimiter && seed.Loudnorm.Pass3FilterPrefix == "" {
+				b.Fatal("Pass 4 limiter ablation requires a fixture that activates the limiter prefix")
+			}
+
+			spec := variant.BuildSpec(seed.Loudnorm)
+			if spec == "" {
+				b.Fatal("Pass 4 ablation filter spec must not be empty")
+			}
+
+			outputDir := b.TempDir()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				outputPath := filepath.Join(outputDir, fmt.Sprintf("%s-%d.flac", variant.Name, i))
+				_, outputMeasurements := runFullbenchFilterSpec(
+					b,
+					seed.Pass2Seed.OutputPath,
+					outputPath,
+					spec,
+					variant.ExtractMeasurements,
+				)
+				if variant.ExtractMeasurements && outputMeasurements == nil {
+					b.Fatal("expected output measurements for Pass 4 ablation variant")
+				}
+				if !variant.ExtractMeasurements && outputMeasurements != nil {
+					b.Fatal("did not expect output measurements for Pass 4 ablation variant")
+				}
+
+				b.StopTimer()
+				if err := os.Remove(outputPath); err != nil {
+					b.Fatalf("failed to remove Pass 4 ablation output: %v", err)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func assertFullbenchFLACOutput(tb testing.TB, outputPath string) {
+	tb.Helper()
+
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		tb.Fatalf("fullbench output was not written: %v", err)
+	}
+	if info.Size() == 0 {
+		tb.Fatal("fullbench output is empty")
+	}
+
+	reader, metadata, err := audio.OpenAudioFile(outputPath)
+	if err != nil {
+		tb.Fatalf("failed to reopen fullbench output: %v", err)
+	}
+	defer reader.Close()
+
+	if metadata.SampleRate != 44100 {
+		tb.Fatalf("output sample rate mismatch: got %d, want 44100", metadata.SampleRate)
+	}
+	if metadata.Channels != 1 {
+		tb.Fatalf("output channels mismatch: got %d, want 1", metadata.Channels)
+	}
+}
+
+func setupFullbenchAdaptedConfig(tb testing.TB, inputPath string) *fullbenchAdaptedSetup {
+	tb.Helper()
+
+	config := DefaultFilterConfig()
+	analysisResult, err := AnalyzeOnlyDetailed(inputPath, config, nil)
+	if err != nil {
+		tb.Fatalf("failed to prepare fullbench adapted config: %v", err)
+	}
+	if analysisResult == nil || analysisResult.Config == nil || analysisResult.Measurements == nil {
+		tb.Fatal("fullbench adapted setup returned incomplete analysis result")
+	}
+
+	analysisResult.Config.Pass = PassProcessing
+	analysisResult.Config.FilterOrder = Pass2FilterOrder
+	analysisResult.Config.OutputAnalysisEnabled = true
+
+	return &fullbenchAdaptedSetup{
+		Config:       analysisResult.Config,
+		Measurements: analysisResult.Measurements,
+	}
+}
+
+func setupFullbenchPass2Seed(tb testing.TB, inputPath string, adapted *fullbenchAdaptedSetup) *fullbenchPass2Seed {
+	tb.Helper()
+
+	if adapted == nil || adapted.Config == nil || adapted.Measurements == nil {
+		tb.Fatal("fullbench Pass 2 seed requires adapted config and measurements")
+	}
+
+	config := *adapted.Config
+	config.Pass = PassProcessing
+	config.FilterOrder = Pass2FilterOrder
+	config.AnalysisEnabled = true
+	config.OutputAnalysisEnabled = true
+
+	outputPath := filepath.Join(tb.TempDir(), "fullbench-pass2-seed.flac")
+	inputMetadata, outputMeasurements := runFullbenchFilterSpec(
+		tb,
+		inputPath,
+		outputPath,
+		config.BuildFilterSpec(),
+		true,
+	)
+	if outputMeasurements == nil {
+		tb.Fatal("fullbench Pass 2 seed did not produce output measurements")
+	}
+
+	return &fullbenchPass2Seed{
+		OutputPath:         outputPath,
+		Config:             &config,
+		InputMeasurements:  adapted.Measurements,
+		OutputMeasurements: outputMeasurements,
+		InputMetadata:      inputMetadata,
+	}
+}
+
+func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) *fullbenchLoudnormSetup {
+	tb.Helper()
+
+	if seed == nil || seed.Config == nil || seed.OutputMeasurements == nil {
+		tb.Fatal("fullbench loudnorm setup requires a Pass 2 seed with output measurements")
+	}
+
+	config := *seed.Config
+	limiterCeiling, limiterNeeded, limiterClamped := calculateLimiterCeiling(
+		seed.OutputMeasurements.OutputI,
+		seed.OutputMeasurements.OutputTP,
+		config.LoudnormTargetI,
+		config.LoudnormTargetTP,
+	)
+	preGainDB, reDerivedCeiling := calculatePreGain(
+		seed.OutputMeasurements.OutputI,
+		config.LoudnormTargetI,
+		config.LoudnormTargetTP,
+	)
+	if limiterClamped {
+		limiterCeiling = reDerivedCeiling
+	}
+
+	filterPrefix := buildPreLimiterPrefix(preGainDB, limiterCeiling, limiterNeeded)
+	measurement, err := measureWithLoudnorm(seed.OutputPath, &config, filterPrefix, nil)
+	if err != nil {
+		tb.Fatalf("failed to prepare fullbench loudnorm measurement: %v", err)
+	}
+	if measurement == nil {
+		tb.Fatal("fullbench loudnorm setup returned nil measurement")
+		return nil
+	}
+	if math.IsInf(measurement.InputI, -1) || measurement.InputI < -70.0 {
+		tb.Fatalf("fullbench loudnorm measurement is not usable: %.1f LUFS", measurement.InputI)
+	}
+
+	effectiveTargetI, _, linearPossible := calculateLinearModeTarget(
+		measurement.InputI,
+		measurement.InputTP,
+		config.LoudnormTargetI,
+		config.LoudnormTargetTP,
+	)
+	effectiveConfig := config
+	effectiveConfig.LoudnormTargetI = effectiveTargetI
+
+	return &fullbenchLoudnormSetup{
+		Measurement:       measurement,
+		EffectiveConfig:   &effectiveConfig,
+		Pass3FilterPrefix: filterPrefix,
+		PreGainDB:         preGainDB,
+		LimiterCeiling:    limiterCeiling,
+		LimiterNeeded:     limiterNeeded,
+		LimiterClamped:    limiterClamped,
+		LinearModeForced:  !linearPossible,
+	}
+}
+
+func setupFullbenchPass4Seed(tb testing.TB, inputPath string) *fullbenchPass4Seed {
+	tb.Helper()
+
+	adapted := setupFullbenchAdaptedConfig(tb, inputPath)
+	pass2Seed := setupFullbenchPass2Seed(tb, inputPath, adapted)
+	loudnorm := setupFullbenchLoudnormMeasurement(tb, pass2Seed)
+
+	return &fullbenchPass4Seed{
+		Pass2Seed: pass2Seed,
+		Loudnorm:  loudnorm,
+	}
+}
+
+func TestFullbenchSetupHelpersSyntheticSmoke(t *testing.T) {
+	inputPath := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 2.0,
+		SampleRate:   44100,
+		ToneFreq:     180.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -58.0,
+		Dir:          t.TempDir(),
+	})
+	defer cleanupTestAudio(t, inputPath)
+
+	adapted := setupFullbenchAdaptedConfig(t, inputPath)
+	if adapted.Config == nil {
+		t.Fatal("expected adapted config")
+	}
+	if adapted.Measurements == nil {
+		t.Fatal("expected Pass 1 measurements")
+	}
+	if adapted.Config.Measurements != adapted.Measurements {
+		t.Fatal("adapted config does not reference Pass 1 measurements")
+	}
+	if adapted.Config.Pass != PassProcessing {
+		t.Fatalf("adapted config pass mismatch: got %d, want %d", adapted.Config.Pass, PassProcessing)
+	}
+
+	pass2Seed := setupFullbenchPass2Seed(t, inputPath, adapted)
+	if pass2Seed.OutputMeasurements == nil {
+		t.Fatal("expected Pass 2 seed output measurements")
+	}
+	assertFullbenchFLACOutput(t, pass2Seed.OutputPath)
+
+	loudnorm := setupFullbenchLoudnormMeasurement(t, pass2Seed)
+	if loudnorm.Measurement == nil {
+		t.Fatal("expected loudnorm measurement")
+	}
+	if loudnorm.EffectiveConfig == nil {
+		t.Fatal("expected effective loudnorm config")
+	}
+	if loudnorm.Pass3FilterPrefix != buildPreLimiterPrefix(loudnorm.PreGainDB, loudnorm.LimiterCeiling, loudnorm.LimiterNeeded) {
+		t.Fatal("loudnorm setup prefix does not match computed limiter values")
+	}
+	if loudnorm.LimiterNeeded && loudnorm.Pass3FilterPrefix == "" {
+		t.Fatal("active limiter setup did not produce a limiter prefix")
+	}
+	effectiveTargetI, _, linearPossible := calculateLinearModeTarget(
+		loudnorm.Measurement.InputI,
+		loudnorm.Measurement.InputTP,
+		pass2Seed.Config.LoudnormTargetI,
+		pass2Seed.Config.LoudnormTargetTP,
+	)
+	if math.Abs(loudnorm.EffectiveConfig.LoudnormTargetI-effectiveTargetI) > 0.01 {
+		t.Fatalf("effective target mismatch: got %.2f, want %.2f", loudnorm.EffectiveConfig.LoudnormTargetI, effectiveTargetI)
+	}
+	if loudnorm.LinearModeForced != !linearPossible {
+		t.Fatalf("linear mode forced mismatch: got %v, want %v", loudnorm.LinearModeForced, !linearPossible)
+	}
+
+	pass4Seed := setupFullbenchPass4Seed(t, inputPath)
+	if pass4Seed.Pass2Seed == nil || pass4Seed.Loudnorm == nil {
+		t.Fatal("expected combined Pass 4 seed setup")
+	}
+	assertFullbenchFLACOutput(t, pass4Seed.Pass2Seed.OutputPath)
+}

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -43,6 +43,12 @@ type fullbenchPass4Seed struct {
 	Loudnorm  *fullbenchLoudnormSetup
 }
 
+type fullbenchFilterSpecRunResult struct {
+	InputMetadata      InputMetadata
+	OutputMetadata     *audio.Metadata
+	OutputMeasurements *OutputMeasurements
+}
+
 type fullbenchPass2AblationVariant struct {
 	Name                string
 	ExtractMeasurements bool
@@ -76,6 +82,9 @@ func resolveFullbenchFixtureFromEnv(tb testing.TB) (string, bool) {
 	}
 
 	if _, err := os.Stat(fixturePath); err != nil { // #nosec G703 -- local benchmark fixture path is explicitly supplied by JIVETALKING_BENCH_FIXTURE.
+		if os.IsNotExist(err) {
+			tb.Skipf("%s is set but benchmark fixture is absent: %s", fullbenchFixtureEnv, fixturePath)
+		}
 		tb.Fatalf("%s is set but cannot be accessed: %v", fullbenchFixtureEnv, err)
 	}
 	return copyBenchmarkFixture(tb, fixturePath, tb.TempDir()), true
@@ -130,6 +139,19 @@ func TestResolveFullbenchFixtureFromEnvCopiesEnvironmentFixture(t *testing.T) {
 }
 
 func runFullbenchFilterSpec(tb testing.TB, inputPath, outputPath, filterSpec string, extractMeasurements bool) (InputMetadata, *OutputMeasurements) {
+	tb.Helper()
+
+	result := runFullbenchFilterSpecCore(tb, inputPath, outputPath, filterSpec, extractMeasurements, false)
+	return result.InputMetadata, result.OutputMeasurements
+}
+
+func runFullbenchFilterSpecResult(tb testing.TB, inputPath, outputPath, filterSpec string, extractMeasurements bool) *fullbenchFilterSpecRunResult {
+	tb.Helper()
+
+	return runFullbenchFilterSpecCore(tb, inputPath, outputPath, filterSpec, extractMeasurements, true)
+}
+
+func runFullbenchFilterSpecCore(tb testing.TB, inputPath, outputPath, filterSpec string, extractMeasurements, includeOutputMetadata bool) *fullbenchFilterSpecRunResult {
 	tb.Helper()
 
 	if filterSpec == "" {
@@ -204,11 +226,17 @@ func runFullbenchFilterSpec(tb testing.TB, inputPath, outputPath, filterSpec str
 	}
 	encoderClosed = true
 
+	result := &fullbenchFilterSpecRunResult{
+		InputMetadata: inputMetadata,
+	}
+	if includeOutputMetadata {
+		result.OutputMetadata = readFullbenchOutputMetadata(tb, outputPath)
+	}
 	if outputAcc != nil {
-		return inputMetadata, finalizeOutputMeasurements(outputAcc)
+		result.OutputMeasurements = finalizeOutputMeasurements(outputAcc)
 	}
 
-	return inputMetadata, nil
+	return result
 }
 
 func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
@@ -736,6 +764,23 @@ func TestRunFullbenchFilterSpecSyntheticSmoke(t *testing.T) {
 	}
 	assertFullbenchFLACOutput(t, measuredOutputPath)
 
+	result := runFullbenchFilterSpecResult(t, inputPath, filepath.Join(t.TempDir(), "result.flac"), filterSpec, true)
+	if result.InputMetadata.SampleRate != 44100 {
+		t.Fatalf("result input metadata sample rate mismatch: got %d, want 44100", result.InputMetadata.SampleRate)
+	}
+	if result.OutputMetadata == nil {
+		t.Fatal("expected result output metadata")
+	}
+	if result.OutputMetadata.SampleRate != 44100 {
+		t.Fatalf("result output metadata sample rate mismatch: got %d, want 44100", result.OutputMetadata.SampleRate)
+	}
+	if result.OutputMetadata.Channels != 1 {
+		t.Fatalf("result output metadata channels mismatch: got %d, want 1", result.OutputMetadata.Channels)
+	}
+	if result.OutputMeasurements == nil {
+		t.Fatal("expected result output measurements when extraction is requested")
+	}
+
 	unmeasuredOutputPath := filepath.Join(t.TempDir(), "unmeasured.flac")
 	_, unmeasuredOutputMeasurements := runFullbenchFilterSpec(t, inputPath, unmeasuredOutputPath, filterSpec, false)
 	if unmeasuredOutputMeasurements != nil {
@@ -828,6 +873,18 @@ func BenchmarkPass4FilterAblations(b *testing.B) {
 	}
 }
 
+func readFullbenchOutputMetadata(tb testing.TB, outputPath string) *audio.Metadata {
+	tb.Helper()
+
+	reader, metadata, err := audio.OpenAudioFile(outputPath)
+	if err != nil {
+		tb.Fatalf("failed to reopen fullbench output: %v", err)
+	}
+	defer reader.Close()
+
+	return metadata
+}
+
 func assertFullbenchFLACOutput(tb testing.TB, outputPath string) {
 	tb.Helper()
 
@@ -839,12 +896,7 @@ func assertFullbenchFLACOutput(tb testing.TB, outputPath string) {
 		tb.Fatal("fullbench output is empty")
 	}
 
-	reader, metadata, err := audio.OpenAudioFile(outputPath)
-	if err != nil {
-		tb.Fatalf("failed to reopen fullbench output: %v", err)
-	}
-	defer reader.Close()
-
+	metadata := readFullbenchOutputMetadata(tb, outputPath)
 	if metadata.SampleRate != 44100 {
 		tb.Fatalf("output sample rate mismatch: got %d, want 44100", metadata.SampleRate)
 	}

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -145,10 +145,10 @@ func runFullbenchFilterSpec(tb testing.TB, inputPath, outputPath, filterSpec str
 	return result.InputMetadata, result.OutputMeasurements
 }
 
-func runFullbenchFilterSpecResult(tb testing.TB, inputPath, outputPath, filterSpec string, extractMeasurements bool) *fullbenchFilterSpecRunResult {
+func runFullbenchFilterSpecResult(tb testing.TB, inputPath, outputPath, filterSpec string) *fullbenchFilterSpecRunResult {
 	tb.Helper()
 
-	return runFullbenchFilterSpecCore(tb, inputPath, outputPath, filterSpec, extractMeasurements, true)
+	return runFullbenchFilterSpecCore(tb, inputPath, outputPath, filterSpec, true, true)
 }
 
 func runFullbenchFilterSpecCore(tb testing.TB, inputPath, outputPath, filterSpec string, extractMeasurements, includeOutputMetadata bool) *fullbenchFilterSpecRunResult {
@@ -764,7 +764,7 @@ func TestRunFullbenchFilterSpecSyntheticSmoke(t *testing.T) {
 	}
 	assertFullbenchFLACOutput(t, measuredOutputPath)
 
-	result := runFullbenchFilterSpecResult(t, inputPath, filepath.Join(t.TempDir(), "result.flac"), filterSpec, true)
+	result := runFullbenchFilterSpecResult(t, inputPath, filepath.Join(t.TempDir(), "result.flac"), filterSpec)
 	if result.InputMetadata.SampleRate != 44100 {
 		t.Fatalf("result input metadata sample rate mismatch: got %d, want 44100", result.InputMetadata.SampleRate)
 	}

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -84,6 +84,20 @@ const (
 	NormToleranceLU = 0.5
 )
 
+// NoiseRemove production defaults.
+const (
+	noiseRemoveProductionPreSampleRate = 32000
+	noiseRemoveProductionStrength      = 0.00001
+	noiseRemoveProductionPatchSec      = 0.0060
+	noiseRemoveProductionResearchSec   = 0.0045
+	noiseRemoveProductionSmooth        = 11.0
+
+	noiseRemoveLegacyStrength    = 0.00001
+	noiseRemoveLegacyPatchSec    = 0.0060
+	noiseRemoveLegacyResearchSec = 0.0058
+	noiseRemoveLegacySmooth      = 11.0
+)
+
 // filterBuilderFunc is a function that builds a filter spec from config.
 // Returns the FFmpeg filter specification string, or empty string if disabled.
 type filterBuilderFunc func(*FilterChainConfig) string
@@ -167,8 +181,9 @@ type FilterChainConfig struct {
 
 	// NoiseRemove - anlmdn + compand noise reduction
 	// Non-Local Means denoiser (anlmdn) with a compand for residual suppression
-	// Validated fast-compand config: -13 to -20 dB silence reduction, 20-24x realtime, ±1-2% spectral preservation
+	// Validated 32 kHz fast config: lower CPU with baseline-equivalent output on EP 68 noise samples.
 	NoiseRemoveEnabled          bool    // Enable anlmdn+compand noise reduction
+	NoiseRemovePreSampleRate    int     // Optional sample-rate cap before anlmdn (0 = disabled)
 	NoiseRemoveCompandEnabled   bool    // Enable compand residual suppression (false = anlmdn-only)
 	NoiseRemoveStrength         float64 // anlmdn strength (0.00001 = minimum, kept constant)
 	NoiseRemovePatchSec         float64 // Patch size in seconds (context window for similarity)
@@ -308,18 +323,19 @@ func DefaultFilterConfig() *FilterChainConfig {
 		DS201LPMix:       1.0,     // Full wet signal
 		DS201LPTransform: "tdii",  // Transposed Direct Form II - best floating-point accuracy
 
-		// NoiseRemove - anlmdn + compand (validated fast-compand config)
-		NoiseRemoveEnabled:          true,    // Primary noise reduction filter
-		NoiseRemoveCompandEnabled:   true,    // Compand enabled when noise profile available
-		NoiseRemoveStrength:         0.00001, // Minimum strength (fixed from spike validation)
-		NoiseRemovePatchSec:         0.006,   // 6ms patch (fast-compand validated)
-		NoiseRemoveResearchSec:      0.0058,  // 5.8ms research (fast-compand validated)
-		NoiseRemoveSmooth:           11.0,    // Default smoothing
-		NoiseRemoveCompandThreshold: -55.0,   // Overridden by adaptive tuning
-		NoiseRemoveCompandExpansion: 6.0,     // Overridden by adaptive tuning
-		NoiseRemoveCompandAttack:    0.005,   // 5ms - fixed, empirically validated for speech
-		NoiseRemoveCompandDecay:     0.100,   // 100ms - fixed, empirically validated for speech
-		NoiseRemoveCompandKnee:      6.0,     // 6dB - fixed, soft knee for transparency
+		// NoiseRemove - anlmdn + compand (32 kHz fast default)
+		NoiseRemoveEnabled:          true,                               // Primary noise reduction filter
+		NoiseRemovePreSampleRate:    noiseRemoveProductionPreSampleRate, // 32 kHz cap before anlmdn for lower CPU
+		NoiseRemoveCompandEnabled:   true,                               // Compand enabled when noise profile available
+		NoiseRemoveStrength:         noiseRemoveProductionStrength,      // Minimum strength (fixed from spike validation)
+		NoiseRemovePatchSec:         noiseRemoveProductionPatchSec,      // 6ms patch
+		NoiseRemoveResearchSec:      noiseRemoveProductionResearchSec,   // 4.5ms research
+		NoiseRemoveSmooth:           noiseRemoveProductionSmooth,        // Default smoothing
+		NoiseRemoveCompandThreshold: -55.0,                              // Overridden by adaptive tuning
+		NoiseRemoveCompandExpansion: 6.0,                                // Overridden by adaptive tuning
+		NoiseRemoveCompandAttack:    0.005,                              // 5ms - fixed, empirically validated for speech
+		NoiseRemoveCompandDecay:     0.100,                              // 100ms - fixed, empirically validated for speech
+		NoiseRemoveCompandKnee:      6.0,                                // 6dB - fixed, soft knee for transparency
 
 		// DS201-Inspired Gate - soft expander for natural speech transitions
 		// All parameters set adaptively based on Pass 1 measurements
@@ -581,12 +597,13 @@ func (cfg *FilterChainConfig) buildDS201LowPassFilter() string {
 // buildNoiseRemoveFilter builds the anlmdn+compand noise reduction filter.
 // Non-Local Means denoiser followed a compand for residual suppression.
 //
-// Filter chain: anlmdn → compand
+// Filter chain: optional pre-sample-rate cap → anlmdn → compand
 //
-// anlmdn parameters (validated fast-compand config):
+// anlmdn parameters (validated 32 kHz fast default):
+// - pre-sample-rate: optional sample-rate cap before anlmdn; production uses 32 kHz
 // - s: strength (0.00001 = minimum, kept constant)
 // - p: patch size in seconds (6ms = 0.006s, context window for similarity)
-// - r: research radius in seconds (5.8ms = 0.0058s, search window for matching)
+// - r: research radius in seconds (4.5ms = 0.0045s, search window for matching)
 // - m: smoothing factor (11 = default, weight smoothing)
 //
 // compand parameters
@@ -600,24 +617,32 @@ func (cfg *FilterChainConfig) buildNoiseRemoveFilter() string {
 		return ""
 	}
 
-	// Build anlmdn filter
+	filters := make([]string, 0, 3)
+	if cfg.NoiseRemovePreSampleRate > 0 {
+		filters = append(filters, fmt.Sprintf(
+			"aformat=sample_rates=%d:channel_layouts=mono:sample_fmts=fltp",
+			cfg.NoiseRemovePreSampleRate,
+		))
+	}
+
 	anlmdnSpec := fmt.Sprintf("anlmdn=s=%.5f:p=%.4f:r=%.4f:m=%.0f",
 		cfg.NoiseRemoveStrength,
 		cfg.NoiseRemovePatchSec,
 		cfg.NoiseRemoveResearchSec,
 		cfg.NoiseRemoveSmooth,
 	)
+	filters = append(filters, anlmdnSpec)
 
 	// When compand is disabled (no noise profile to calibrate), use anlmdn only
 	if !cfg.NoiseRemoveCompandEnabled {
-		return anlmdnSpec
+		return strings.Join(filters, ",")
 	}
 
 	// Build compand filter for residual suppression
 	compandSpec := cfg.buildNoiseRemoveCompandFilter()
+	filters = append(filters, compandSpec)
 
-	// Combine: anlmdn,compand
-	return fmt.Sprintf("%s,%s", anlmdnSpec, compandSpec)
+	return strings.Join(filters, ",")
 }
 
 // buildNoiseRemoveCompandFilter builds the compand filter for residual noise suppression.

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -276,6 +276,7 @@ type FilterChainConfig struct {
 	AdeclickThreshold float64 // Detection sensitivity (0.1-8.0, lower=more sensitive)
 	AdeclickWindow    float64 // Analysis window in ms (10-100)
 	AdeclickOverlap   float64 // Window overlap percentage (50-95)
+	AdeclickMethod    string  // Interpolation method ("" = default "a" = average; "s" = spline)
 
 	// Loudnorm (Pass 3) - EBU R128 dynamic loudness normalisation
 	// Replaces simple volume gain + limiting with integrated dynamic normalisation
@@ -387,11 +388,12 @@ func DefaultFilterConfig() *FilterChainConfig {
 		VolumaxOutputLevel: 1.0, // Unity output
 
 		// Adeclick - click/pop repair (Pass 4 only)
-		// Conservative parameters for transparent repair
+		// Tuned for transparent repair at lower CPU cost
 		AdeclickEnabled:   true,
-		AdeclickThreshold: 1.5,  // Slightly more sensitive than FFmpeg default (2.0)
+		AdeclickThreshold: 2.0,  // Less sensitive threshold reduces CPU cost without harming repair quality
 		AdeclickWindow:    55.0, // Default window, appropriate for speech
-		AdeclickOverlap:   75.0, // Default overlap, good detection coverage
+		AdeclickOverlap:   50.0, // Lower overlap further reduces cost while remaining within FFmpeg's valid range
+		AdeclickMethod:    "s",  // Spline interpolation preserves transient peak shapes better than the default average method
 
 		// Filter chain order - use default order
 		FilterOrder: Pass2FilterOrder,
@@ -787,12 +789,16 @@ func (cfg *FilterChainConfig) buildAdeclickFilter() string {
 	if !cfg.AdeclickEnabled {
 		return ""
 	}
-	return fmt.Sprintf(
+	spec := fmt.Sprintf(
 		"adeclick=t=%.1f:w=%.0f:o=%.0f",
 		cfg.AdeclickThreshold,
 		cfg.AdeclickWindow,
 		cfg.AdeclickOverlap,
 	)
+	if cfg.AdeclickMethod != "" {
+		spec += ":m=" + cfg.AdeclickMethod
+	}
+	return spec
 }
 
 // BuildFilterSpec builds the FFmpeg filter specification string for Pass 2 processing.

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -64,6 +64,7 @@ func newTestConfig() *FilterChainConfig {
 		VolumaxOutputLevel: 1.0,
 
 		// NoiseRemove defaults (anlmdn + compand)
+		NoiseRemovePreSampleRate:    0,
 		NoiseRemoveCompandEnabled:   true,
 		NoiseRemoveStrength:         0.00001,
 		NoiseRemovePatchSec:         0.006,
@@ -650,6 +651,25 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 		if strings.Contains(spec, "compand=") {
 			t.Errorf("compand-disabled spec should not contain compand, got: %s", spec)
 		}
+	})
+
+	t.Run("pre-sample-rate cap appears before anlmdn", func(t *testing.T) {
+		config := newTestConfig()
+		config.NoiseRemoveEnabled = true
+		config.NoiseRemovePreSampleRate = 32000
+
+		spec := config.buildNoiseRemoveFilter()
+
+		assertFullbenchSpecContains(t, spec, []string{
+			"aformat=sample_rates=32000:channel_layouts=mono:sample_fmts=fltp",
+			"anlmdn=",
+			"compand=",
+		})
+		assertFullbenchSpecOrder(t, spec, []string{
+			"aformat=sample_rates=32000",
+			"anlmdn=",
+			"compand=",
+		})
 	})
 
 	t.Run("different expansion levels", func(t *testing.T) {

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -86,9 +86,10 @@ func newTestConfig() *FilterChainConfig {
 
 		// Adeclick defaults (Pass 4)
 		AdeclickEnabled:   true,
-		AdeclickThreshold: 1.5,
+		AdeclickThreshold: 2.0,
 		AdeclickWindow:    55.0,
-		AdeclickOverlap:   75.0,
+		AdeclickOverlap:   50.0,
+		AdeclickMethod:    "s",
 
 		FilterOrder: Pass2FilterOrder,
 	}
@@ -744,26 +745,14 @@ func TestBuildVolumaxFilter(t *testing.T) {
 }
 
 func TestBuildAdeclickFilter(t *testing.T) {
-	t.Run("default parameters", func(t *testing.T) {
-		config := newTestConfig()
-		config.AdeclickEnabled = true
-		config.AdeclickThreshold = 1.5
-		config.AdeclickWindow = 55.0
-		config.AdeclickOverlap = 75.0
+	t.Run("default config emits production clause", func(t *testing.T) {
+		config := DefaultFilterConfig()
 
 		spec := config.buildAdeclickFilter()
 
-		wantIn := []string{
-			"adeclick=",
-			"t=1.5",
-			"w=55",
-			"o=75",
-		}
-
-		for _, want := range wantIn {
-			if !strings.Contains(spec, want) {
-				t.Errorf("buildAdeclickFilter() = %q, want to contain %q", spec, want)
-			}
+		const want = "adeclick=t=2.0:w=55:o=50:m=s"
+		if spec != want {
+			t.Errorf("buildAdeclickFilter() = %q, want %q", spec, want)
 		}
 	})
 
@@ -773,17 +762,40 @@ func TestBuildAdeclickFilter(t *testing.T) {
 		config.AdeclickThreshold = 2.0
 		config.AdeclickWindow = 100.0
 		config.AdeclickOverlap = 50.0
+		config.AdeclickMethod = "s"
 
 		spec := config.buildAdeclickFilter()
 
-		if !strings.Contains(spec, "t=2.0") {
-			t.Errorf("buildAdeclickFilter() = %q, want to contain t=2.0", spec)
+		wantIn := []string{
+			"adeclick=",
+			"t=2.0",
+			"w=100",
+			"o=50",
+			"m=s",
 		}
-		if !strings.Contains(spec, "w=100") {
-			t.Errorf("buildAdeclickFilter() = %q, want to contain w=100", spec)
+		for _, want := range wantIn {
+			if !strings.Contains(spec, want) {
+				t.Errorf("buildAdeclickFilter() = %q, want to contain %q", spec, want)
+			}
 		}
-		if !strings.Contains(spec, "o=50") {
-			t.Errorf("buildAdeclickFilter() = %q, want to contain o=50", spec)
+	})
+
+	t.Run("empty method omits m segment", func(t *testing.T) {
+		config := newTestConfig()
+		config.AdeclickEnabled = true
+		config.AdeclickThreshold = 2.0
+		config.AdeclickWindow = 55.0
+		config.AdeclickOverlap = 50.0
+		config.AdeclickMethod = ""
+
+		spec := config.buildAdeclickFilter()
+
+		const want = "adeclick=t=2.0:w=55:o=50"
+		if spec != want {
+			t.Errorf("buildAdeclickFilter() = %q, want %q", spec, want)
+		}
+		if strings.Contains(spec, ":m=") {
+			t.Errorf("buildAdeclickFilter() = %q, must omit :m= segment when method is empty", spec)
 		}
 	})
 

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
 	"github.com/linuxmatters/jivetalking/internal/audio"
@@ -411,6 +412,8 @@ type NormalisationResult struct {
 	LimiterClamped    bool    // True when calculateLimiterCeiling clamped ceiling to minimum
 	Pass3FilterPrefix string  // Filter prefix used for Pass 3 measurement (empty when no pre-gain/limiting)
 
+	RegionMeasurementTime time.Duration // Final-output silence/speech region measurement duration
+
 	// FinalMeasurements contains full analysis after normalisation (Pass 4)
 	// Includes spectral characteristics, amplitude stats, and loudness measurements
 	// for comparison with Pass 1 input and Pass 2 filtered measurements
@@ -515,7 +518,7 @@ func ApplyNormalisation(
 	effectiveConfig.LoudnormTargetI = effectiveTargetI
 
 	// Pass 4: Apply loudnorm with linear=true and the measurements
-	finalLUFS, finalTP, finalMeasurements, loudnormStats, err := applyLoudnormAndMeasure(inputPath, &effectiveConfig, measurement, inputMeasurements, preGainDB, limiterCeiling, limiterNeeded, progressCallback)
+	finalLUFS, finalTP, finalMeasurements, loudnormStats, regionMeasurementTime, err := applyLoudnormAndMeasure(inputPath, &effectiveConfig, measurement, inputMeasurements, preGainDB, limiterCeiling, limiterNeeded, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("loudnorm application failed: %w", err)
 	}
@@ -530,24 +533,25 @@ func ApplyNormalisation(
 	withinTarget := finalDeviation <= 0.5
 
 	return &NormalisationResult{
-		InputLUFS:         measurement.InputI,
-		InputTP:           measurement.InputTP,
-		OutputLUFS:        finalLUFS,
-		OutputTP:          finalTP,
-		GainApplied:       offset,
-		WithinTarget:      withinTarget,
-		Skipped:           false,
-		LoudnormStats:     loudnormStats,
-		RequestedTargetI:  config.LoudnormTargetI,
-		EffectiveTargetI:  effectiveTargetI,
-		LinearModeForced:  !linearPossible,
-		LimiterEnabled:    limiterNeeded,
-		LimiterCeiling:    limiterCeiling,
-		LimiterGain:       limiterGain,
-		PreGainDB:         preGainDB,
-		LimiterClamped:    limiterClamped,
-		Pass3FilterPrefix: filterPrefix,
-		FinalMeasurements: finalMeasurements,
+		InputLUFS:             measurement.InputI,
+		InputTP:               measurement.InputTP,
+		OutputLUFS:            finalLUFS,
+		OutputTP:              finalTP,
+		GainApplied:           offset,
+		WithinTarget:          withinTarget,
+		Skipped:               false,
+		LoudnormStats:         loudnormStats,
+		RequestedTargetI:      config.LoudnormTargetI,
+		EffectiveTargetI:      effectiveTargetI,
+		LinearModeForced:      !linearPossible,
+		LimiterEnabled:        limiterNeeded,
+		LimiterCeiling:        limiterCeiling,
+		LimiterGain:           limiterGain,
+		PreGainDB:             preGainDB,
+		LimiterClamped:        limiterClamped,
+		Pass3FilterPrefix:     filterPrefix,
+		RegionMeasurementTime: regionMeasurementTime,
+		FinalMeasurements:     finalMeasurements,
 	}, nil
 }
 
@@ -572,7 +576,7 @@ func applyLoudnormAndMeasure(
 	ceiling float64,
 	needsLimiting bool,
 	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
-) (float64, float64, *OutputMeasurements, *LoudnormStats, error) {
+) (float64, float64, *OutputMeasurements, *LoudnormStats, time.Duration, error) {
 	// Start capturing loudnorm's JSON output for diagnostics
 	startLoudnormCapture()
 
@@ -585,7 +589,7 @@ func applyLoudnormAndMeasure(
 	// Open input file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
-		return 0.0, 0.0, nil, getLoudnormStats(), fmt.Errorf("failed to open input: %w", err)
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to open input: %w", err)
 	}
 	defer reader.Close()
 
@@ -601,7 +605,7 @@ func applyLoudnormAndMeasure(
 		filterSpec,
 	)
 	if err != nil {
-		return 0.0, 0.0, nil, getLoudnormStats(), fmt.Errorf("failed to create filter graph: %w", err)
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create filter graph: %w", err)
 	}
 	// Note: We free the filter graph explicitly before getting stats, not via defer.
 	// loudnorm outputs its JSON when the filter graph is freed.
@@ -610,7 +614,7 @@ func applyLoudnormAndMeasure(
 	encoder, err := createOutputEncoder(tempPath, metadata, bufferSinkCtx)
 	if err != nil {
 		ffmpeg.AVFilterGraphFree(&filterGraph)
-		return 0.0, 0.0, nil, getLoudnormStats(), fmt.Errorf("failed to create encoder: %w", err)
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create encoder: %w", err)
 	}
 	defer encoder.Close()
 
@@ -653,25 +657,25 @@ func applyLoudnormAndMeasure(
 	})
 	if loopErr != nil {
 		ffmpeg.AVFilterGraphFree(&filterGraph)
-		return 0.0, 0.0, nil, getLoudnormStats(), loopErr
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, loopErr
 	}
 
 	// Flush encoder
 	if err := encoder.Flush(); err != nil {
 		ffmpeg.AVFilterGraphFree(&filterGraph)
-		return 0.0, 0.0, nil, getLoudnormStats(), fmt.Errorf("failed to flush encoder: %w", err)
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to flush encoder: %w", err)
 	}
 
 	// Close encoder before rename
 	if err := encoder.Close(); err != nil {
 		ffmpeg.AVFilterGraphFree(&filterGraph)
-		return 0.0, 0.0, nil, getLoudnormStats(), fmt.Errorf("failed to close encoder: %w", err)
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to close encoder: %w", err)
 	}
 
 	// Atomic rename: temp file → original file (in-place update)
 	if err := os.Rename(tempPath, inputPath); err != nil {
 		ffmpeg.AVFilterGraphFree(&filterGraph)
-		return 0.0, 0.0, nil, getLoudnormStats(), fmt.Errorf("failed to rename output: %w", err)
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to rename output: %w", err)
 	}
 
 	// Free filter graph before getting stats — loudnorm outputs JSON on graph destruction
@@ -682,19 +686,22 @@ func applyLoudnormAndMeasure(
 
 	// Build complete OutputMeasurements from accumulators
 	finalMeasurements := finalizeOutputMeasurements(&acc)
+	var regionMeasurementTime time.Duration
 
 	// Measure silence and speech regions in final output (same regions as Pass 1 profiles)
 	// NOTE: inputPath now contains the normalised output after os.Rename above
 	if inputMeasurements != nil {
 		silRegion, spRegion := extractRegionPair(inputMeasurements)
 		if silRegion != nil || spRegion != nil {
+			regionStart := time.Now()
 			silSample, spSample := MeasureOutputRegions(inputPath, silRegion, spRegion)
+			regionMeasurementTime = time.Since(regionStart)
 			finalMeasurements.SilenceSample = silSample
 			finalMeasurements.SpeechSample = spSample
 		}
 	}
 
-	return acc.ebur128OutputI, acc.ebur128OutputTP, finalMeasurements, stats, nil
+	return acc.ebur128OutputI, acc.ebur128OutputTP, finalMeasurements, stats, regionMeasurementTime, nil
 }
 
 // buildLoudnormFilterSpec constructs the filter chain for Pass 4 loudnorm application.

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -762,11 +762,15 @@ func buildLoudnormFilterSpec(config *FilterChainConfig, measurement *LoudnormMea
 	// Repairs waveform discontinuities from limiter/loudnorm gain transitions
 	// Must come after loudnorm (catches its clicks) and before measurement filters
 	if config.AdeclickEnabled {
-		filters = append(filters, fmt.Sprintf("adeclick=t=%.1f:w=%.0f:o=%.0f",
+		spec := fmt.Sprintf("adeclick=t=%.1f:w=%.0f:o=%.0f",
 			config.AdeclickThreshold,
 			config.AdeclickWindow,
 			config.AdeclickOverlap,
-		))
+		)
+		if config.AdeclickMethod != "" {
+			spec += ":m=" + config.AdeclickMethod
+		}
+		filters = append(filters, spec)
 	}
 
 	// 4. astats for amplitude measurements (same as Pass 2)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
 	"github.com/linuxmatters/jivetalking/internal/audio"
@@ -18,24 +19,52 @@ import (
 func AnalyzeOnly(inputPath string, config *FilterChainConfig,
 	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
 ) (*AudioMeasurements, *FilterChainConfig, error) {
+	result, err := AnalyzeOnlyDetailed(inputPath, config, progressCallback)
+	if err != nil {
+		return nil, nil, err
+	}
+	return result.Measurements, result.Config, nil
+}
+
+// AnalysisResult contains analysis-only measurements and stage timings.
+type AnalysisResult struct {
+	Measurements       *AudioMeasurements
+	Config             *FilterChainConfig
+	AnalysisDuration   time.Duration
+	AdaptationDuration time.Duration
+}
+
+// AnalyzeOnlyDetailed performs Pass 1 analysis and returns stage timing details.
+func AnalyzeOnlyDetailed(inputPath string, config *FilterChainConfig,
+	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
+) (*AnalysisResult, error) {
 	// Pass 1: Analysis
 	if progressCallback != nil {
 		progressCallback(PassAnalysis, "Analyzing", 0.0, 0.0, nil)
 	}
 
+	analysisStart := time.Now()
 	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
 	if err != nil {
-		return nil, nil, fmt.Errorf("analysis failed: %w", err)
+		return nil, fmt.Errorf("analysis failed: %w", err)
 	}
+	analysisDuration := time.Since(analysisStart)
 
 	if progressCallback != nil {
 		progressCallback(PassAnalysis, "Analyzing", 1.0, 0.0, measurements)
 	}
 
 	// Adapt config to show what would be used in Pass 2
+	adaptationStart := time.Now()
 	AdaptConfig(config, measurements)
+	adaptationDuration := time.Since(adaptationStart)
 
-	return measurements, config, nil
+	return &AnalysisResult{
+		Measurements:       measurements,
+		Config:             config,
+		AnalysisDuration:   analysisDuration,
+		AdaptationDuration: adaptationDuration,
+	}, nil
 }
 
 // ProcessAudio performs complete two-pass audio processing:
@@ -80,8 +109,10 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 
 	// Track output measurements from Pass 2 (filtered but not yet normalised)
 	var filteredMeasurements *OutputMeasurements
+	var regionTimings RegionMeasurementTimings
 
-	if err := processWithFilters(inputPath, outputPath, config, progressCallback, measurements, &filteredMeasurements); err != nil {
+	inputMetadata, err := processWithFilters(inputPath, outputPath, config, progressCallback, measurements, &filteredMeasurements)
+	if err != nil {
 		return nil, fmt.Errorf("pass 2 failed: %w", err)
 	}
 
@@ -93,7 +124,9 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 	if filteredMeasurements != nil {
 		silRegion, spRegion := extractRegionPair(measurements)
 		if silRegion != nil || spRegion != nil {
+			regionStart := time.Now()
 			silSample, spSample := MeasureOutputRegions(outputPath, silRegion, spRegion)
+			regionTimings.FilteredOutput = time.Since(regionStart)
 			filteredMeasurements.SilenceSample = silSample
 			filteredMeasurements.SpeechSample = spSample
 		}
@@ -107,6 +140,7 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 		if err != nil {
 			return nil, fmt.Errorf("pass 3 failed: %w", err)
 		}
+		regionTimings.FinalOutput = normResult.RegionMeasurementTime
 	}
 
 	// Return the processing result with output measurements for comparison
@@ -117,6 +151,8 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 		NoiseFloor:           measurements.NoiseFloor,
 		Measurements:         measurements,
 		Config:               config, // Include config for logging adaptive parameters
+		InputMetadata:        inputMetadata,
+		RegionTimings:        regionTimings,
 		FilteredMeasurements: filteredMeasurements,
 		NormResult:           normResult,
 	}
@@ -139,6 +175,19 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 	return result, nil
 }
 
+// InputMetadata contains the report-needed subset of input file metadata.
+type InputMetadata struct {
+	SampleRate   int
+	Channels     int
+	DurationSecs float64
+}
+
+// RegionMeasurementTimings contains optional reportable region measurement durations.
+type RegionMeasurementTimings struct {
+	FilteredOutput time.Duration
+	FinalOutput    time.Duration
+}
+
 // ProcessingResult contains the results of audio processing
 type ProcessingResult struct {
 	OutputPath   string
@@ -147,6 +196,9 @@ type ProcessingResult struct {
 	NoiseFloor   float64
 	Measurements *AudioMeasurements
 	Config       *FilterChainConfig // Contains adaptive parameters used
+
+	InputMetadata InputMetadata
+	RegionTimings RegionMeasurementTimings
 
 	// Pass 2 output analysis (populated when OutputAnalysisEnabled is true)
 	// Contains measurements after filter chain but before normalisation
@@ -161,13 +213,18 @@ type ProcessingResult struct {
 // Applies the filter chain built by BuildFilterSpec() which includes asendcmd for noise profile learning
 // when NoiseProfileStart/End timestamps are set in the config.
 // If outputMeasurements is non-nil and config.OutputAnalysisEnabled is true, populates it with Pass 2 output analysis.
-func processWithFilters(inputPath, outputPath string, config *FilterChainConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements), measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) error {
+func processWithFilters(inputPath, outputPath string, config *FilterChainConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements), measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) (InputMetadata, error) {
 	// Open input audio file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
-		return fmt.Errorf("failed to open input file: %w", err)
+		return InputMetadata{}, fmt.Errorf("failed to open input file: %w", err)
 	}
 	defer reader.Close()
+	inputMetadata := InputMetadata{
+		SampleRate:   metadata.SampleRate,
+		Channels:     metadata.Channels,
+		DurationSecs: metadata.Duration,
+	}
 
 	// Get total duration for progress calculation
 	totalDuration := metadata.Duration
@@ -186,14 +243,14 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 		config,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create filter graph: %w", err)
+		return InputMetadata{}, fmt.Errorf("failed to create filter graph: %w", err)
 	}
 	defer ffmpeg.AVFilterGraphFree(&filterGraph)
 
 	// Create output encoder
 	encoder, err := createOutputEncoder(outputPath, metadata, bufferSinkCtx)
 	if err != nil {
-		return fmt.Errorf("failed to create encoder: %w", err)
+		return InputMetadata{}, fmt.Errorf("failed to create encoder: %w", err)
 	}
 	defer encoder.Close()
 
@@ -251,12 +308,12 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 			return FrameDiscard, nil
 		},
 	}); err != nil {
-		return err
+		return InputMetadata{}, err
 	}
 
 	// Flush the encoder
 	if err := encoder.Flush(); err != nil {
-		return fmt.Errorf("failed to flush encoder: %w", err)
+		return InputMetadata{}, fmt.Errorf("failed to flush encoder: %w", err)
 	}
 
 	// Finalize output measurements if enabled
@@ -266,7 +323,7 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 		*outputMeasurements = finalizeOutputMeasurements(outputAcc)
 	}
 
-	return nil
+	return inputMetadata, nil
 }
 
 // generateOutputPath creates the intermediate output filename from the input filename.

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -138,6 +138,17 @@ func TestProcessAudio(t *testing.T) {
 		t.Error("ProcessAudio returned nil measurements")
 	}
 
+	// Verify report-needed input metadata is populated from the processing path
+	if result.InputMetadata.SampleRate != 44100 {
+		t.Errorf("InputMetadata.SampleRate = %d, want 44100", result.InputMetadata.SampleRate)
+	}
+	if result.InputMetadata.Channels != 1 {
+		t.Errorf("InputMetadata.Channels = %d, want 1", result.InputMetadata.Channels)
+	}
+	if result.InputMetadata.DurationSecs < 2.9 || result.InputMetadata.DurationSecs > 3.1 {
+		t.Errorf("InputMetadata.DurationSecs = %.3f, want about 3.0", result.InputMetadata.DurationSecs)
+	}
+
 	// Verify filtered measurements are populated (Pass 2 output analysis)
 	if result.FilteredMeasurements == nil {
 		t.Error("ProcessAudio returned nil FilteredMeasurements")
@@ -167,6 +178,11 @@ func TestProcessAudio(t *testing.T) {
 		} else {
 			t.Logf("SpeechProfile is nil - skipping speech sample validation")
 		}
+
+		if (result.FilteredMeasurements.SilenceSample != nil || result.FilteredMeasurements.SpeechSample != nil) &&
+			result.RegionTimings.FilteredOutput <= 0 {
+			t.Error("RegionTimings.FilteredOutput was not captured despite filtered region measurements")
+		}
 	}
 
 	// Verify final measurements are populated (Pass 4 output analysis after normalisation)
@@ -194,11 +210,83 @@ func TestProcessAudio(t *testing.T) {
 		t.Logf("NormResult or FinalMeasurements is nil - skipping Pass 4 validation")
 	}
 
+	if result.NormResult != nil && result.NormResult.FinalMeasurements != nil &&
+		(result.NormResult.FinalMeasurements.SilenceSample != nil || result.NormResult.FinalMeasurements.SpeechSample != nil) &&
+		result.RegionTimings.FinalOutput <= 0 {
+		t.Error("RegionTimings.FinalOutput was not captured despite final region measurements")
+	}
+
 	// Log results
 	t.Logf("Input LUFS: %.2f", result.InputLUFS)
 	t.Logf("Output LUFS: %.2f", result.OutputLUFS)
 	t.Logf("Noise Floor: %.2f", result.NoiseFloor)
 	t.Logf("Output: %s", result.OutputPath)
+}
+
+func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 2.0,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -55.0,
+		SilenceGap: struct {
+			Start    float64
+			Duration float64
+		}{
+			Start:    1.0,
+			Duration: 0.3,
+		},
+	})
+	defer cleanupTestAudio(t, testFile)
+
+	config := newTestConfig()
+	config.DownmixEnabled = true
+	config.AnalysisEnabled = true
+
+	result, err := AnalyzeOnlyDetailed(testFile, config, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeOnlyDetailed failed: %v", err)
+	}
+
+	if result.Measurements == nil {
+		t.Fatal("AnalyzeOnlyDetailed returned nil measurements")
+	}
+	if result.Config == nil {
+		t.Fatal("AnalyzeOnlyDetailed returned nil config")
+	}
+	if result.AnalysisDuration <= 0 {
+		t.Errorf("AnalysisDuration = %s, want > 0", result.AnalysisDuration)
+	}
+	if result.AdaptationDuration <= 0 {
+		t.Errorf("AdaptationDuration = %s, want > 0", result.AdaptationDuration)
+	}
+}
+
+func TestAnalyzeOnlyWrapper(t *testing.T) {
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 1.0,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -55.0,
+	})
+	defer cleanupTestAudio(t, testFile)
+
+	config := newTestConfig()
+	config.DownmixEnabled = true
+	config.AnalysisEnabled = true
+
+	measurements, config, err := AnalyzeOnly(testFile, config, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeOnly failed: %v", err)
+	}
+	if measurements == nil {
+		t.Fatal("AnalyzeOnly returned nil measurements")
+	}
+	if config == nil {
+		t.Fatal("AnalyzeOnly returned nil config")
+	}
 }
 
 // TestFilterChainBuilder tests the filter specification generation

--- a/internal/processor/testutil_test.go
+++ b/internal/processor/testutil_test.go
@@ -15,6 +15,7 @@ type TestAudioOptions struct {
 	ToneFreq     float64 // Sine wave frequency in Hz (0 = no tone)
 	ToneLevel    float64 // Tone level in dBFS (e.g., -23.0)
 	NoiseLevel   float64 // White noise level in dBFS (0 = no noise, -60 = quiet noise)
+	Dir          string  // Directory for the generated file (default: OS temp dir)
 	SilenceGap   struct {
 		Start    float64 // Start time of silence gap in seconds
 		Duration float64 // Duration of silence gap in seconds
@@ -24,8 +25,8 @@ type TestAudioOptions struct {
 // generateTestAudio creates a synthetic WAV audio file for testing.
 // The generated audio can include a sine wave tone, white noise, and silence gaps.
 // Returns the path to the temporary file (caller must clean up with os.Remove).
-func generateTestAudio(t *testing.T, opts TestAudioOptions) string {
-	t.Helper()
+func generateTestAudio(tb testing.TB, opts TestAudioOptions) string {
+	tb.Helper()
 
 	// Set defaults
 	if opts.SampleRate == 0 {
@@ -112,9 +113,9 @@ func generateTestAudio(t *testing.T, opts TestAudioOptions) string {
 	}
 
 	// Create temp file
-	tmpFile, err := os.CreateTemp("", "jivetalking-test-*.wav")
+	tmpFile, err := os.CreateTemp(opts.Dir, "jivetalking-test-*.wav")
 	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
+		tb.Fatalf("failed to create temp file: %v", err)
 	}
 	tmpPath := tmpFile.Name()
 
@@ -122,12 +123,12 @@ func generateTestAudio(t *testing.T, opts TestAudioOptions) string {
 	if err := writeWAV(tmpFile, samples, opts.SampleRate); err != nil {
 		tmpFile.Close()
 		os.Remove(tmpPath)
-		t.Fatalf("failed to write WAV file: %v", err)
+		tb.Fatalf("failed to write WAV file: %v", err)
 	}
 
 	if err := tmpFile.Close(); err != nil {
 		os.Remove(tmpPath)
-		t.Fatalf("failed to close temp file: %v", err)
+		tb.Fatalf("failed to close temp file: %v", err)
 	}
 
 	return tmpPath
@@ -202,15 +203,15 @@ func writeWAV(f *os.File, samples []int16, sampleRate int) error {
 }
 
 // cleanupTestAudio removes a test audio file and its processed output (if any)
-func cleanupTestAudio(t *testing.T, path string) {
-	t.Helper()
+func cleanupTestAudio(tb testing.TB, path string) {
+	tb.Helper()
 	if path == "" {
 		return
 	}
 
 	// Remove the input file
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		t.Logf("warning: failed to remove test file %s: %v", path, err)
+		tb.Logf("warning: failed to remove test file %s: %v", path, err)
 	}
 
 	// Remove any processed output files (both old -processed and new -LUFS-NN-processed patterns)

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -29,6 +29,7 @@ type AnalysisModel struct {
 	spinnerIndex int
 
 	// Results (populated when complete)
+	Result       *processor.AnalysisResult
 	Measurements *processor.AudioMeasurements
 	Config       *processor.FilterChainConfig
 	Error        error
@@ -53,6 +54,7 @@ type AnalysisProgressMsg struct {
 
 // AnalysisCompleteMsg signals analysis has completed
 type AnalysisCompleteMsg struct {
+	Result       *processor.AnalysisResult
 	Measurements *processor.AudioMeasurements
 	Config       *processor.FilterChainConfig
 	Error        error
@@ -113,8 +115,14 @@ func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case AnalysisCompleteMsg:
-		m.Measurements = msg.Measurements
-		m.Config = msg.Config
+		m.Result = msg.Result
+		if msg.Result != nil {
+			m.Measurements = msg.Result.Measurements
+			m.Config = msg.Result.Config
+		} else {
+			m.Measurements = msg.Measurements
+			m.Config = msg.Config
+		}
 		m.Error = msg.Error
 		m.Done = true
 		return m, tea.Quit

--- a/justfile
+++ b/justfile
@@ -103,7 +103,9 @@ test: _check-submodule
 bench: _check-submodule
     go test -run '^$' -bench . -benchmem ./internal/processor
 
-# Run focused Pass 2 and Pass 4 filter-ablation benchmarks
+# Run focused Pass 2 and Pass 4 filter-ablation benchmarks.
+# Use the short local fixture for iteration:
+# JIVETALKING_BENCH_FIXTURE=testdata/fixture-5m.flac just bench-fullbench
 bench-fullbench: _check-submodule
     #!/usr/bin/env bash
     set -e
@@ -119,7 +121,9 @@ bench-profile: _check-submodule
     echo "Run CPU profile analysis with:"
     echo "  go tool pprof .bench/cpu.out"
 
-# Run focused Pass 2 and Pass 4 filter-ablation benchmarks with a CPU profile
+# Run focused Pass 2 and Pass 4 filter-ablation benchmarks with a CPU profile.
+# Use the short local fixture for iteration:
+# JIVETALKING_BENCH_FIXTURE=testdata/fixture-5m.flac just bench-fullbench-profile
 bench-fullbench-profile: _check-submodule
     #!/usr/bin/env bash
     set -e
@@ -128,6 +132,67 @@ bench-fullbench-profile: _check-submodule
     go test -run '^$' -bench 'BenchmarkPass(2|4)FilterAblations' -benchmem -cpuprofile .bench/fullbench-cpu.out ./internal/processor
     echo "Run CPU profile analysis with:"
     echo "  go tool pprof .bench/fullbench-cpu.out"
+
+# Capture baseline focused benchmark output with the 5-minute local fixture
+capture-baseline-bench: _check-submodule
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    fixture="testdata/fixture-5m.flac"
+    baseline="testdata/baseline-fullbench.txt"
+    profile_baseline="testdata/baseline-fullbench-profile.txt"
+    profile_out="testdata/baseline-fullbench-profile-cpu.out"
+    profile_bin="testdata/baseline-fullbench-profile-processor.test"
+
+    export GOCACHE="${GOCACHE:-/tmp/jivetalking-go-build-cache}"
+    export GOMODCACHE="${GOMODCACHE:-/tmp/jivetalking-go-mod-cache}"
+    export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/jivetalking-xdg-cache}"
+    mkdir -p "$GOCACHE" "$GOMODCACHE" "$XDG_CACHE_HOME"
+
+    if [ ! -f "$fixture" ]; then
+        echo "Missing benchmark fixture: $fixture" >&2
+        exit 1
+    fi
+    fixture_abs="$(pwd -P)/$fixture"
+
+    echo "This will delete .bench and overwrite:"
+    echo "  $baseline"
+    echo "  $profile_baseline"
+    echo "  $profile_out"
+    echo "  $profile_bin"
+    printf "Continue? [y/N] "
+    read -r answer
+    case "$answer" in
+        y|Y|yes|YES)
+            ;;
+        *)
+            echo "Aborted."
+            exit 1
+            ;;
+    esac
+
+    if [ -d .bench ]; then
+        chmod -R u+w .bench 2>/dev/null || true
+        rm -rf .bench
+    fi
+    rm -f "$baseline" "$profile_baseline" "$profile_out" "$profile_bin"
+
+    echo "Capturing fullbench baseline..."
+    JIVETALKING_BENCH_FIXTURE="$fixture_abs" just bench-fullbench 2>&1 | tee "$baseline"
+
+    echo "Capturing fullbench profile baseline..."
+    JIVETALKING_BENCH_FIXTURE="$fixture_abs" just bench-fullbench-profile 2>&1 | tee "$profile_baseline"
+
+    if [ -f .bench/fullbench-cpu.out ]; then
+        mv .bench/fullbench-cpu.out "$profile_out"
+    fi
+    if [ -f processor.test ]; then
+        mv processor.test "$profile_bin"
+    fi
+
+    echo "Baseline fullbench output: $baseline"
+    echo "Baseline fullbench profile output: $profile_baseline"
+    echo "Baseline fullbench CPU profile: $profile_out"
 
 # Benchmark a full CLI processing run against a copied input file
 bench-cli FILE: build

--- a/justfile
+++ b/justfile
@@ -103,6 +103,13 @@ test: _check-submodule
 bench: _check-submodule
     go test -run '^$' -bench . -benchmem ./internal/processor
 
+# Run focused Pass 2 and Pass 4 filter-ablation benchmarks
+bench-fullbench: _check-submodule
+    #!/usr/bin/env bash
+    set -e
+    echo "Using JIVETALKING_BENCH_FIXTURE when set; otherwise fullbench benchmarks skip"
+    go test -run '^$' -bench 'BenchmarkPass(2|4)FilterAblations' -benchmem -count=3 ./internal/processor
+
 # Run processor package benchmarks with a CPU profile
 bench-profile: _check-submodule
     #!/usr/bin/env bash
@@ -111,6 +118,16 @@ bench-profile: _check-submodule
     go test -run '^$' -bench . -benchmem -cpuprofile .bench/cpu.out ./internal/processor
     echo "Run CPU profile analysis with:"
     echo "  go tool pprof .bench/cpu.out"
+
+# Run focused Pass 2 and Pass 4 filter-ablation benchmarks with a CPU profile
+bench-fullbench-profile: _check-submodule
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p .bench
+    echo "Using JIVETALKING_BENCH_FIXTURE when set; otherwise fullbench benchmarks skip"
+    go test -run '^$' -bench 'BenchmarkPass(2|4)FilterAblations' -benchmem -cpuprofile .bench/fullbench-cpu.out ./internal/processor
+    echo "Run CPU profile analysis with:"
+    echo "  go tool pprof .bench/fullbench-cpu.out"
 
 # Benchmark a full CLI processing run against a copied input file
 bench-cli FILE: build

--- a/justfile
+++ b/justfile
@@ -99,6 +99,52 @@ clean:
 test: _check-submodule
     go test ./...
 
+# Run processor package benchmarks
+bench: _check-submodule
+    go test -run '^$' -bench . -benchmem ./internal/processor
+
+# Run processor package benchmarks with a CPU profile
+bench-profile: _check-submodule
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p .bench
+    go test -run '^$' -bench . -benchmem -cpuprofile .bench/cpu.out ./internal/processor
+    echo "Run CPU profile analysis with:"
+    echo "  go tool pprof .bench/cpu.out"
+
+# Benchmark a full CLI processing run against a copied input file
+bench-cli FILE: build
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p .bench/input
+    input_name=$(basename -- "{{FILE}}")
+    bench_input=".bench/input/$input_name"
+    cp -- "{{FILE}}" "$bench_input"
+    time_bin="/usr/bin/time"
+    if [ ! -x "$time_bin" ]; then
+        time_bin=$(type -P time)
+    fi
+    if [ -t 1 ]; then
+        "$time_bin" -v -o .bench/cli-time.txt ./jivetalking "$bench_input"
+    else
+        cmd=$(printf './jivetalking %q' "$bench_input")
+        "$time_bin" -v -o .bench/cli-time.txt script -qefc "$cmd" /dev/null > .bench/cli-output.txt
+    fi
+
+# Benchmark a CLI analysis-only run against a copied input file
+bench-analysis FILE: build
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p .bench/input
+    input_name=$(basename -- "{{FILE}}")
+    bench_input=".bench/input/$input_name"
+    cp -- "{{FILE}}" "$bench_input"
+    time_bin="/usr/bin/time"
+    if [ ! -x "$time_bin" ]; then
+        time_bin=$(type -P time)
+    fi
+    "$time_bin" -v -o .bench/analysis-time.txt ./jivetalking --analysis-only "$bench_input"
+
 # Install jivetalking to ~/.local/bin
 install: build
     @mkdir -p ~/.local/bin 2>/dev/null || true

--- a/justfile
+++ b/justfile
@@ -112,6 +112,102 @@ bench-fullbench: _check-submodule
     echo "Using JIVETALKING_BENCH_FIXTURE when set; otherwise fullbench benchmarks skip"
     go test -run '^$' -bench 'BenchmarkPass(2|4)FilterAblations' -benchmem -count=3 ./internal/processor
 
+# Run focused anlmdn variant benchmarks.
+# Use the short local fixture for iteration:
+# JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn
+# Opt in to artefact capture with:
+# JIVETALKING_ANLMDN_BENCH_CAPTURE=1 JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn
+# Capture writes .bench/anlmdn/<variant>/ with processed.flac, filter.txt, metrics.json, validation.md, and timing.txt.
+bench-anlmdn: _check-submodule
+    #!/usr/bin/env bash
+    set -e
+    echo "Using JIVETALKING_BENCH_FIXTURE when set; otherwise anlmdn benchmarks skip"
+    echo "Set JIVETALKING_ANLMDN_BENCH_CAPTURE=1 to write .bench/anlmdn artefacts"
+    go test -run '^$' -bench 'BenchmarkAnlmdnVariants' -benchmem -count=3 ./internal/processor
+
+# Run focused anlmdn benchmark profiling.
+# Defaults to the production anlmdn variant:
+# JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn-profile
+# Profile a named variant:
+# JIVETALKING_ANLMDN_PROFILE_VARIANT=anlmdn_legacy_default JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-anlmdn-profile
+bench-anlmdn-profile: _check-submodule
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p .bench/anlmdn
+    variant="${JIVETALKING_ANLMDN_PROFILE_VARIANT:-anlmdn_sr_32000_best_r}"
+    case "$variant" in
+        ""|*[!A-Za-z0-9_]*)
+            echo "Invalid JIVETALKING_ANLMDN_PROFILE_VARIANT: $variant" >&2
+            echo "Use an anlmdn benchmark variant name such as anlmdn_sr_32000_best_r or anlmdn_legacy_default." >&2
+            exit 1
+            ;;
+    esac
+    echo "Profiling BenchmarkAnlmdnVariants/$variant"
+    echo "Using JIVETALKING_BENCH_FIXTURE when set; otherwise anlmdn benchmarks skip"
+    go test -run '^$' -bench "^BenchmarkAnlmdnVariants/${variant}$" -benchmem -cpuprofile .bench/anlmdn/cpu.out ./internal/processor
+    echo "Run CPU profile analysis with:"
+    echo "  go tool pprof .bench/anlmdn/cpu.out"
+
+# Capture anlmdn benchmark artefacts with the 5-minute local fixture.
+bench-anlmdn-capture: _check-submodule
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    fixture="testdata/fixture-5m.flac"
+    root=".bench/anlmdn"
+    timing="$root/benchmark.txt"
+    environment="$root/environment.txt"
+
+    if [ ! -f "$fixture" ]; then
+        echo "Missing benchmark fixture: $fixture" >&2
+        exit 1
+    fi
+    fixture_abs="$(pwd -P)/$fixture"
+    root_abs="$(pwd -P)/$root"
+
+    if [ -d "$root" ]; then
+        echo "This will delete $root before capturing fresh anlmdn artefacts."
+        printf "Continue? [y/N] "
+        read -r answer
+        case "$answer" in
+            y|Y|yes|YES)
+                ;;
+            *)
+                echo "Aborted."
+                exit 1
+                ;;
+        esac
+        chmod -R u+w "$root" 2>/dev/null || true
+        rm -rf "$root"
+    fi
+    mkdir -p "$root"
+
+    {
+        echo "go_version: $(go version)"
+        echo "goos: $(go env GOOS)"
+        echo "goarch: $(go env GOARCH)"
+        echo "benchmark_fixture_path: $fixture_abs"
+        printf "ffmpeg_statigo_module: "
+        go list -m github.com/linuxmatters/ffmpeg-statigo 2>/dev/null || echo "unavailable"
+        case "$(go env GOOS)" in
+            linux)
+                cpu_model="$(awk -F: '/^(model name|Hardware|Processor)[[:space:]]*:/{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' /proc/cpuinfo 2>/dev/null || true)"
+                ;;
+            darwin)
+                cpu_model="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || sysctl -n hw.model 2>/dev/null || true)"
+                ;;
+            *)
+                cpu_model=""
+                ;;
+        esac
+        echo "cpu_model: ${cpu_model:-unavailable}"
+    } > "$environment"
+
+    JIVETALKING_ANLMDN_BENCH_CAPTURE=1 JIVETALKING_ANLMDN_BENCH_CAPTURE_ROOT="$root_abs" JIVETALKING_BENCH_FIXTURE="$fixture_abs" \
+        go test -run '^$' -bench 'BenchmarkAnlmdnVariants' -benchmem -count=1 ./internal/processor 2>&1 | tee "$timing"
+    echo "Anlmdn artefacts: $root"
+    echo "Benchmark timing: $timing"
+
 # Run processor package benchmarks with a CPU profile
 bench-profile: _check-submodule
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -394,9 +394,16 @@ bench-cli FILE: build
     input_name=$(basename -- "{{FILE}}")
     bench_input=".bench/input/$input_name"
     cp -- "{{FILE}}" "$bench_input"
+    # Resolve a GNU-compatible time(1). /usr/bin/time on macOS is BSD time and
+    # rejects -v/-o; fall back to gtime (brew install coreutils) when present.
     time_bin="/usr/bin/time"
-    if [ ! -x "$time_bin" ]; then
-        time_bin=$(type -P time)
+    if ! "$time_bin" -v true >/dev/null 2>&1; then
+        if command -v gtime >/dev/null 2>&1 && gtime -v true >/dev/null 2>&1; then
+            time_bin="gtime"
+        else
+            echo "GNU time required for verbose output. On macOS install via 'brew install coreutils' (provides gtime)." >&2
+            exit 1
+        fi
     fi
     if [ -t 1 ]; then
         "$time_bin" -v -o .bench/cli-time.txt ./jivetalking "$bench_input"
@@ -413,9 +420,16 @@ bench-analysis FILE: build
     input_name=$(basename -- "{{FILE}}")
     bench_input=".bench/input/$input_name"
     cp -- "{{FILE}}" "$bench_input"
+    # Resolve a GNU-compatible time(1). /usr/bin/time on macOS is BSD time and
+    # rejects -v/-o; fall back to gtime (brew install coreutils) when present.
     time_bin="/usr/bin/time"
-    if [ ! -x "$time_bin" ]; then
-        time_bin=$(type -P time)
+    if ! "$time_bin" -v true >/dev/null 2>&1; then
+        if command -v gtime >/dev/null 2>&1 && gtime -v true >/dev/null 2>&1; then
+            time_bin="gtime"
+        else
+            echo "GNU time required for verbose output. On macOS install via 'brew install coreutils' (provides gtime)." >&2
+            exit 1
+        fi
     fi
     "$time_bin" -v -o .bench/analysis-time.txt ./jivetalking --analysis-only "$bench_input"
 

--- a/justfile
+++ b/justfile
@@ -208,6 +208,102 @@ bench-anlmdn-capture: _check-submodule
     echo "Anlmdn artefacts: $root"
     echo "Benchmark timing: $timing"
 
+# Run focused Pass 4 adeclick variant benchmarks.
+# Use the short local fixture for iteration:
+# JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-adeclick
+# Opt in to artefact capture with:
+# JIVETALKING_ADECLICK_BENCH_CAPTURE=1 JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-adeclick
+# Capture writes .bench/adeclick/<variant>/ with processed.flac, filter.txt, metrics.json, validation.md, and timing.txt.
+bench-adeclick: _check-submodule
+    #!/usr/bin/env bash
+    set -e
+    echo "Using JIVETALKING_BENCH_FIXTURE when set; otherwise adeclick benchmarks skip"
+    echo "Set JIVETALKING_ADECLICK_BENCH_CAPTURE=1 to write .bench/adeclick artefacts"
+    go test -run '^$' -bench 'BenchmarkAdeclickVariants' -benchmem -count=3 ./internal/processor
+
+# Run focused adeclick benchmark profiling.
+# Defaults to the production adeclick variant:
+# JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-adeclick-profile
+# Profile a named variant:
+# JIVETALKING_ADECLICK_PROFILE_VARIANT=without_adeclick JIVETALKING_BENCH_FIXTURE="$(pwd -P)/testdata/fixture-5m.flac" just bench-adeclick-profile
+bench-adeclick-profile: _check-submodule
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p .bench/adeclick
+    variant="${JIVETALKING_ADECLICK_PROFILE_VARIANT:-adeclick_current_t_2_0_w_55_o_50_m_s}"
+    case "$variant" in
+        ""|*[!A-Za-z0-9_]*)
+            echo "Invalid JIVETALKING_ADECLICK_PROFILE_VARIANT: $variant" >&2
+            echo "Use an adeclick benchmark variant name such as adeclick_current_t_2_0_w_55_o_50_m_s or without_adeclick." >&2
+            exit 1
+            ;;
+    esac
+    echo "Profiling BenchmarkAdeclickVariants/$variant"
+    echo "Using JIVETALKING_BENCH_FIXTURE when set; otherwise adeclick benchmarks skip"
+    go test -run '^$' -bench "^BenchmarkAdeclickVariants/${variant}$" -benchmem -cpuprofile .bench/adeclick/cpu.out ./internal/processor
+    echo "Run CPU profile analysis with:"
+    echo "  go tool pprof .bench/adeclick/cpu.out"
+
+# Capture adeclick benchmark artefacts with the 5-minute local fixture.
+bench-adeclick-capture: _check-submodule
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    fixture="testdata/fixture-5m.flac"
+    root=".bench/adeclick"
+    timing="$root/benchmark.txt"
+    environment="$root/environment.txt"
+
+    if [ ! -f "$fixture" ]; then
+        echo "Missing benchmark fixture: $fixture" >&2
+        exit 1
+    fi
+    fixture_abs="$(pwd -P)/$fixture"
+    root_abs="$(pwd -P)/$root"
+
+    if [ -d "$root" ]; then
+        echo "This will delete $root before capturing fresh adeclick artefacts."
+        printf "Continue? [y/N] "
+        read -r answer
+        case "$answer" in
+            y|Y|yes|YES)
+                ;;
+            *)
+                echo "Aborted."
+                exit 1
+                ;;
+        esac
+        chmod -R u+w "$root" 2>/dev/null || true
+        rm -rf "$root"
+    fi
+    mkdir -p "$root"
+
+    {
+        echo "go_version: $(go version)"
+        echo "goos: $(go env GOOS)"
+        echo "goarch: $(go env GOARCH)"
+        echo "benchmark_fixture_path: $fixture_abs"
+        printf "ffmpeg_statigo_module: "
+        go list -m github.com/linuxmatters/ffmpeg-statigo 2>/dev/null || echo "unavailable"
+        case "$(go env GOOS)" in
+            linux)
+                cpu_model="$(awk -F: '/^(model name|Hardware|Processor)[[:space:]]*:/{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' /proc/cpuinfo 2>/dev/null || true)"
+                ;;
+            darwin)
+                cpu_model="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || sysctl -n hw.model 2>/dev/null || true)"
+                ;;
+            *)
+                cpu_model=""
+                ;;
+        esac
+        echo "cpu_model: ${cpu_model:-unavailable}"
+    } > "$environment"
+
+    JIVETALKING_ADECLICK_BENCH_CAPTURE=1 JIVETALKING_ADECLICK_BENCH_CAPTURE_ROOT="$root_abs" JIVETALKING_BENCH_FIXTURE="$fixture_abs" \
+        go test -run '^$' -bench 'BenchmarkAdeclickVariants' -benchmem -count=1 ./internal/processor 2>&1 | tee "$timing"
+    echo "Adeclick artefacts: $root"
+    echo "Benchmark timing: $timing"
+
 # Run processor package benchmarks with a CPU profile
 bench-profile: _check-submodule
     #!/usr/bin/env bash

--- a/testdata/justfile
+++ b/testdata/justfile
@@ -1,5 +1,7 @@
 # Jivetalking - Presenter Integration Tests
 # This file contains commands for testing with local audio files (not in git)
+# Use fixture-5m.flac for iterative fullbench runs from the repo root:
+# JIVETALKING_BENCH_FIXTURE=testdata/fixture-5m.flac just bench-fullbench
 # Path to testdata directory (source_directory returns the directory of THIS file)
 
 testdata := source_directory()

--- a/testdata/justfile
+++ b/testdata/justfile
@@ -19,7 +19,7 @@ mark-log-stash:
 # Process mark audio
 mark:
     @rm -f {{ testdata }}/LMP-{{ episode }}-mark-*-processed.*
-    @./jivetalking --debug --logs --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-mark.flac
+    @./jivetalking --debug --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-mark.flac
     @just mark-logs
 
 # Get Martin's processed logs
@@ -33,7 +33,7 @@ martin-log-stash:
 # Process martin audio
 martin:
     @rm -f {{ testdata }}/LMP-{{ episode }}-martin-*-processed.*
-    @./jivetalking --debug --logs --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-martin.flac
+    @./jivetalking --debug --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-martin.flac
     @just martin-logs
 
 # Get popey's processed logs
@@ -47,7 +47,7 @@ popey-log-stash:
 # Process popey audio
 popey:
     @rm -f {{ testdata }}/LMP-{{ episode }}-popey-*-processed.*
-    @./jivetalking --debug --logs --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-popey.flac
+    @./jivetalking --debug --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-popey.flac
     @just popey-logs
 
 # Analyse Mark's audio
@@ -76,7 +76,7 @@ all-episodes:
         for presenter in mark martin popey; do
             echo "--- $presenter ---"
             rm -f {{ testdata }}/LMP-${ep}-${presenter}-*-processed.*
-            ./jivetalking --debug --logs {{ testdata }}/LMP-${ep}-${presenter}.flac
+            ./jivetalking --debug {{ testdata }}/LMP-${ep}-${presenter}.flac
         done
     done
 


### PR DESCRIPTION
## Summary
Establishes a benchmark and profiling foundation across the processor and CLI, makes per-file processing reports always-on, and ships tuned production defaults for `anlmdn` (32 kHz pre-resample, `r=0.0045`) and `adeclick` (threshold 2.0, overlap 50, spline method) that cut Pass 4 runtime by ~75% at metric-parity quality. Adds analysis-only timing output and sanitises non-TTY output for benchmark fixture paths.

## Changes
- Add full processor benchmark scaffolding: full-processing, analysis, region-measurement, filter-ablation (Pass 2/4), `anlmdn`, and `adeclick` variant suites
- Add justfile recipes: `bench`, `bench-anlmdn`, `bench-adeclick`, `bench-fullbench`, profile variants, and `capture-baseline-bench` with interactive overwrite confirmation
- Adopt `anlmdn_sr_32000_best_r` as production default; thread optional pre-`anlmdn` resample through the noise-reduce filter
- Tune `adeclick` defaults to `t=2.0:w=55:o=50:m=s`; add `AdeclickMethod` field threaded through Pass 2 and loudnorm-stage builders
- Make processing reports always-on: remove `--logs` CLI flag, emit styled warnings on report write failure, add sample-rate and channel metadata to report header
- Add reportable pass timings (analysis, adaptation, filter, normalisation, measurement) on both `ProcessAudio` and `AnalyzeOnly` paths
- Display elapsed analysis and adaptation durations in analysis-only console report
- Sanitise non-TTY analysis output to print only base file names (no `.bench/` path leakage); extract `runAnalysisOnlyWithDeps` for testability
- Add `docs/Benchmarks.md` documenting variant matrices and profiling workflow; add `CPU-OVERVIEW.md` planning document
- Update README to remove `--logs`, document default `.log` generation, and describe benchmark commands

## Testing
- `just test` passes (new tests cover timing fields, report metadata, audio metric tables, non-TTY path sanitisation, ablation filter ordering)
- `just lint` passes
- Benchmark suites exercised via `just bench-anlmdn`, `just bench-adeclick`, and `just bench-fullbench` against `JIVETALKING_BENCH_FIXTURE`

## Breaking Changes
- Removed `--logs` CLI flag; per-file `.log` reports are now always generated

## Related Issues
None