### PR TITLE
feat(reports): prioritise elected candidates

### DIFF
--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -70,82 +70,32 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 
 	if len(measurements.SilenceCandidates) > 0 { //nolint:gocritic // ifElseChain: complex display logic unsuitable for switch
 		fmt.Fprintf(w, "  Candidates:     %d evaluated\n", len(measurements.SilenceCandidates))
-
-		// Find the elected candidate index
-		electedIdx := -1
-		electedWasRefined := false
-		var electedRefinedStart time.Duration
-		var electedRefinedDuration time.Duration
-		if measurements.NoiseProfile != nil {
-			for i, c := range measurements.SilenceCandidates {
-				if measurements.NoiseProfile.WasRefined {
-					if c.Region.Start == measurements.NoiseProfile.OriginalStart {
-						electedIdx = i
-						electedWasRefined = true
-						electedRefinedStart = measurements.NoiseProfile.Start
-						electedRefinedDuration = measurements.NoiseProfile.Duration
-						break
-					}
-				} else {
-					if c.Region.Start == measurements.NoiseProfile.Start {
-						electedIdx = i
-						break
-					}
-				}
-			}
+		electedCandidate, displayCandidates := rankedSilenceCandidateEntries(measurements)
+		if summary := candidateDisplaySummary(len(measurements.SilenceCandidates), electedCandidate != nil, len(displayCandidates)); summary != "" {
+			fmt.Fprintf(w, "  Displayed:      %s\n", summary)
 		}
 
-		if electedIdx >= 0 {
-			if measurements.VoiceActivated {
-				fmt.Fprintln(w, "  Voice-activated recording detected")
-			}
-			// Print elected candidate first with distinct header
-			c := measurements.SilenceCandidates[electedIdx]
-			fmt.Fprintf(w, "  ELECTED CANDIDATE\n")
-			fmt.Fprintf(w, "  #%d: %.1fs at %s\n",
-				electedIdx+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
-			if electedWasRefined {
-				fmt.Fprintf(w, "      Refined:     %.1fs at %s (golden sub-region)\n",
-					electedRefinedDuration.Seconds(), formatTimestamp(electedRefinedStart))
-			}
-			writeSilenceCandidateMetrics(w, c)
+		if measurements.VoiceActivated {
+			fmt.Fprintln(w, "  Voice-activated recording detected")
+		}
+		if electedCandidate != nil || len(displayCandidates) > 0 {
 			fmt.Fprintln(w)
-
-			// Print remaining candidates (skip zero-scored rejected candidates)
-			visibleCount := 0
-			for i, c := range measurements.SilenceCandidates {
-				if i == electedIdx || c.Score == 0.0 {
-					continue
-				}
-				visibleCount++
-			}
-			if visibleCount > 0 {
-				fmt.Fprintf(w, "  OTHER CANDIDATES\n")
-				for i, c := range measurements.SilenceCandidates {
-					if i == electedIdx {
-						continue
-					}
-					if c.Score == 0.0 {
-						continue
-					}
-					fmt.Fprintf(w, "  #%d: %.1fs at %s\n",
-						i+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
-					writeSilenceCandidateMetrics(w, c)
-					fmt.Fprintln(w)
-				}
-			}
-		} else {
-			// No elected candidate - print all in discovery order
-			if measurements.VoiceActivated {
-				fmt.Fprintln(w, "  Voice-activated recording detected")
-			}
-			for i, c := range measurements.SilenceCandidates {
-				if c.Score == 0.0 {
-					continue
-				}
-				fmt.Fprintf(w, "  #%d: %.1fs at %s\n",
+			if electedCandidate != nil {
+				i := electedCandidate.index
+				c := electedCandidate.candidate
+				fmt.Fprintf(w, "  #%d: %.1fs at %s (elected)\n",
 					i+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
+				if measurements.NoiseProfile.WasRefined {
+					fmt.Fprintf(w, "      Refined:     %.1fs at %s (golden sub-region)\n",
+						measurements.NoiseProfile.Duration.Seconds(), formatTimestamp(measurements.NoiseProfile.Start))
+				}
 				writeSilenceCandidateMetrics(w, c)
+				fmt.Fprintln(w)
+			}
+			for _, entry := range displayCandidates {
+				i := entry.index
+				c := entry.candidate
+				writeCompactAnalysisSilenceCandidateRow(w, i, c)
 				fmt.Fprintln(w)
 			}
 		}
@@ -168,50 +118,26 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 	writeAnalysisSection(w, "SPEECH DETECTION")
 	if len(measurements.SpeechCandidates) > 0 { //nolint:gocritic // ifElseChain: complex display logic unsuitable for switch
 		fmt.Fprintf(w, "  Candidates:     %d evaluated\n", len(measurements.SpeechCandidates))
+		electedCandidate, displayCandidates := rankedSpeechCandidateEntries(measurements)
+		if summary := candidateDisplaySummary(len(measurements.SpeechCandidates), electedCandidate != nil, len(displayCandidates)); summary != "" {
+			fmt.Fprintf(w, "  Displayed:      %s\n", summary)
+		}
 		fmt.Fprintln(w)
 
-		for i, c := range measurements.SpeechCandidates {
-			// Check if this candidate was elected
-			// Note: When a candidate is refined to a golden sub-region, the candidate
-			// in the list is replaced with refined metrics. The refined candidate has:
-			// - Region.Start = refined start
-			// - WasRefined = true
-			// - OriginalStart = original candidate start
-			// - OriginalDuration = original candidate duration
-			isElected := false
-			wasRefined := c.WasRefined
+		if electedCandidate != nil {
+			i := electedCandidate.index
+			c := electedCandidate.candidate
+			fmt.Fprintf(w, "  #%d: %.1fs at %s (elected)\n",
+				i+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
 
-			if measurements.SpeechProfile != nil {
-				// If this candidate was refined, compare against SpeechProfile.Region.Start
-				// (both will have the refined start after replacement)
-				// If not refined, compare Region.Start directly
-				isElected = c.Region.Start == measurements.SpeechProfile.Region.Start
+			if c.WasRefined {
+				fmt.Fprintf(w, "      Refined:     %.1fs at %s -> %.1fs at %s (golden sub-region)\n",
+					c.OriginalDuration.Seconds(),
+					formatTimestamp(c.OriginalStart),
+					c.Region.Duration.Seconds(),
+					formatTimestamp(c.Region.Start))
 			}
 
-			electedMark := ""
-			if isElected {
-				electedMark = " [ELECTED]"
-			}
-
-			// For refined candidates, display the original duration/start, then show refined info
-			displayStart := c.Region.Start
-			displayDuration := c.Region.Duration
-			if wasRefined {
-				displayStart = c.OriginalStart
-				displayDuration = c.OriginalDuration
-			}
-
-			fmt.Fprintf(w, "  #%d: %.1fs at %s%s\n",
-				i+1, displayDuration.Seconds(), formatTimestamp(displayStart), electedMark)
-
-			// Show refinement details only for elected candidate
-			if isElected && wasRefined {
-				// Show refined region info (c.Region now contains the refined values)
-				fmt.Fprintf(w, "      Refined:     %.1fs at %s (golden sub-region)\n",
-					c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
-			}
-
-			// Show full metrics for all candidates
 			fmt.Fprintf(w, "      Score:       %.2f\n", c.Score)
 			fmt.Fprintf(w, "      RMS Level:   %.1f dBFS\n", c.RMSLevel)
 			fmt.Fprintf(w, "      Crest:       %.1f dB\n", c.CrestFactor)
@@ -222,6 +148,13 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 			}
 			fmt.Fprintln(w)
 		}
+		for _, entry := range displayCandidates {
+			i := entry.index
+			c := entry.candidate
+			writeCompactAnalysisSpeechCandidateRow(w, i, c)
+			fmt.Fprintln(w)
+		}
+		writeSpeechRejectionSummary(w, measurements.SpeechCandidates)
 	} else if measurements.SpeechProfile != nil {
 		fmt.Fprintf(w, "  Sample:         %.1fs at %s\n",
 			measurements.SpeechProfile.Region.Duration.Seconds(),
@@ -345,37 +278,32 @@ func writeSilenceCandidateMetrics(w io.Writer, c processor.SilenceCandidateMetri
 	fmt.Fprintf(w, "      Centroid:    %.0f Hz\n", c.Spectral.Centroid)
 }
 
+func writeCompactAnalysisSilenceCandidateRow(w io.Writer, index int, c processor.SilenceCandidateMetrics) {
+	fmt.Fprintf(w, "  #%d: %.1fs at %s (score: %.3f)\n",
+		index+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start), c.Score)
+	fmt.Fprintf(w, "      RMS: %.1f dBFS, Crest: %.1f dB, Entropy: %.3f (%s)\n",
+		c.RMSLevel, c.CrestFactor, c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))
+}
+
+func writeCompactAnalysisSpeechCandidateRow(w io.Writer, index int, c processor.SpeechCandidateMetrics) {
+	fmt.Fprintf(w, "  #%d: %.1fs at %s (score: %.2f)\n",
+		index+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start), c.Score)
+	fmt.Fprintf(w, "      RMS: %.1f dBFS, Crest: %.1f dB, Centroid: %.0f Hz (%s)\n",
+		c.RMSLevel, c.CrestFactor, c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
+}
+
 // writeSilenceRejectionSummary outputs a compact summary of rejected silence candidates.
 // Groups zero-scored candidates by rejection reason extracted from TransientWarning.
 func writeSilenceRejectionSummary(w io.Writer, candidates []processor.SilenceCandidateMetrics) {
-	reasonCounts := make(map[string]int)
-	for _, c := range candidates {
-		if c.Score != 0.0 {
-			continue
-		}
-		reason := classifyRejectionReason(c.TransientWarning)
-		reasonCounts[reason]++
-	}
+	writeAnalysisCandidateRejectionSummary(w, silenceRejectionSummary(candidates))
+}
 
-	if len(reasonCounts) == 0 {
-		return
-	}
+func writeSpeechRejectionSummary(w io.Writer, candidates []processor.SpeechCandidateMetrics) {
+	writeAnalysisCandidateRejectionSummary(w, speechRejectionSummary(candidates))
+}
 
-	// Build summary parts in a stable order
-	order := []string{"digital silence", "crosstalk", "transient contamination", "too loud"}
-	var parts []string
-	for _, reason := range order {
-		if count, ok := reasonCounts[reason]; ok {
-			parts = append(parts, fmt.Sprintf("%d %s", count, reason))
-			delete(reasonCounts, reason)
-		}
-	}
-	// Any unexpected reasons
-	for reason, count := range reasonCounts {
-		parts = append(parts, fmt.Sprintf("%d %s", count, reason))
-	}
-
-	fmt.Fprintf(w, "  Rejected:       %s\n", strings.Join(parts, ", "))
+func writeAnalysisCandidateRejectionSummary(w io.Writer, summary string) {
+	fmt.Fprintf(w, "  Rejected:       %s\n", summary)
 }
 
 // classifyRejectionReason maps a TransientWarning string to a short label.

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -221,6 +221,164 @@ func TestDisplayAnalysisResults_ExcludesProcessingOnlyFields(t *testing.T) {
 	}
 }
 
+func TestDisplayAnalysisResults_CapsSilenceCandidatesChronologicallyWithElectedFirst(t *testing.T) {
+	m := makeMinimalMeasurements()
+	m.SilenceCandidates = makeRankedSilenceCandidates(12)
+	m.NoiseProfile = &processor.NoiseProfile{
+		Start:              m.SilenceCandidates[0].Region.Start,
+		Duration:           m.SilenceCandidates[0].Region.Duration,
+		MeasuredNoiseFloor: m.SilenceCandidates[0].RMSLevel,
+	}
+
+	config := processor.DefaultFilterConfig()
+	var buf bytes.Buffer
+	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
+	output := buf.String()
+
+	for _, want := range []string{
+		"  Candidates:     12 evaluated",
+		"  Displayed:      elected + top 10 chronological (1 omitted)",
+		"  #1: 5.0s at 1.0s (elected)",
+		"  #2: 5.0s at 2.0s (score: 0.020)",
+		"      RMS: -59.8 dBFS, Crest: 12.0 dB, Entropy: 0.420 (mixed voiced/unvoiced)",
+		"  Rejected:       0",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("analysis output missing %q", want)
+		}
+	}
+
+	for _, detailedLine := range []string{
+		"      Score:       ",
+		"      RMS Level:   ",
+		"      Peak Level:  ",
+		"      Flatness:    ",
+		"      Kurtosis:    ",
+	} {
+		if count := strings.Count(output, detailedLine); count != 1 {
+			t.Fatalf("analysis silence detail line %q count = %d, want 1", strings.TrimSpace(detailedLine), count)
+		}
+	}
+
+	if count := strings.Count(output, "  #"); count != 11 {
+		t.Fatalf("displayed analysis silence candidates = %d, want 11", count)
+	}
+	assertAppearsBefore(t, output, "#1:", "#2:")
+	assertAppearsBefore(t, output, "#2:", "#3:")
+	assertAppearsBefore(t, output, "#10:", "#11:")
+	if strings.Contains(output, "#12:") {
+		t.Fatal("expected silence candidate 12 to be omitted")
+	}
+	if strings.Contains(output, "[SELECTED]") {
+		t.Fatal("expected silence output to use elected terminology")
+	}
+	assertCandidateSummaryTerminology(t, output, "  Displayed:      elected + top 10 chronological (1 omitted)")
+}
+
+func TestDisplayAnalysisResults_CapsSpeechCandidatesChronologicallyWithElectedFirst(t *testing.T) {
+	m := makeMinimalMeasurements()
+	m.SpeechCandidates = makeRankedSpeechCandidates(12)
+	m.SpeechCandidates[0].VoicingDensity = 0.82
+	m.SpeechProfile = &m.SpeechCandidates[0]
+
+	config := processor.DefaultFilterConfig()
+	var buf bytes.Buffer
+	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
+	output := buf.String()
+
+	for _, want := range []string{
+		"  Candidates:     12 evaluated",
+		"  Displayed:      elected + top 10 chronological (1 omitted)",
+		"  #1: 60.0s at 1.0s (elected)",
+		"      Voicing:     82%",
+		"  #2: 60.0s at 2.0s (score: 0.02)",
+		"      RMS: -29.8 dBFS, Crest: 10.0 dB, Centroid: 2400 Hz (forward, clear)",
+		"  Rejected:       0",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("analysis output missing %q", want)
+		}
+	}
+
+	for _, detailedLine := range []string{
+		"      Score:       ",
+		"      RMS Level:   ",
+		"      Kurtosis:    ",
+		"      Voicing:     ",
+	} {
+		if count := strings.Count(output, detailedLine); count != 1 {
+			t.Fatalf("analysis speech detail line %q count = %d, want 1", strings.TrimSpace(detailedLine), count)
+		}
+	}
+
+	if count := strings.Count(output, "  #"); count != 11 {
+		t.Fatalf("displayed analysis speech candidates = %d, want 11", count)
+	}
+	assertAppearsBefore(t, output, "#1:", "#2:")
+	assertAppearsBefore(t, output, "#2:", "#3:")
+	assertAppearsBefore(t, output, "#10:", "#11:")
+	if strings.Contains(output, "#12:") {
+		t.Fatal("expected speech candidate 12 to be omitted")
+	}
+	if strings.Contains(output, "[SELECTED]") {
+		t.Fatal("expected speech output to use elected terminology")
+	}
+	assertCandidateSummaryTerminology(t, output, "  Displayed:      elected + top 10 chronological (1 omitted)")
+}
+
+func TestDisplayAnalysisResults_SpeechRejectionSummaryIncludesZeroScore(t *testing.T) {
+	m := makeMinimalMeasurements()
+	m.SpeechCandidates = makeRankedSpeechCandidates(3)
+	m.SpeechCandidates[1].Score = 0.0
+	m.SpeechProfile = &m.SpeechCandidates[0]
+
+	config := processor.DefaultFilterConfig()
+	var buf bytes.Buffer
+	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
+	output := buf.String()
+
+	for _, want := range []string{
+		"  Candidates:     3 evaluated",
+		"  Displayed:      elected + 1 chronological (1 omitted)",
+		"  #1: 60.0s at 1.0s (elected)",
+		"  #3: 60.0s at 3.0s (score: 0.03)",
+		"      RMS: -29.7 dBFS, Crest: 10.0 dB, Centroid: 2400 Hz (forward, clear)",
+		"  Rejected:       1 zero score",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("analysis speech output missing %q", want)
+		}
+	}
+
+	if strings.Contains(output, "#2:") {
+		t.Fatal("expected zero-score speech candidate to be omitted from displayed candidates")
+	}
+	assertCandidateSummaryTerminology(t, output, "  Displayed:      elected + 1 chronological (1 omitted)")
+}
+
+func TestDisplayAnalysisResults_SpeechDisplaySummaryIncludesZeroOmitted(t *testing.T) {
+	m := makeMinimalMeasurements()
+	m.SpeechCandidates = makeRankedSpeechCandidates(4)
+	m.SpeechProfile = &m.SpeechCandidates[0]
+
+	config := processor.DefaultFilterConfig()
+	var buf bytes.Buffer
+	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
+	output := buf.String()
+
+	for _, want := range []string{
+		"  Candidates:     4 evaluated",
+		"  Displayed:      elected + 3 chronological (0 omitted)",
+		"  #1: 60.0s at 1.0s (elected)",
+		"  #4: 60.0s at 4.0s (score: 0.04)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("analysis speech output missing %q", want)
+		}
+	}
+	assertCandidateSummaryTerminology(t, output, "  Displayed:      elected + 3 chronological (0 omitted)")
+}
+
 func TestWriteDiagnosticSilence_VoiceActivated_WithCandidates(t *testing.T) {
 	m := makeMinimalMeasurements()
 	m.VoiceActivated = true

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -4,6 +4,7 @@ package logging
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -13,6 +14,18 @@ import (
 
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
+
+const candidateDisplayLimit = 10
+
+type silenceCandidateDisplayEntry struct {
+	index     int
+	candidate processor.SilenceCandidateMetrics
+}
+
+type speechCandidateDisplayEntry struct {
+	index     int
+	candidate processor.SpeechCandidateMetrics
+}
 
 // ============================================================================
 // Spectral Characteristic Interpretation Functions
@@ -1646,61 +1659,21 @@ func writeDiagnosticSilence(f *os.File, measurements *processor.AudioMeasurement
 		}
 	}
 
-	// Silence candidates (all evaluated candidates with scores)
+	// Silence candidates (ranked display of evaluated candidates with scores)
 	//nolint:gocritic // ifElseChain: complex display branches with different condition types
 	if len(measurements.SilenceCandidates) > 0 {
 		fmt.Fprintf(f, "Silence Candidates:  %d evaluated\n", len(measurements.SilenceCandidates))
 		if measurements.VoiceActivated {
 			fmt.Fprintf(f, "Voice-Activated:     yes (digital silence fraction >= 95%%)\n")
 		}
-		for i, c := range measurements.SilenceCandidates {
-			// Check if this candidate was selected (may have been refined, so check original start if refined)
-			isSelected := false
-			if measurements.NoiseProfile != nil {
-				if measurements.NoiseProfile.WasRefined {
-					// Compare against original candidate bounds before refinement
-					isSelected = c.Region.Start == measurements.NoiseProfile.OriginalStart
-				} else {
-					isSelected = c.Region.Start == measurements.NoiseProfile.Start
-				}
-			}
-
-			if isSelected {
-				fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f) [SELECTED]\n",
-					i+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score)
-
-				// Show refinement details if this candidate was refined to a golden sub-region
-				if measurements.NoiseProfile.WasRefined {
-					fmt.Fprintf(f, "    Refined:         %.1fs at %.1fs (golden sub-region)\n",
-						measurements.NoiseProfile.Duration.Seconds(),
-						measurements.NoiseProfile.Start.Seconds())
-				}
-
-				fmt.Fprintf(f, "    Amplitude:\n")
-				fmt.Fprintf(f, "      RMS Level:     %.1f dBFS\n", c.RMSLevel)
-				fmt.Fprintf(f, "      Peak Level:    %.1f dBFS\n", c.PeakLevel)
-				fmt.Fprintf(f, "      Crest Factor:  %.1f dB\n", c.CrestFactor)
-				fmt.Fprintf(f, "    Spectral:\n")
-				fmt.Fprintf(f, "      Centroid:      %.0f Hz (%s)\n", c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
-				fmt.Fprintf(f, "      Spread:        %.0f Hz\n", c.Spectral.Spread)
-				fmt.Fprintf(f, "      Rolloff:       %.0f Hz\n", c.Spectral.Rolloff)
-				fmt.Fprintf(f, "      Flatness:      %.3f (%s)\n", c.Spectral.Flatness, interpretFlatness(c.Spectral.Flatness))
-				fmt.Fprintf(f, "      Entropy:       %.3f (%s)\n", c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))
-				fmt.Fprintf(f, "      Kurtosis:      %.1f (%s)\n", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))
-				fmt.Fprintf(f, "      Skewness:      %.2f\n", c.Spectral.Skewness)
-				fmt.Fprintf(f, "      Flux:          %.4f\n", c.Spectral.Flux)
-				fmt.Fprintf(f, "      Slope:         %.2e\n", c.Spectral.Slope)
-				fmt.Fprintf(f, "    Loudness:\n")
-				fmt.Fprintf(f, "      Momentary:     %.1f LUFS\n", c.MomentaryLUFS)
-				fmt.Fprintf(f, "      Short-term:    %.1f LUFS\n", c.ShortTermLUFS)
-				fmt.Fprintf(f, "      True Peak:     %.1f dBTP\n", c.TruePeak)
-			} else {
-				if c.Score == 0.0 {
-					continue
-				}
-				fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f, RMS %.1f dBFS)\n",
-					i+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score, c.RMSLevel)
-			}
+		electedCandidate, displayCandidates := rankedSilenceCandidateEntries(measurements)
+		writeCandidateDisplaySummary(f, len(measurements.SilenceCandidates), electedCandidate != nil, len(displayCandidates))
+		if electedCandidate != nil {
+			entry := *electedCandidate
+			writeReportSilenceCandidateMetrics(f, entry.index, entry.candidate, true)
+		}
+		for _, entry := range displayCandidates {
+			writeReportSilenceCandidateMetrics(f, entry.index, entry.candidate, false)
 		}
 
 		// Rejection summary for zero-scored candidates
@@ -1727,34 +1700,105 @@ func writeDiagnosticSilence(f *os.File, measurements *processor.AudioMeasurement
 	fmt.Fprintln(f, "")
 }
 
-// writeReportRejectionSummary outputs a compact summary of rejected silence candidates to the report file.
-func writeReportRejectionSummary(f *os.File, candidates []processor.SilenceCandidateMetrics) {
-	reasonCounts := make(map[string]int)
-	for _, c := range candidates {
-		if c.Score != 0.0 {
-			continue
-		}
-		reason := classifyRejectionReason(c.TransientWarning)
-		reasonCounts[reason]++
-	}
-
-	if len(reasonCounts) == 0 {
+func writeReportSilenceCandidateMetrics(f io.Writer, index int, c processor.SilenceCandidateMetrics, elected bool) {
+	if !elected {
+		writeReportCompactSilenceCandidateRow(f, index, c)
 		return
 	}
 
-	order := []string{"digital silence", "crosstalk", "transient contamination", "too loud"}
-	var parts []string
-	for _, reason := range order {
-		if count, ok := reasonCounts[reason]; ok {
-			parts = append(parts, fmt.Sprintf("%d %s", count, reason))
-			delete(reasonCounts, reason)
-		}
+	electedLabel := ""
+	if elected {
+		electedLabel = ", elected"
 	}
-	for reason, count := range reasonCounts {
-		parts = append(parts, fmt.Sprintf("%d %s", count, reason))
+	fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f%s)\n",
+		index+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score, electedLabel)
+
+	if c.WasRefined {
+		fmt.Fprintf(f, "    Refined:         %.1fs at %.1fs -> %.1fs at %.1fs (golden sub-region)\n",
+			c.OriginalDuration.Seconds(),
+			c.OriginalStart.Seconds(),
+			c.Region.Duration.Seconds(),
+			c.Region.Start.Seconds())
 	}
 
-	fmt.Fprintf(f, "Rejected:            %s\n", strings.Join(parts, ", "))
+	fmt.Fprintf(f, "    Amplitude:\n")
+	fmt.Fprintf(f, "      RMS Level:     %.1f dBFS\n", c.RMSLevel)
+	fmt.Fprintf(f, "      Peak Level:    %.1f dBFS\n", c.PeakLevel)
+	fmt.Fprintf(f, "      Crest Factor:  %.1f dB\n", c.CrestFactor)
+	fmt.Fprintf(f, "    Spectral:\n")
+	fmt.Fprintf(f, "      Centroid:      %.0f Hz (%s)\n", c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
+	fmt.Fprintf(f, "      Spread:        %.0f Hz\n", c.Spectral.Spread)
+	fmt.Fprintf(f, "      Rolloff:       %.0f Hz\n", c.Spectral.Rolloff)
+	fmt.Fprintf(f, "      Flatness:      %.3f (%s)\n", c.Spectral.Flatness, interpretFlatness(c.Spectral.Flatness))
+	fmt.Fprintf(f, "      Entropy:       %.3f (%s)\n", c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))
+	fmt.Fprintf(f, "      Kurtosis:      %.1f (%s)\n", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))
+	fmt.Fprintf(f, "      Skewness:      %.2f\n", c.Spectral.Skewness)
+	fmt.Fprintf(f, "      Flux:          %.4f\n", c.Spectral.Flux)
+	fmt.Fprintf(f, "      Slope:         %.2e\n", c.Spectral.Slope)
+	fmt.Fprintf(f, "    Loudness:\n")
+	fmt.Fprintf(f, "      Momentary:     %.1f LUFS\n", c.MomentaryLUFS)
+	fmt.Fprintf(f, "      Short-term:    %.1f LUFS\n", c.ShortTermLUFS)
+	fmt.Fprintf(f, "      True Peak:     %.1f dBTP\n", c.TruePeak)
+}
+
+func writeReportCompactSilenceCandidateRow(f io.Writer, index int, c processor.SilenceCandidateMetrics) {
+	fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f)\n",
+		index+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score)
+	fmt.Fprintf(f, "    RMS: %.1f dBFS, Crest: %.1f dB, Entropy: %.3f (%s)\n",
+		c.RMSLevel, c.CrestFactor, c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))
+}
+
+// writeReportRejectionSummary outputs a compact summary of rejected silence candidates to the report file.
+func writeReportRejectionSummary(f *os.File, candidates []processor.SilenceCandidateMetrics) {
+	writeReportCandidateRejectionSummary(f, silenceRejectionSummary(candidates))
+}
+
+func rankedSilenceCandidateEntries(measurements *processor.AudioMeasurements) (*silenceCandidateDisplayEntry, []silenceCandidateDisplayEntry) {
+	if measurements == nil || len(measurements.SilenceCandidates) == 0 {
+		return nil, nil
+	}
+
+	entries := make([]silenceCandidateDisplayEntry, 0, len(measurements.SilenceCandidates))
+	var elected *silenceCandidateDisplayEntry
+	for i, c := range measurements.SilenceCandidates {
+		entry := silenceCandidateDisplayEntry{index: i, candidate: c}
+		if isSelectedSilenceCandidate(c, measurements) {
+			electedEntry := entry
+			elected = &electedEntry
+			continue
+		}
+		if c.Score == 0.0 {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].candidate.Region.Start == entries[j].candidate.Region.Start {
+			return entries[i].index < entries[j].index
+		}
+		return entries[i].candidate.Region.Start < entries[j].candidate.Region.Start
+	})
+
+	return elected, selectSilenceCandidateEntries(entries)
+}
+
+func selectSilenceCandidateEntries(entries []silenceCandidateDisplayEntry) []silenceCandidateDisplayEntry {
+	displayCount := min(candidateDisplayLimit, len(entries))
+
+	displayed := make([]silenceCandidateDisplayEntry, displayCount)
+	copy(displayed, entries[:displayCount])
+	return displayed
+}
+
+func isSelectedSilenceCandidate(c processor.SilenceCandidateMetrics, measurements *processor.AudioMeasurements) bool {
+	if measurements == nil || measurements.NoiseProfile == nil {
+		return false
+	}
+	if measurements.NoiseProfile.WasRefined {
+		return c.Region.Start == measurements.NoiseProfile.OriginalStart
+	}
+	return c.Region.Start == measurements.NoiseProfile.Start
 }
 
 // writeDiagnosticSpeech outputs detailed speech detection diagnostics.
@@ -1774,58 +1818,17 @@ func writeDiagnosticSpeech(f *os.File, measurements *processor.AudioMeasurements
 	//nolint:gocritic // ifElseChain: complex display branches with different condition types
 	if len(measurements.SpeechCandidates) > 0 {
 		fmt.Fprintf(f, "Speech Candidates:   %d evaluated\n", len(measurements.SpeechCandidates))
+		electedCandidate, displayCandidates := rankedSpeechCandidateEntries(measurements)
+		writeCandidateDisplaySummary(f, len(measurements.SpeechCandidates), electedCandidate != nil, len(displayCandidates))
 
-		for i, c := range measurements.SpeechCandidates {
-			// Check if this candidate was selected
-			// For refined regions, compare against original start since Region.Start is the refined position
-			isSelected := false
-			if measurements.SpeechProfile != nil {
-				if c.WasRefined {
-					isSelected = c.OriginalStart == measurements.SpeechProfile.OriginalStart
-				} else {
-					isSelected = c.Region.Start == measurements.SpeechProfile.Region.Start
-				}
-			}
-
-			if isSelected {
-				fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f) [SELECTED]\n",
-					i+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score)
-
-				// Show refinement details if this candidate was refined to a golden sub-region
-				if c.WasRefined {
-					fmt.Fprintf(f, "    Refined:         %.1fs at %.1fs → %.1fs at %.1fs (golden sub-region)\n",
-						c.OriginalDuration.Seconds(),
-						c.OriginalStart.Seconds(),
-						c.Region.Duration.Seconds(),
-						c.Region.Start.Seconds())
-				}
-
-				fmt.Fprintf(f, "    Amplitude:\n")
-				fmt.Fprintf(f, "      RMS Level:     %.1f dBFS\n", c.RMSLevel)
-				fmt.Fprintf(f, "      Peak Level:    %.1f dBFS\n", c.PeakLevel)
-				fmt.Fprintf(f, "      Crest Factor:  %.1f dB\n", c.CrestFactor)
-				fmt.Fprintf(f, "    Spectral:\n")
-				fmt.Fprintf(f, "      Centroid:      %.0f Hz (%s)\n", c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
-				fmt.Fprintf(f, "      Spread:        %.0f Hz\n", c.Spectral.Spread)
-				fmt.Fprintf(f, "      Rolloff:       %.0f Hz\n", c.Spectral.Rolloff)
-				fmt.Fprintf(f, "      Flatness:      %.3f (%s)\n", c.Spectral.Flatness, interpretFlatness(c.Spectral.Flatness))
-				fmt.Fprintf(f, "      Entropy:       %.3f (%s)\n", c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))
-				fmt.Fprintf(f, "      Kurtosis:      %.1f (%s)\n", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))
-				fmt.Fprintf(f, "      Skewness:      %.2f\n", c.Spectral.Skewness)
-				fmt.Fprintf(f, "      Flux:          %.4f\n", c.Spectral.Flux)
-				fmt.Fprintf(f, "      Slope:         %.2e\n", c.Spectral.Slope)
-				if c.VoicingDensity > 0 {
-					fmt.Fprintf(f, "    Voicing Density: %.1f%%\n", c.VoicingDensity*100)
-				}
-				fmt.Fprintf(f, "    Loudness:\n")
-				fmt.Fprintf(f, "      Momentary:     %.1f LUFS\n", c.MomentaryLUFS)
-				fmt.Fprintf(f, "      Short-term:    %.1f LUFS\n", c.ShortTermLUFS)
-				fmt.Fprintf(f, "      True Peak:     %.1f dBTP\n", c.TruePeak)
-			} else {
-				fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f, RMS %.1f dBFS)\n",
-					i+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score, c.RMSLevel)
-			}
+		if electedCandidate != nil {
+			entry := *electedCandidate
+			writeReportSpeechCandidateMetrics(f, entry.index, entry.candidate, true)
 		}
+		for _, entry := range displayCandidates {
+			writeReportSpeechCandidateMetrics(f, entry.index, entry.candidate, false)
+		}
+		writeReportSpeechRejectionSummary(f, measurements.SpeechCandidates)
 	} else if measurements.SpeechProfile != nil {
 		// Profile exists but no candidates list (shouldn't happen, but handle gracefully)
 		profile := measurements.SpeechProfile
@@ -1844,6 +1847,197 @@ func writeDiagnosticSpeech(f *os.File, measurements *processor.AudioMeasurements
 	}
 
 	fmt.Fprintln(f, "")
+}
+
+func writeReportSpeechCandidateMetrics(f io.Writer, index int, c processor.SpeechCandidateMetrics, elected bool) {
+	if !elected {
+		writeReportCompactSpeechCandidateRow(f, index, c)
+		return
+	}
+
+	electedLabel := ""
+	if elected {
+		electedLabel = ", elected"
+	}
+	fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f%s)\n",
+		index+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score, electedLabel)
+
+	if c.WasRefined {
+		fmt.Fprintf(f, "    Refined:         %.1fs at %.1fs -> %.1fs at %.1fs (golden sub-region)\n",
+			c.OriginalDuration.Seconds(),
+			c.OriginalStart.Seconds(),
+			c.Region.Duration.Seconds(),
+			c.Region.Start.Seconds())
+	}
+
+	fmt.Fprintf(f, "    Amplitude:\n")
+	fmt.Fprintf(f, "      RMS Level:     %.1f dBFS\n", c.RMSLevel)
+	fmt.Fprintf(f, "      Peak Level:    %.1f dBFS\n", c.PeakLevel)
+	fmt.Fprintf(f, "      Crest Factor:  %.1f dB\n", c.CrestFactor)
+	fmt.Fprintf(f, "    Spectral:\n")
+	fmt.Fprintf(f, "      Centroid:      %.0f Hz (%s)\n", c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
+	fmt.Fprintf(f, "      Spread:        %.0f Hz\n", c.Spectral.Spread)
+	fmt.Fprintf(f, "      Rolloff:       %.0f Hz\n", c.Spectral.Rolloff)
+	fmt.Fprintf(f, "      Flatness:      %.3f (%s)\n", c.Spectral.Flatness, interpretFlatness(c.Spectral.Flatness))
+	fmt.Fprintf(f, "      Entropy:       %.3f (%s)\n", c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))
+	fmt.Fprintf(f, "      Kurtosis:      %.1f (%s)\n", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))
+	fmt.Fprintf(f, "      Skewness:      %.2f\n", c.Spectral.Skewness)
+	fmt.Fprintf(f, "      Flux:          %.4f\n", c.Spectral.Flux)
+	fmt.Fprintf(f, "      Slope:         %.2e\n", c.Spectral.Slope)
+	if c.VoicingDensity > 0 {
+		fmt.Fprintf(f, "    Voicing Density: %.1f%%\n", c.VoicingDensity*100)
+	}
+	fmt.Fprintf(f, "    Loudness:\n")
+	fmt.Fprintf(f, "      Momentary:     %.1f LUFS\n", c.MomentaryLUFS)
+	fmt.Fprintf(f, "      Short-term:    %.1f LUFS\n", c.ShortTermLUFS)
+	fmt.Fprintf(f, "      True Peak:     %.1f dBTP\n", c.TruePeak)
+}
+
+func writeReportCompactSpeechCandidateRow(f io.Writer, index int, c processor.SpeechCandidateMetrics) {
+	fmt.Fprintf(f, "  Candidate %d:       %.1fs at %.1fs (score: %.3f)\n",
+		index+1, c.Region.Duration.Seconds(), c.Region.Start.Seconds(), c.Score)
+	fmt.Fprintf(f, "    RMS: %.1f dBFS, Crest: %.1f dB, Centroid: %.0f Hz (%s)\n",
+		c.RMSLevel, c.CrestFactor, c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
+}
+
+func rankedSpeechCandidateEntries(measurements *processor.AudioMeasurements) (*speechCandidateDisplayEntry, []speechCandidateDisplayEntry) {
+	if measurements == nil || len(measurements.SpeechCandidates) == 0 {
+		return nil, nil
+	}
+
+	entries := make([]speechCandidateDisplayEntry, 0, len(measurements.SpeechCandidates))
+	var elected *speechCandidateDisplayEntry
+	for i, c := range measurements.SpeechCandidates {
+		entry := speechCandidateDisplayEntry{index: i, candidate: c}
+		if isSelectedSpeechCandidate(c, measurements) {
+			electedEntry := entry
+			elected = &electedEntry
+			continue
+		}
+		if c.Score == 0.0 {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].candidate.Region.Start == entries[j].candidate.Region.Start {
+			return entries[i].index < entries[j].index
+		}
+		return entries[i].candidate.Region.Start < entries[j].candidate.Region.Start
+	})
+
+	return elected, selectSpeechCandidateEntries(entries)
+}
+
+func selectSpeechCandidateEntries(entries []speechCandidateDisplayEntry) []speechCandidateDisplayEntry {
+	displayCount := min(candidateDisplayLimit, len(entries))
+
+	displayed := make([]speechCandidateDisplayEntry, displayCount)
+	copy(displayed, entries[:displayCount])
+	return displayed
+}
+
+func isSelectedSpeechCandidate(c processor.SpeechCandidateMetrics, measurements *processor.AudioMeasurements) bool {
+	if measurements == nil || measurements.SpeechProfile == nil {
+		return false
+	}
+	if c.WasRefined {
+		return c.OriginalStart == measurements.SpeechProfile.OriginalStart
+	}
+	return c.Region.Start == measurements.SpeechProfile.Region.Start
+}
+
+func writeCandidateDisplaySummary(f *os.File, totalCandidates int, hasElected bool, displayedCandidates int) {
+	summary := candidateDisplaySummary(totalCandidates, hasElected, displayedCandidates)
+	if summary == "" {
+		return
+	}
+	fmt.Fprintf(f, "Displayed:           %s\n", summary)
+}
+
+func candidateDisplaySummary(totalCandidates int, hasElected bool, displayedCandidates int) string {
+	if totalCandidates <= 0 {
+		return ""
+	}
+
+	electedCount := 0
+	if hasElected {
+		electedCount = 1
+	}
+	if displayedCandidates < 0 {
+		displayedCandidates = 0
+	}
+	omitted := totalCandidates - displayedCandidates
+	omitted -= electedCount
+	if omitted < 0 {
+		omitted = 0
+	}
+
+	if hasElected && displayedCandidates == 0 {
+		return fmt.Sprintf("elected (%d omitted)", omitted)
+	}
+
+	displayLabel := fmt.Sprintf("%d chronological", displayedCandidates)
+	if omitted > 0 && displayedCandidates == candidateDisplayLimit {
+		displayLabel = fmt.Sprintf("top %d chronological", candidateDisplayLimit)
+	}
+	if hasElected {
+		return fmt.Sprintf("elected + %s (%d omitted)", displayLabel, omitted)
+	}
+	return fmt.Sprintf("%s (%d omitted)", displayLabel, omitted)
+}
+
+func writeReportSpeechRejectionSummary(f *os.File, candidates []processor.SpeechCandidateMetrics) {
+	writeReportCandidateRejectionSummary(f, speechRejectionSummary(candidates))
+}
+
+func writeReportCandidateRejectionSummary(w io.Writer, summary string) {
+	fmt.Fprintf(w, "Rejected:            %s\n", summary)
+}
+
+func silenceRejectionSummary(candidates []processor.SilenceCandidateMetrics) string {
+	reasonCounts := make(map[string]int)
+	for _, c := range candidates {
+		if c.Score != 0.0 {
+			continue
+		}
+		reason := classifyRejectionReason(c.TransientWarning)
+		reasonCounts[reason]++
+	}
+
+	return formatRejectionSummary(reasonCounts, []string{"digital silence", "crosstalk", "transient contamination", "too loud"})
+}
+
+func speechRejectionSummary(candidates []processor.SpeechCandidateMetrics) string {
+	reasonCounts := make(map[string]int)
+	for _, c := range candidates {
+		if c.Score != 0.0 {
+			continue
+		}
+		reasonCounts["zero score"]++
+	}
+
+	return formatRejectionSummary(reasonCounts, []string{"zero score"})
+}
+
+func formatRejectionSummary(reasonCounts map[string]int, order []string) string {
+	if len(reasonCounts) == 0 {
+		return "0"
+	}
+
+	var parts []string
+	for _, reason := range order {
+		if count, ok := reasonCounts[reason]; ok {
+			parts = append(parts, fmt.Sprintf("%d %s", count, reason))
+			delete(reasonCounts, reason)
+		}
+	}
+	for reason, count := range reasonCounts {
+		parts = append(parts, fmt.Sprintf("%d %s", count, reason))
+	}
+
+	return strings.Join(parts, ", ")
 }
 
 // writeDiagnosticPeakLimiter outputs the Pass 4 pre-limiting diagnostics.

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -282,3 +282,254 @@ func TestGenerateReport_SkippedNormalisationTimingLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteDiagnosticSilence_CapsCandidatesChronologicallyWithElectedFirst(t *testing.T) {
+	m := makeInputMeasurements()
+	m.SilenceCandidates = makeRankedSilenceCandidates(12)
+	m.NoiseProfile = &processor.NoiseProfile{
+		Start:              m.SilenceCandidates[0].Region.Start,
+		Duration:           m.SilenceCandidates[0].Region.Duration,
+		MeasuredNoiseFloor: m.SilenceCandidates[0].RMSLevel,
+	}
+
+	output := captureReportDiagnostic(t, func(f *os.File) {
+		writeDiagnosticSilence(f, m)
+	})
+
+	for _, want := range []string{
+		"Silence Candidates:  12 evaluated",
+		"Displayed:           elected + top 10 chronological (1 omitted)",
+		"Candidate 1:       5.0s at 1.0s (score: 0.010, elected)",
+		"Candidate 2:       5.0s at 2.0s (score: 0.020)",
+		"RMS: -59.8 dBFS, Crest: 12.0 dB, Entropy: 0.420 (mixed voiced/unvoiced)",
+		"Rejected:            0",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("silence diagnostic missing %q", want)
+		}
+	}
+
+	for _, heading := range []string{"    Amplitude:\n", "    Spectral:\n", "    Loudness:\n"} {
+		if count := strings.Count(output, heading); count != 1 {
+			t.Fatalf("silence diagnostic %q heading count = %d, want 1", strings.TrimSpace(heading), count)
+		}
+	}
+
+	if count := strings.Count(output, "  Candidate "); count != 11 {
+		t.Fatalf("displayed silence candidates = %d, want 11", count)
+	}
+	assertAppearsBefore(t, output, "Candidate 1:", "Candidate 2:")
+	assertAppearsBefore(t, output, "Candidate 2:", "Candidate 3:")
+	assertAppearsBefore(t, output, "Candidate 10:", "Candidate 11:")
+	if strings.Contains(output, "Candidate 12:") {
+		t.Fatal("expected candidate 12 to be omitted")
+	}
+	if strings.Contains(output, "[SELECTED]") {
+		t.Fatal("expected silence diagnostic to use elected terminology")
+	}
+	assertCandidateSummaryTerminology(t, output, "Displayed:           elected + top 10 chronological (1 omitted)")
+}
+
+func TestWriteDiagnosticSpeech_CapsCandidatesChronologicallyWithElectedFirst(t *testing.T) {
+	m := makeInputMeasurements()
+	m.SpeechCandidates = makeRankedSpeechCandidates(12)
+	m.SpeechCandidates[0].VoicingDensity = 0.82
+	m.SpeechProfile = &m.SpeechCandidates[0]
+
+	output := captureReportDiagnostic(t, func(f *os.File) {
+		writeDiagnosticSpeech(f, m)
+	})
+
+	for _, want := range []string{
+		"Speech Candidates:   12 evaluated",
+		"Displayed:           elected + top 10 chronological (1 omitted)",
+		"Candidate 1:       60.0s at 1.0s (score: 0.010, elected)",
+		"Voicing Density: 82.0%",
+		"Candidate 2:       60.0s at 2.0s (score: 0.020)",
+		"RMS: -29.8 dBFS, Crest: 10.0 dB, Centroid: 2400 Hz (forward, clear)",
+		"Rejected:            0",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("speech diagnostic missing %q", want)
+		}
+	}
+
+	for _, heading := range []string{"    Amplitude:\n", "    Spectral:\n", "    Loudness:\n"} {
+		if count := strings.Count(output, heading); count != 1 {
+			t.Fatalf("speech diagnostic %q heading count = %d, want 1", strings.TrimSpace(heading), count)
+		}
+	}
+
+	if count := strings.Count(output, "  Candidate "); count != 11 {
+		t.Fatalf("displayed speech candidates = %d, want 11", count)
+	}
+	assertAppearsBefore(t, output, "Candidate 1:", "Candidate 2:")
+	assertAppearsBefore(t, output, "Candidate 2:", "Candidate 3:")
+	assertAppearsBefore(t, output, "Candidate 10:", "Candidate 11:")
+	if strings.Contains(output, "Candidate 12:") {
+		t.Fatal("expected candidate 12 to be omitted")
+	}
+	if strings.Contains(output, "[SELECTED]") {
+		t.Fatal("expected speech diagnostic to use elected terminology")
+	}
+	assertCandidateSummaryTerminology(t, output, "Displayed:           elected + top 10 chronological (1 omitted)")
+}
+
+func TestWriteDiagnosticSpeech_RejectionSummaryIncludesZeroScore(t *testing.T) {
+	m := makeInputMeasurements()
+	m.SpeechCandidates = makeRankedSpeechCandidates(3)
+	m.SpeechCandidates[1].Score = 0.0
+	m.SpeechProfile = &m.SpeechCandidates[0]
+
+	output := captureReportDiagnostic(t, func(f *os.File) {
+		writeDiagnosticSpeech(f, m)
+	})
+
+	for _, want := range []string{
+		"Speech Candidates:   3 evaluated",
+		"Displayed:           elected + 1 chronological (1 omitted)",
+		"Candidate 1:       60.0s at 1.0s (score: 0.010, elected)",
+		"Candidate 3:       60.0s at 3.0s (score: 0.030)",
+		"Rejected:            1 zero score",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("speech diagnostic missing %q", want)
+		}
+	}
+
+	if strings.Contains(output, "Candidate 2:") {
+		t.Fatal("expected zero-score speech candidate to be omitted from displayed candidates")
+	}
+	assertCandidateSummaryTerminology(t, output, "Displayed:           elected + 1 chronological (1 omitted)")
+}
+
+func TestWriteDiagnosticSpeech_DisplaySummaryIncludesZeroOmitted(t *testing.T) {
+	m := makeInputMeasurements()
+	m.SpeechCandidates = makeRankedSpeechCandidates(4)
+	m.SpeechProfile = &m.SpeechCandidates[0]
+
+	output := captureReportDiagnostic(t, func(f *os.File) {
+		writeDiagnosticSpeech(f, m)
+	})
+
+	for _, want := range []string{
+		"Speech Candidates:   4 evaluated",
+		"Displayed:           elected + 3 chronological (0 omitted)",
+		"Candidate 1:       60.0s at 1.0s (score: 0.010, elected)",
+		"Candidate 4:       60.0s at 4.0s (score: 0.040)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("speech diagnostic missing %q", want)
+		}
+	}
+	assertCandidateSummaryTerminology(t, output, "Displayed:           elected + 3 chronological (0 omitted)")
+}
+
+func TestCandidateRejectionSummaries(t *testing.T) {
+	silenceCandidates := makeRankedSilenceCandidates(3)
+	if got := silenceRejectionSummary(silenceCandidates); got != "0" {
+		t.Fatalf("silenceRejectionSummary() = %q, want 0", got)
+	}
+
+	silenceCandidates[0].Score = 0.0
+	silenceCandidates[0].TransientWarning = "rejected: digital silence"
+	silenceCandidates[1].Score = 0.0
+	silenceCandidates[1].TransientWarning = "rejected: transient contamination"
+	if got := silenceRejectionSummary(silenceCandidates); got != "1 digital silence, 1 transient contamination" {
+		t.Fatalf("silenceRejectionSummary() = %q", got)
+	}
+
+	speechCandidates := makeRankedSpeechCandidates(3)
+	if got := speechRejectionSummary(speechCandidates); got != "0" {
+		t.Fatalf("speechRejectionSummary() = %q, want 0", got)
+	}
+	speechCandidates[1].Score = 0.0
+	if got := speechRejectionSummary(speechCandidates); got != "1 zero score" {
+		t.Fatalf("speechRejectionSummary() = %q", got)
+	}
+}
+
+func makeRankedSilenceCandidates(count int) []processor.SilenceCandidateMetrics {
+	candidates := make([]processor.SilenceCandidateMetrics, 0, count)
+	for i := 1; i <= count; i++ {
+		c := *makeSilenceSample(-60.0 + float64(i)/10.0)
+		start := time.Duration(i) * time.Second
+		c.Region = processor.SilenceRegion{
+			Start:    start,
+			End:      start + 5*time.Second,
+			Duration: 5 * time.Second,
+		}
+		c.Score = float64(i) / 100.0
+		candidates = append(candidates, c)
+	}
+	return candidates
+}
+
+func makeRankedSpeechCandidates(count int) []processor.SpeechCandidateMetrics {
+	candidates := make([]processor.SpeechCandidateMetrics, 0, count)
+	for i := 1; i <= count; i++ {
+		c := *makeSpeechSample(-30.0 + float64(i)/10.0)
+		start := time.Duration(i) * time.Second
+		c.Region = processor.SpeechRegion{
+			Start:    start,
+			End:      start + 60*time.Second,
+			Duration: 60 * time.Second,
+		}
+		c.Score = float64(i) / 100.0
+		candidates = append(candidates, c)
+	}
+	return candidates
+}
+
+func captureReportDiagnostic(t *testing.T, write func(*os.File)) string {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp("", "report-diagnostic-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	write(tmpFile)
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func assertAppearsBefore(t *testing.T, output, first, second string) {
+	t.Helper()
+
+	firstIndex := strings.Index(output, first)
+	if firstIndex < 0 {
+		t.Fatalf("missing %q", first)
+	}
+	secondIndex := strings.Index(output, second)
+	if secondIndex < 0 {
+		t.Fatalf("missing %q", second)
+	}
+	if firstIndex >= secondIndex {
+		t.Fatalf("expected %q to appear before %q", first, second)
+	}
+}
+
+func assertCandidateSummaryTerminology(t *testing.T, output, expectedSummary string) {
+	t.Helper()
+
+	if !strings.Contains(output, expectedSummary) {
+		t.Fatalf("missing candidate display summary %q", expectedSummary)
+	}
+	for _, forbidden := range []string{"by score", "[SELECTED]", "[ELECTED]"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("candidate output contains legacy terminology %q", forbidden)
+		}
+	}
+	if !strings.Contains(output, "elected") {
+		t.Fatal("candidate output missing elected terminology")
+	}
+}

--- a/internal/processor/analyzer_candidates.go
+++ b/internal/processor/analyzer_candidates.go
@@ -1107,7 +1107,10 @@ func findBestSilenceRegion(regions []SilenceRegion, intervals []IntervalSample, 
 			}
 		}
 
-		// Select earliest candidate within selectionTolerance of max
+		// Select earliest accepted candidate within selectionTolerance of max.
+		// If every measured candidate falls below the normal threshold, fall back
+		// to the earliest candidate within tolerance so detected room tone is never
+		// discarded wholesale.
 		// Uses Region field from metrics to avoid index correspondence issues
 		// (result.Candidates may have fewer entries than candidates if some
 		// returned nil from measureSilenceCandidateFromIntervals)
@@ -1120,6 +1123,19 @@ func findBestSilenceRegion(regions []SilenceRegion, intervals []IntervalSample, 
 					Duration: region.Duration,
 				}
 				break
+			}
+		}
+		if result.BestRegion == nil {
+			for _, c := range result.Candidates {
+				if c.Score >= maxScore-selectionTolerance {
+					region := c.Region
+					result.BestRegion = &SilenceRegion{
+						Start:    region.Start,
+						End:      region.End,
+						Duration: region.Duration,
+					}
+					break
+				}
 			}
 		}
 	}
@@ -1621,6 +1637,9 @@ func findBestSpeechRegion(regions []SpeechRegion, intervals []IntervalSample, no
 
 	var bestCandidate *SpeechRegion
 	var bestDuration time.Duration
+	var fallbackCandidate *SpeechRegion
+	var fallbackScore float64
+	hasFallback := false
 
 	for i := range regions {
 		candidate := &regions[i]
@@ -1657,12 +1676,23 @@ func findBestSpeechRegion(regions []SpeechRegion, intervals []IntervalSample, no
 		// Store for reporting
 		result.Candidates = append(result.Candidates, *metrics)
 
+		if !hasFallback || score > fallbackScore {
+			fallbackRegion := metrics.Region
+			fallbackCandidate = &fallbackRegion
+			fallbackScore = score
+			hasFallback = true
+		}
+
 		// Selection: longest candidate above minimum quality
 		const minAcceptableSpeechScore = 0.3
 		if score >= minAcceptableSpeechScore && candidate.Duration > bestDuration {
 			bestCandidate = candidate
 			bestDuration = candidate.Duration
 		}
+	}
+
+	if bestCandidate == nil && hasFallback {
+		bestCandidate = fallbackCandidate
 	}
 
 	// Refine long candidates to golden sub-region

--- a/internal/processor/analyzer_candidates.go
+++ b/internal/processor/analyzer_candidates.go
@@ -1127,7 +1127,7 @@ func findBestSilenceRegion(regions []SilenceRegion, intervals []IntervalSample, 
 		}
 		if result.BestRegion == nil {
 			for _, c := range result.Candidates {
-				if c.Score >= maxScore-selectionTolerance {
+				if c.Score > 0.0 && c.Score >= maxScore-selectionTolerance {
 					region := c.Region
 					result.BestRegion = &SilenceRegion{
 						Start:    region.Start,

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -573,7 +573,7 @@ func TestFindBestSilenceRegion_EarlierCandidatePreferredWithinTolerance(t *testi
 	}
 }
 
-func TestFindBestSilenceRegion_BelowMinAcceptableScoreNeverElected(t *testing.T) {
+func TestFindBestSilenceRegion_AllBelowMinAcceptableScoreFallsBack(t *testing.T) {
 	// Two regions that will score below minAcceptableScore (0.3).
 	// Both have poor characteristics: high RMS, voice-range centroid, etc.
 
@@ -598,8 +598,19 @@ func TestFindBestSilenceRegion_BelowMinAcceptableScoreNeverElected(t *testing.T)
 
 	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
 
-	if result.BestRegion != nil {
-		t.Errorf("expected BestRegion to be nil (all candidates below minAcceptableScore), got start=%v", result.BestRegion.Start)
+	if result.BestRegion == nil {
+		t.Fatal("expected fallback BestRegion when candidates exist below minAcceptableScore")
+	}
+	if result.BestRegion.Start != 0 {
+		t.Errorf("BestRegion.Start = %v, want 0 (earliest fallback candidate within tolerance)", result.BestRegion.Start)
+	}
+	if len(result.Candidates) != 2 {
+		t.Fatalf("len(Candidates) = %d, want 2", len(result.Candidates))
+	}
+	for _, c := range result.Candidates {
+		if c.Score >= minAcceptableScore {
+			t.Errorf("candidate start=%v score=%.4f, want below minAcceptableScore %.1f", c.Region.Start, c.Score, minAcceptableScore)
+		}
 	}
 
 	// Log scores for debugging
@@ -1174,6 +1185,58 @@ func TestFindBestSpeechRegion(t *testing.T) {
 			t.Errorf("expected 2 candidates stored, got %d", len(result.Candidates))
 		}
 	})
+}
+
+func TestFindBestSpeechRegion_AllBelowMinAcceptableScoreFallsBack(t *testing.T) {
+	regions := []SpeechRegion{
+		{Start: 0, End: 30 * time.Second, Duration: 30 * time.Second},
+		{Start: 35 * time.Second, End: 65 * time.Second, Duration: 30 * time.Second},
+	}
+
+	makePoorSpeechIntervals := func(start time.Duration, duration time.Duration, rolloff float64) []IntervalSample {
+		count := int(duration / (250 * time.Millisecond))
+		intervals := make([]IntervalSample, count)
+		for i := range intervals {
+			intervals[i] = IntervalSample{
+				Timestamp:        start + time.Duration(i)*250*time.Millisecond,
+				RMSLevel:         -35.0,
+				PeakLevel:        -10.0,
+				SpectralKurtosis: 2.0,
+				SpectralCentroid: 8000.0,
+				SpectralRolloff:  rolloff,
+				SpectralFlux:     0.05,
+			}
+		}
+		return intervals
+	}
+
+	lowScoreIntervals := makePoorSpeechIntervals(0, 30*time.Second, 12000.0)
+	higherScoreIntervals := makePoorSpeechIntervals(35*time.Second, 30*time.Second, 6000.0)
+	intervals := make([]IntervalSample, 0, len(lowScoreIntervals)+len(higherScoreIntervals))
+	intervals = append(intervals, lowScoreIntervals...)
+	intervals = append(intervals, higherScoreIntervals...)
+
+	result := findBestSpeechRegion(regions, intervals, nil)
+
+	if result.BestRegion == nil {
+		t.Fatal("expected fallback BestRegion when speech candidates exist below threshold")
+	}
+	if result.BestRegion.Start != 35*time.Second {
+		t.Errorf("BestRegion.Start = %v, want 35s (highest-scored fallback candidate)", result.BestRegion.Start)
+	}
+	if len(result.Candidates) != 2 {
+		t.Fatalf("len(Candidates) = %d, want 2", len(result.Candidates))
+	}
+
+	const minAcceptableSpeechScore = 0.3
+	for _, c := range result.Candidates {
+		if c.Score >= minAcceptableSpeechScore {
+			t.Errorf("candidate start=%v score=%.4f, want below speech threshold %.1f", c.Region.Start, c.Score, minAcceptableSpeechScore)
+		}
+	}
+	if result.Candidates[1].Score <= result.Candidates[0].Score {
+		t.Errorf("expected second candidate score %.4f to exceed first %.4f", result.Candidates[1].Score, result.Candidates[0].Score)
+	}
 }
 
 func TestScoreSpeechCandidate(t *testing.T) {

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -619,6 +619,36 @@ func TestFindBestSilenceRegion_AllBelowMinAcceptableScoreFallsBack(t *testing.T)
 	}
 }
 
+func TestFindBestSilenceRegion_AllRejectedCandidatesDoNotFallback(t *testing.T) {
+	regions := []SilenceRegion{
+		{Start: 0, End: 10 * time.Second, Duration: 10 * time.Second},
+		{Start: 15 * time.Second, End: 25 * time.Second, Duration: 10 * time.Second},
+	}
+
+	intervalsA := makeSilenceTestIntervals(0, 10*time.Second,
+		-120.0, -120.0, 100.0, 0.8, 2.0, 0.0)
+	intervalsB := makeSilenceTestIntervals(15*time.Second, 10*time.Second,
+		-120.0, -120.0, 100.0, 0.8, 2.0, 0.0)
+
+	allIntervals := make([]IntervalSample, 0, len(intervalsA)+len(intervalsB))
+	allIntervals = append(allIntervals, intervalsA...)
+	allIntervals = append(allIntervals, intervalsB...)
+
+	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
+
+	if result.BestRegion != nil {
+		t.Fatalf("BestRegion = %+v, want nil for all rejected candidates", result.BestRegion)
+	}
+	if len(result.Candidates) != 2 {
+		t.Fatalf("len(Candidates) = %d, want 2", len(result.Candidates))
+	}
+	for _, c := range result.Candidates {
+		if c.Score != 0.0 {
+			t.Errorf("candidate start=%v score=%.4f, want 0.0", c.Region.Start, c.Score)
+		}
+	}
+}
+
 func TestFindBestSilenceRegion_SingleAcceptableCandidateElected(t *testing.T) {
 	// A single region with an acceptable score should be elected.
 

--- a/testdata/justfile
+++ b/testdata/justfile
@@ -8,7 +8,7 @@ testdata := source_directory()
 
 # Test episode number (change this to test different episodes)
 
-episode := "79"
+episode := "81"
 
 # Get Mark's processed logs
 mark-logs:
@@ -21,7 +21,7 @@ mark-log-stash:
 # Process mark audio
 mark:
     @rm -f {{ testdata }}/LMP-{{ episode }}-mark-*-processed.*
-    @./jivetalking --debug --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-mark.flac
+    @./jivetalking --debug {{ testdata }}/LMP-{{ episode }}-mark.flac
     @just mark-logs
 
 # Get Martin's processed logs
@@ -35,7 +35,7 @@ martin-log-stash:
 # Process martin audio
 martin:
     @rm -f {{ testdata }}/LMP-{{ episode }}-martin-*-processed.*
-    @./jivetalking --debug --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-martin.flac
+    @./jivetalking --debug {{ testdata }}/LMP-{{ episode }}-martin.flac
     @just martin-logs
 
 # Get popey's processed logs
@@ -49,20 +49,20 @@ popey-log-stash:
 # Process popey audio
 popey:
     @rm -f {{ testdata }}/LMP-{{ episode }}-popey-*-processed.*
-    @./jivetalking --debug --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-popey.flac
+    @./jivetalking --debug {{ testdata }}/LMP-{{ episode }}-popey.flac
     @just popey-logs
 
 # Analyse Mark's audio
 mark-analysis:
-    @./jivetalking -a --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-mark.flac | tee {{ testdata }}/LMP-{{ episode }}-mark-analysis.log
+    @./jivetalking -a {{ testdata }}/LMP-{{ episode }}-mark.flac | tee {{ testdata }}/LMP-{{ episode }}-mark-analysis.log
 
 # Analyse Martin's audio
 martin-analysis:
-    @./jivetalking -a --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-martin.flac | tee {{ testdata }}/LMP-{{ episode }}-martin-analysis.log
+    @./jivetalking -a {{ testdata }}/LMP-{{ episode }}-martin.flac | tee {{ testdata }}/LMP-{{ episode }}-martin-analysis.log
 
 # Analyse popey's audio
 popey-analysis:
-    @./jivetalking -a --silence-scan-duration=3m {{ testdata }}/LMP-{{ episode }}-popey.flac | tee {{ testdata }}/LMP-{{ episode }}-popey-analysis.log
+    @./jivetalking -a {{ testdata }}/LMP-{{ episode }}-popey.flac | tee {{ testdata }}/LMP-{{ episode }}-popey-analysis.log
 
 # Process all presenters
 presenters: mark martin popey
@@ -70,10 +70,10 @@ presenters: mark martin popey
 # Analyse all presenter
 analysis: mark-analysis martin-analysis popey-analysis
 
-# Process all presenters for episodes 70, 71, and 72
+# Process all presenters for all episodes
 all-episodes:
     #!/usr/bin/env bash
-    for ep in 68 69 70 71 72 73 74 75 76 77; do
+    for ep in 68 69 70 71 72 73 74 75 76 77 78 79 80 81; do
         echo "=== Processing Episode $ep ==="
         for presenter in mark martin popey; do
             echo "--- $presenter ---"
@@ -85,7 +85,7 @@ all-episodes:
 # Run analysis-only mode on all episodes and presenters
 all-analyse:
     #!/usr/bin/env bash
-    for ep in 68 69 70 71 72 73 74 75 76 77; do
+    for ep in 68 69 70 71 72 73 74 75 76 77 78 79 80 81; do
         echo "=== Analysing Episode $ep ==="
         for presenter in mark martin popey; do
             audio_file="{{ testdata }}/LMP-${ep}-${presenter}.flac"
@@ -106,7 +106,7 @@ stash: mark-log-stash martin-log-stash popey-log-stash
 # Run analysis-only mode on all episodes and presenters
 stash-analysis:
     #!/usr/bin/env bash
-    for ep in 68 69 70 71 72 73 74 75 77; do
+    for ep in 68 69 70 71 72 73 74 75 77 78 79 80 81; do
         for presenter in mark martin popey; do
             log_file="{{ testdata }}/LMP-${ep}-${presenter}-analysis.log"
             stash_log_file="{{ testdata }}/LMP-${ep}-${presenter}-analysis-before.log"

--- a/testdata/justfile
+++ b/testdata/justfile
@@ -106,7 +106,7 @@ stash: mark-log-stash martin-log-stash popey-log-stash
 # Run analysis-only mode on all episodes and presenters
 stash-analysis:
     #!/usr/bin/env bash
-    for ep in 68 69 70 71 72 73 74 75 77 78 79 80 81; do
+    for ep in 68 69 70 71 72 73 74 75 76 77 78 79 80 81; do
         for presenter in mark martin popey; do
             log_file="{{ testdata }}/LMP-${ep}-${presenter}-analysis.log"
             stash_log_file="{{ testdata }}/LMP-${ep}-${presenter}-analysis-before.log"


### PR DESCRIPTION
## Summary
Improve candidate reporting so elected silence and speech candidates are surfaced first with complete detail, while non-elected candidates remain compact and consistent across report modes.

## Changes
- Show elected silence and speech candidates first with full details
- Render non-elected top candidates as compact chronological rows
- Keep candidate totals, display summaries, and rejection summaries consistent between analysis-only and processed reports
- Add and update tests for candidate fallback and report formatting
- Regenerate sample log support data

## Testing
- just test

## Related Issues
