### PR TITLE
refactor(processor): clean up audio processing and reporting internals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ internal/
 │   ├── filters.go          # FilterChainConfig, filter builder funcs, BuildFilterSpec(), DefaultFilterConfig()
 │   ├── frame_processor.go  # runFilterGraph(), FrameLoopConfig - shared filter graph execution
 │   ├── normalise.go        # ApplyNormalisation() - Pass 3/4: loudnorm measurement + application
-│   └── processor.go        # ProcessAudio(), AnalyzeOnly() - pass orchestration
+│   └── processor.go        # ProcessAudio(), AnalyzeOnlyDetailed() - pass orchestration
 ├── logging/
 │   ├── analysis_display.go # DisplayAnalysisResults() - console output for --analysis-only mode
 │   ├── recording_tips.go   # Actionable recording advice from measurements
@@ -52,7 +52,7 @@ internal/
 
 **Data flow (processing):** `main.go` spawns goroutine → `ProcessAudio()` → Pass 1 (`AnalyzeAudio`) → `AdaptConfig()` → Pass 2 (filter chain) → Pass 3/4 (`ApplyNormalisation`) → `GenerateReport()` writes an always-on processing report → sends `ui.*Msg` to TUI via `tea.Program.Send()`.
 
-**Data flow (analysis-only):** `main.go` → `runAnalysisOnly()` → `AnalyzeOnly()` → Pass 1 + `AdaptConfig()` → `AnalysisModel` TUI shows progress → `DisplayAnalysisResults()` prints report to console. No output files created.
+**Data flow (analysis-only):** `main.go` → `runAnalysisOnly()` → `AnalyzeOnlyDetailed()` → Pass 1 + `AdaptConfig()` → `AnalysisModel` TUI shows progress → `DisplayAnalysisResults()` prints report to console. No output files created.
 
 ## Audio processing pipeline
 

--- a/internal/audio/reader.go
+++ b/internal/audio/reader.go
@@ -174,16 +174,6 @@ func (r *Reader) ReadFrame() (*ffmpeg.AVFrame, error) {
 	}
 }
 
-// GetTimeBase returns the time base of the audio stream
-func (r *Reader) GetTimeBase() *ffmpeg.AVRational {
-	return r.fmtCtx.Streams().Get(uintptr(r.streamIdx)).TimeBase() //nolint:gosec // streamIdx is validated in OpenAudioFile
-}
-
-// FormatName returns the short name of the input container format (e.g. "flac", "wav").
-func (r *Reader) FormatName() string {
-	return r.fmtCtx.Iformat().Name().String()
-}
-
 // GetDecoderContext returns the decoder context (needed for filter graph setup)
 func (r *Reader) GetDecoderContext() *ffmpeg.AVCodecContext {
 	return r.decCtx

--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -22,6 +22,11 @@ type AnalysisTimings struct {
 	ReportOutput time.Duration
 }
 
+type analysisMetricSpec struct {
+	Label string
+	Value string
+}
+
 // DisplayAnalysisResults outputs Pass 1 analysis results to the console.
 // Used by --analysis-only mode for rapid inspection without full processing.
 func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig, timings ...AnalysisTimings) {
@@ -31,205 +36,149 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 	}
 	reportOutputStart := time.Now()
 
-	// Header
+	writeAnalysisHeader(w, inputPath, metadata)
+	writeAnalysisLoudnessAndDynamics(w, measurements)
+	writeAnalysisSilenceDetection(w, measurements)
+	writeAnalysisSpeechDetection(w, measurements)
+	writeAnalysisDerivedMeasurements(w, measurements)
+	writeAnalysisFilterAdaptation(w, measurements, config)
+	writeAnalysisSpectralSummary(w, measurements)
+	writeAnalysisTips(w, measurements, config)
+
+	if len(timings) > 0 && hasAnalysisTimings(timings[0]) {
+		fmt.Fprintln(w)
+		writeAnalysisTimingSection(w, completeAnalysisTimings(timings[0], reportOutputStart))
+	}
+}
+
+func writeAnalysisHeader(w io.Writer, inputPath string, metadata *audio.Metadata) {
 	fmt.Fprintln(w, strings.Repeat("=", 70))
 	fmt.Fprintf(w, "ANALYSIS: %s\n", filepath.Base(inputPath))
 	fmt.Fprintln(w, strings.Repeat("=", 70))
-
-	// File info
-	fmt.Fprintf(w, "Duration:    %s\n", formatDurationHMS(metadata.Duration))
+	fmt.Fprintf(w, "Duration:    %s\n", formatDuration(time.Duration(metadata.Duration*float64(time.Second))))
 	fmt.Fprintf(w, "Sample Rate: %d Hz\n", metadata.SampleRate)
 	fmt.Fprintf(w, "Channels:    %s\n", channelName(metadata.Channels))
 	fmt.Fprintln(w)
+}
 
-	// Loudness section
+func writeAnalysisLoudnessAndDynamics(w io.Writer, measurements *processor.AudioMeasurements) {
 	writeAnalysisSection(w, "LOUDNESS")
-	fmt.Fprintf(w, "  Integrated:     %.1f LUFS\n", measurements.InputI)
-	fmt.Fprintf(w, "  True Peak:      %.1f dBTP\n", measurements.InputTP)
-	fmt.Fprintf(w, "  Loudness Range: %.1f LU\n", measurements.InputLRA)
+	writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+		{"Integrated", fmt.Sprintf("%.1f LUFS", measurements.InputI)},
+		{"True Peak", fmt.Sprintf("%.1f dBTP", measurements.InputTP)},
+		{"Loudness Range", fmt.Sprintf("%.1f LU", measurements.InputLRA)},
+	})
 	fmt.Fprintln(w)
 
-	// Dynamics section
 	writeAnalysisSection(w, "DYNAMICS")
-	fmt.Fprintf(w, "  RMS Level:      %.1f dBFS\n", measurements.RMSLevel)
-	fmt.Fprintf(w, "  Peak Level:     %.1f dBFS\n", measurements.PeakLevel)
-	fmt.Fprintf(w, "  Dynamic Range:  %.1f dB\n", measurements.DynamicRange)
 	crestFactor := measurements.PeakLevel - measurements.RMSLevel
 	crestSource := "full-file"
 	if measurements.SpeechProfile != nil && measurements.SpeechProfile.CrestFactor > 0 {
 		crestFactor = measurements.SpeechProfile.CrestFactor
 		crestSource = "speech"
 	}
-	fmt.Fprintf(w, "  Crest Factor:   %.1f dB (%s)\n", crestFactor, crestSource)
+	writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+		{"RMS Level", fmt.Sprintf("%.1f dBFS", measurements.RMSLevel)},
+		{"Peak Level", fmt.Sprintf("%.1f dBFS", measurements.PeakLevel)},
+		{"Dynamic Range", fmt.Sprintf("%.1f dB", measurements.DynamicRange)},
+		{"Crest Factor", fmt.Sprintf("%.1f dB (%s)", crestFactor, crestSource)},
+	})
 	fmt.Fprintln(w)
+}
 
-	// Silence detection section
+func writeAnalysisSilenceDetection(w io.Writer, measurements *processor.AudioMeasurements) {
 	writeAnalysisSection(w, "SILENCE DETECTION")
 	fmt.Fprintf(w, "  Threshold:      %.1f dB (%.1f dBFS room tone estimate + 1 dB)\n",
 		measurements.SilenceDetectLevel, measurements.PreScanNoiseFloor)
 
-	if len(measurements.SilenceCandidates) > 0 { //nolint:gocritic // ifElseChain: complex display logic unsuitable for switch
-		fmt.Fprintf(w, "  Candidates:     %d evaluated\n", len(measurements.SilenceCandidates))
-		electedCandidate, displayCandidates := rankedSilenceCandidateEntries(measurements)
-		if summary := candidateDisplaySummary(len(measurements.SilenceCandidates), electedCandidate != nil, len(displayCandidates)); summary != "" {
-			fmt.Fprintf(w, "  Displayed:      %s\n", summary)
-		}
-
-		if measurements.VoiceActivated {
-			fmt.Fprintln(w, "  Voice-activated recording detected")
-		}
-		if electedCandidate != nil || len(displayCandidates) > 0 {
-			fmt.Fprintln(w)
-			if electedCandidate != nil {
-				i := electedCandidate.index
-				c := electedCandidate.candidate
-				fmt.Fprintf(w, "  #%d: %.1fs at %s (elected)\n",
-					i+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
-				if measurements.NoiseProfile.WasRefined {
-					fmt.Fprintf(w, "      Refined:     %.1fs at %s (golden sub-region)\n",
-						measurements.NoiseProfile.Duration.Seconds(), formatTimestamp(measurements.NoiseProfile.Start))
-				}
-				writeSilenceCandidateMetrics(w, c)
-				fmt.Fprintln(w)
-			}
-			for _, entry := range displayCandidates {
-				i := entry.index
-				c := entry.candidate
-				writeCompactAnalysisSilenceCandidateRow(w, i, c)
-				fmt.Fprintln(w)
-			}
-		}
-
-		// Rejection summary: count zero-scored candidates by reason
-		writeSilenceRejectionSummary(w, measurements.SilenceCandidates)
-	} else if measurements.NoiseProfile != nil {
-		fmt.Fprintf(w, "  Sample:         %.1fs at %s\n",
-			measurements.NoiseProfile.Duration.Seconds(), formatTimestamp(measurements.NoiseProfile.Start))
-		fmt.Fprintf(w, "  Noise Floor:    %.1f dBFS\n", measurements.NoiseProfile.MeasuredNoiseFloor)
-	} else {
-		fmt.Fprintln(w, "  No silence detected")
-		if measurements.VoiceActivated {
-			fmt.Fprintln(w, "  Voice-activated recording detected")
-		}
-	}
+	writeAnalysisSilenceCandidates(w, measurements)
 	fmt.Fprintln(w)
+}
 
-	// Speech detection section
+func writeAnalysisSpeechDetection(w io.Writer, measurements *processor.AudioMeasurements) {
 	writeAnalysisSection(w, "SPEECH DETECTION")
-	if len(measurements.SpeechCandidates) > 0 { //nolint:gocritic // ifElseChain: complex display logic unsuitable for switch
-		fmt.Fprintf(w, "  Candidates:     %d evaluated\n", len(measurements.SpeechCandidates))
-		electedCandidate, displayCandidates := rankedSpeechCandidateEntries(measurements)
-		if summary := candidateDisplaySummary(len(measurements.SpeechCandidates), electedCandidate != nil, len(displayCandidates)); summary != "" {
-			fmt.Fprintf(w, "  Displayed:      %s\n", summary)
-		}
-		fmt.Fprintln(w)
-
-		if electedCandidate != nil {
-			i := electedCandidate.index
-			c := electedCandidate.candidate
-			fmt.Fprintf(w, "  #%d: %.1fs at %s (elected)\n",
-				i+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
-
-			if c.WasRefined {
-				fmt.Fprintf(w, "      Refined:     %.1fs at %s -> %.1fs at %s (golden sub-region)\n",
-					c.OriginalDuration.Seconds(),
-					formatTimestamp(c.OriginalStart),
-					c.Region.Duration.Seconds(),
-					formatTimestamp(c.Region.Start))
-			}
-
-			fmt.Fprintf(w, "      Score:       %.2f\n", c.Score)
-			fmt.Fprintf(w, "      RMS Level:   %.1f dBFS\n", c.RMSLevel)
-			fmt.Fprintf(w, "      Crest:       %.1f dB\n", c.CrestFactor)
-			fmt.Fprintf(w, "      Centroid:    %.0f Hz (%s)\n", c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
-			fmt.Fprintf(w, "      Kurtosis:    %.1f (%s)\n", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))
-			if c.VoicingDensity > 0 {
-				fmt.Fprintf(w, "      Voicing:     %.0f%%\n", c.VoicingDensity*100)
-			}
-			fmt.Fprintln(w)
-		}
-		for _, entry := range displayCandidates {
-			i := entry.index
-			c := entry.candidate
-			writeCompactAnalysisSpeechCandidateRow(w, i, c)
-			fmt.Fprintln(w)
-		}
-		writeSpeechRejectionSummary(w, measurements.SpeechCandidates)
-	} else if measurements.SpeechProfile != nil {
-		fmt.Fprintf(w, "  Sample:         %.1fs at %s\n",
-			measurements.SpeechProfile.Region.Duration.Seconds(),
-			formatTimestamp(measurements.SpeechProfile.Region.Start))
-		fmt.Fprintf(w, "  RMS Level:      %.1f dBFS\n", measurements.SpeechProfile.RMSLevel)
-	} else {
-		fmt.Fprintln(w, "  No speech profile available")
-	}
+	writeAnalysisSpeechCandidates(w, measurements)
 	fmt.Fprintln(w)
+}
 
-	// Derived measurements section
+func writeAnalysisDerivedMeasurements(w io.Writer, measurements *processor.AudioMeasurements) {
 	writeAnalysisSection(w, "DERIVED MEASUREMENTS")
 	if measurements.NoiseProfile != nil {
-		fmt.Fprintf(w, "  Noise Floor:    %.1f dBFS (from elected silence)\n", measurements.NoiseProfile.MeasuredNoiseFloor)
-		// SuggestedGateThreshold is stored as linear amplitude, convert to dB
 		suggestedGateDB := processor.LinearToDb(measurements.SuggestedGateThreshold)
-		fmt.Fprintf(w, "  Gate Baseline:  %.1f dB (noise floor + margin)\n", suggestedGateDB)
-		fmt.Fprintf(w, "  NR Headroom:    %.1f dB (noise-to-speech gap)\n", measurements.NoiseReductionHeadroom)
+		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+			{"Noise Floor", fmt.Sprintf("%.1f dBFS (from elected silence)", measurements.NoiseProfile.MeasuredNoiseFloor)},
+			{"Gate Baseline", fmt.Sprintf("%.1f dB (noise floor + margin)", suggestedGateDB)},
+			{"NR Headroom", fmt.Sprintf("%.1f dB (noise-to-speech gap)", measurements.NoiseReductionHeadroom)},
+		})
 	} else {
-		fmt.Fprintf(w, "  Noise Floor:    %.1f dBFS (%s)\n", measurements.NoiseFloor, noiseFloorSourceLabel(measurements.NoiseFloorSource))
+		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+			{"Noise Floor", fmt.Sprintf("%.1f dBFS (%s)", measurements.NoiseFloor, noiseFloorSourceLabel(measurements.NoiseFloorSource))},
+		})
 	}
 	fmt.Fprintln(w)
+}
 
-	// Filter adaptation section
+func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig) {
 	writeAnalysisSection(w, "FILTER ADAPTATION")
 	if config != nil {
-		fmt.Fprintf(w, "  Highpass:       %.0f Hz (from spectral analysis)\n", config.DS201HPFreq)
+		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+			{"Highpass", fmt.Sprintf("%.0f Hz (from spectral analysis)", config.DS201HPFreq)},
+		})
 		if measurements.NoiseProfile != nil {
 			gateThresholdDB := processor.LinearToDb(config.DS201GateThreshold)
-			// Determine threshold description based on whether SpeechProfile was used
 			gateDesc := "(from noise floor)"
 			if measurements.SpeechProfile != nil {
 				gateDesc = "(with breath reduction)"
 			}
-			fmt.Fprintf(w, "  Gate Threshold: %.1f dB %s\n", gateThresholdDB, gateDesc)
-			fmt.Fprintf(w, "  Gate Ratio:     %.1f:1\n", config.DS201GateRatio)
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"Gate Threshold", fmt.Sprintf("%.1f dB %s", gateThresholdDB, gateDesc)},
+				{"Gate Ratio", fmt.Sprintf("%.1f:1", config.DS201GateRatio)},
+			})
 		}
 		if config.NoiseRemoveCompandEnabled {
-			fmt.Fprintf(w, "  NR Threshold:   %.0f dB\n", config.NoiseRemoveCompandThreshold)
-			fmt.Fprintf(w, "  NR Expansion:   %.0f dB\n", config.NoiseRemoveCompandExpansion)
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"NR Threshold", fmt.Sprintf("%.0f dB", config.NoiseRemoveCompandThreshold)},
+				{"NR Expansion", fmt.Sprintf("%.0f dB", config.NoiseRemoveCompandExpansion)},
+			})
 		} else {
-			fmt.Fprintln(w, "  NR Compander:   disabled")
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"NR Compander", "disabled"},
+			})
 		}
 		if config.DeessIntensity > 0 {
-			fmt.Fprintf(w, "  De-esser:       %.0f%% intensity\n", config.DeessIntensity*100)
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"De-esser", fmt.Sprintf("%.0f%% intensity", config.DeessIntensity*100)},
+			})
 		} else {
-			fmt.Fprintf(w, "  De-esser:       disabled (no sibilance detected)\n")
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"De-esser", "disabled (no sibilance detected)"},
+			})
 		}
-		fmt.Fprintf(w, "  LA-2A Thresh:   %.0f dB\n", config.LA2AThreshold)
-		fmt.Fprintf(w, "  LA-2A Ratio:    %.1f:1\n", config.LA2ARatio)
+		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+			{"LA-2A Thresh", fmt.Sprintf("%.0f dB", config.LA2AThreshold)},
+			{"LA-2A Ratio", fmt.Sprintf("%.1f:1", config.LA2ARatio)},
+		})
 	}
+}
 
-	// Spectral summary (all spectral metrics from aspectralstats)
+func writeAnalysisSpectralSummary(w io.Writer, measurements *processor.AudioMeasurements) {
 	writeAnalysisSection(w, "SPECTRAL SUMMARY")
+	writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+		{"Centroid", fmt.Sprintf("%.0f Hz (%s)", measurements.SpectralCentroid, interpretCentroid(measurements.SpectralCentroid))},
+		{"Spread", fmt.Sprintf("%.0f Hz (%s)", measurements.SpectralSpread, interpretSpread(measurements.SpectralSpread))},
+		{"Rolloff", fmt.Sprintf("%.0f Hz (%s)", measurements.SpectralRolloff, interpretRolloff(measurements.SpectralRolloff))},
+		{"Flatness", fmt.Sprintf("%.3f (%s)", measurements.SpectralFlatness, interpretFlatness(measurements.SpectralFlatness))},
+		{"Kurtosis", fmt.Sprintf("%.1f (%s)", measurements.SpectralKurtosis, interpretKurtosis(measurements.SpectralKurtosis))},
+		{"Skewness", fmt.Sprintf("%.2f (%s)", measurements.SpectralSkewness, interpretSkewness(measurements.SpectralSkewness))},
+		{"Crest", fmt.Sprintf("%.1f (%s)", measurements.SpectralCrest, interpretCrest(measurements.SpectralCrest))},
+		{"Slope", fmt.Sprintf("%.2e (%s)", measurements.SpectralSlope, interpretSlope(measurements.SpectralSlope))},
+		{"Decrease", fmt.Sprintf("%.4f (%s)", measurements.SpectralDecrease, interpretDecrease(measurements.SpectralDecrease))},
+		{"Entropy", fmt.Sprintf("%.3f (%s)", measurements.SpectralEntropy, interpretEntropy(measurements.SpectralEntropy))},
+		{"Flux", fmt.Sprintf("%.4f (%s)", measurements.SpectralFlux, interpretFlux(measurements.SpectralFlux))},
+	})
+}
 
-	// Frequency distribution metrics
-	fmt.Fprintf(w, "  Centroid:       %.0f Hz (%s)\n", measurements.SpectralCentroid, interpretCentroid(measurements.SpectralCentroid))
-	fmt.Fprintf(w, "  Spread:         %.0f Hz (%s)\n", measurements.SpectralSpread, interpretSpread(measurements.SpectralSpread))
-	fmt.Fprintf(w, "  Rolloff:        %.0f Hz (%s)\n", measurements.SpectralRolloff, interpretRolloff(measurements.SpectralRolloff))
-
-	// Distribution shape metrics
-	fmt.Fprintf(w, "  Flatness:       %.3f (%s)\n", measurements.SpectralFlatness, interpretFlatness(measurements.SpectralFlatness))
-	fmt.Fprintf(w, "  Kurtosis:       %.1f (%s)\n", measurements.SpectralKurtosis, interpretKurtosis(measurements.SpectralKurtosis))
-	fmt.Fprintf(w, "  Skewness:       %.2f (%s)\n", measurements.SpectralSkewness, interpretSkewness(measurements.SpectralSkewness))
-	fmt.Fprintf(w, "  Crest:          %.1f (%s)\n", measurements.SpectralCrest, interpretCrest(measurements.SpectralCrest))
-
-	// Spectral slope/energy metrics
-	fmt.Fprintf(w, "  Slope:          %.2e (%s)\n", measurements.SpectralSlope, interpretSlope(measurements.SpectralSlope))
-	fmt.Fprintf(w, "  Decrease:       %.4f (%s)\n", measurements.SpectralDecrease, interpretDecrease(measurements.SpectralDecrease))
-
-	// Dynamics and disorder metrics
-	fmt.Fprintf(w, "  Entropy:        %.3f (%s)\n", measurements.SpectralEntropy, interpretEntropy(measurements.SpectralEntropy))
-	fmt.Fprintf(w, "  Flux:           %.4f (%s)\n", measurements.SpectralFlux, interpretFlux(measurements.SpectralFlux))
-
-	// Recording tips section
+func writeAnalysisTips(w io.Writer, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig) {
 	tips := GenerateRecordingTips(measurements, config)
 	fmt.Fprintln(w)
 	writeAnalysisSection(w, "RECORDING TIPS")
@@ -241,22 +190,25 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 			fmt.Fprintf(w, "  ⚠ %s\n", wrapped)
 		}
 	}
-
-	if len(timings) > 0 && hasAnalysisTimings(timings[0]) {
-		fmt.Fprintln(w)
-		writeAnalysisTimingSection(w, completeAnalysisTimings(timings[0], reportOutputStart))
-	}
 }
 
 func hasAnalysisTimings(timings AnalysisTimings) bool {
 	return timings.Analysis > 0 || timings.Adaptation > 0 || timings.ReportOutput > 0
 }
 
+func writeAnalysisMetricRows(w io.Writer, indent string, labelWidth int, rows []analysisMetricSpec) {
+	for _, row := range rows {
+		fmt.Fprintf(w, "%s%-*s %s\n", indent, labelWidth, row.Label+":", row.Value)
+	}
+}
+
 func writeAnalysisTimingSection(w io.Writer, timings AnalysisTimings) {
 	writeAnalysisSection(w, "ANALYSIS TIMINGS")
-	fmt.Fprintf(w, "  Analysis:      %s\n", formatDurationHMS(timings.Analysis.Seconds()))
-	fmt.Fprintf(w, "  Adaptation:    %s\n", formatDurationHMS(timings.Adaptation.Seconds()))
-	fmt.Fprintf(w, "  Report Output: %s\n", formatDurationHMS(timings.ReportOutput.Seconds()))
+	writeAnalysisMetricRows(w, "  ", 14, []analysisMetricSpec{
+		{"Analysis", formatDuration(timings.Analysis)},
+		{"Adaptation", formatDuration(timings.Adaptation)},
+		{"Report Output", formatDuration(timings.ReportOutput)},
+	})
 }
 
 func completeAnalysisTimings(timings AnalysisTimings, reportOutputStart time.Time) AnalysisTimings {
@@ -266,16 +218,167 @@ func completeAnalysisTimings(timings AnalysisTimings, reportOutputStart time.Tim
 	return timings
 }
 
+func writeAnalysisSilenceCandidates(w io.Writer, measurements *processor.AudioMeasurements) {
+	if len(measurements.SilenceCandidates) == 0 {
+		writeAnalysisSilenceFallback(w, measurements)
+		return
+	}
+
+	electedCandidate, displayCandidates := rankedSilenceCandidateEntries(measurements)
+	writeAnalysisCandidateFlow(
+		w,
+		len(measurements.SilenceCandidates),
+		electedCandidate,
+		displayCandidates,
+		func() {
+			if measurements.VoiceActivated {
+				fmt.Fprintln(w, "  Voice-activated recording detected")
+			}
+		},
+		func(w io.Writer, entry candidateDisplayEntry[processor.SilenceCandidateMetrics]) {
+			writeAnalysisSilenceCandidateMetrics(w, entry, measurements)
+		},
+		func(w io.Writer, entry candidateDisplayEntry[processor.SilenceCandidateMetrics]) {
+			writeCompactAnalysisSilenceCandidateRow(w, entry.index, entry.candidate)
+		},
+		func() {
+			writeSilenceRejectionSummary(w, measurements.SilenceCandidates)
+		},
+	)
+}
+
+func writeAnalysisSilenceFallback(w io.Writer, measurements *processor.AudioMeasurements) {
+	if measurements.NoiseProfile != nil {
+		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+			{"Sample", fmt.Sprintf("%.1fs at %s", measurements.NoiseProfile.Duration.Seconds(), formatTimestamp(measurements.NoiseProfile.Start))},
+			{"Noise Floor", fmt.Sprintf("%.1f dBFS", measurements.NoiseProfile.MeasuredNoiseFloor)},
+		})
+		return
+	}
+
+	fmt.Fprintln(w, "  No silence detected")
+	if measurements.VoiceActivated {
+		fmt.Fprintln(w, "  Voice-activated recording detected")
+	}
+}
+
+func writeAnalysisSpeechCandidates(w io.Writer, measurements *processor.AudioMeasurements) {
+	if len(measurements.SpeechCandidates) == 0 {
+		writeAnalysisSpeechFallback(w, measurements)
+		return
+	}
+
+	electedCandidate, displayCandidates := rankedSpeechCandidateEntries(measurements)
+	writeAnalysisCandidateFlow(
+		w,
+		len(measurements.SpeechCandidates),
+		electedCandidate,
+		displayCandidates,
+		nil,
+		writeAnalysisSpeechCandidateMetrics,
+		func(w io.Writer, entry candidateDisplayEntry[processor.SpeechCandidateMetrics]) {
+			writeCompactAnalysisSpeechCandidateRow(w, entry.index, entry.candidate)
+		},
+		func() {
+			writeSpeechRejectionSummary(w, measurements.SpeechCandidates)
+		},
+	)
+}
+
+func writeAnalysisSpeechFallback(w io.Writer, measurements *processor.AudioMeasurements) {
+	if measurements.SpeechProfile != nil {
+		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+			{"Sample", fmt.Sprintf("%.1fs at %s", measurements.SpeechProfile.Region.Duration.Seconds(), formatTimestamp(measurements.SpeechProfile.Region.Start))},
+			{"RMS Level", fmt.Sprintf("%.1f dBFS", measurements.SpeechProfile.RMSLevel)},
+		})
+		return
+	}
+
+	fmt.Fprintln(w, "  No speech profile available")
+}
+
+func writeAnalysisCandidateFlow[T any](
+	w io.Writer,
+	totalCandidates int,
+	electedCandidate *candidateDisplayEntry[T],
+	displayCandidates []candidateDisplayEntry[T],
+	afterSummary func(),
+	writeElected func(io.Writer, candidateDisplayEntry[T]),
+	writeDisplayed func(io.Writer, candidateDisplayEntry[T]),
+	writeRejected func(),
+) {
+	fmt.Fprintf(w, "  Candidates:     %d evaluated\n", totalCandidates)
+	if summary := candidateDisplaySummary(totalCandidates, electedCandidate != nil, len(displayCandidates)); summary != "" {
+		fmt.Fprintf(w, "  Displayed:      %s\n", summary)
+	}
+	if afterSummary != nil {
+		afterSummary()
+	}
+
+	if electedCandidate != nil || len(displayCandidates) > 0 {
+		fmt.Fprintln(w)
+		if electedCandidate != nil {
+			writeElected(w, *electedCandidate)
+			fmt.Fprintln(w)
+		}
+		for _, entry := range displayCandidates {
+			writeDisplayed(w, entry)
+			fmt.Fprintln(w)
+		}
+	}
+
+	writeRejected()
+}
+
 // writeSilenceCandidateMetrics writes the metric lines for a single silence candidate.
 func writeSilenceCandidateMetrics(w io.Writer, c processor.SilenceCandidateMetrics) {
-	fmt.Fprintf(w, "      Score:       %.3f\n", c.Score)
-	fmt.Fprintf(w, "      RMS Level:   %.1f dBFS\n", c.RMSLevel)
-	fmt.Fprintf(w, "      Peak Level:  %.1f dBFS\n", c.PeakLevel)
-	fmt.Fprintf(w, "      Crest:       %.1f dB\n", c.CrestFactor)
-	fmt.Fprintf(w, "      Entropy:     %.3f (%s)\n", c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))
-	fmt.Fprintf(w, "      Flatness:    %.3f (%s)\n", c.Spectral.Flatness, interpretFlatness(c.Spectral.Flatness))
-	fmt.Fprintf(w, "      Kurtosis:    %.1f (%s)\n", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))
-	fmt.Fprintf(w, "      Centroid:    %.0f Hz\n", c.Spectral.Centroid)
+	writeAnalysisMetricRows(w, "      ", 12, []analysisMetricSpec{
+		{"Score", fmt.Sprintf("%.3f", c.Score)},
+		{"RMS Level", fmt.Sprintf("%.1f dBFS", c.RMSLevel)},
+		{"Peak Level", fmt.Sprintf("%.1f dBFS", c.PeakLevel)},
+		{"Crest", fmt.Sprintf("%.1f dB", c.CrestFactor)},
+		{"Entropy", fmt.Sprintf("%.3f (%s)", c.Spectral.Entropy, interpretEntropy(c.Spectral.Entropy))},
+		{"Flatness", fmt.Sprintf("%.3f (%s)", c.Spectral.Flatness, interpretFlatness(c.Spectral.Flatness))},
+		{"Kurtosis", fmt.Sprintf("%.1f (%s)", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))},
+		{"Centroid", fmt.Sprintf("%.0f Hz", c.Spectral.Centroid)},
+	})
+}
+
+func writeAnalysisSilenceCandidateMetrics(w io.Writer, entry candidateDisplayEntry[processor.SilenceCandidateMetrics], measurements *processor.AudioMeasurements) {
+	c := entry.candidate
+	fmt.Fprintf(w, "  #%d: %.1fs at %s (elected)\n",
+		entry.index+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
+	if measurements.NoiseProfile.WasRefined {
+		fmt.Fprintf(w, "      Refined:     %.1fs at %s (golden sub-region)\n",
+			measurements.NoiseProfile.Duration.Seconds(), formatTimestamp(measurements.NoiseProfile.Start))
+	}
+	writeSilenceCandidateMetrics(w, c)
+}
+
+func writeAnalysisSpeechCandidateMetrics(w io.Writer, entry candidateDisplayEntry[processor.SpeechCandidateMetrics]) {
+	c := entry.candidate
+	fmt.Fprintf(w, "  #%d: %.1fs at %s (elected)\n",
+		entry.index+1, c.Region.Duration.Seconds(), formatTimestamp(c.Region.Start))
+
+	if c.WasRefined {
+		fmt.Fprintf(w, "      Refined:     %.1fs at %s -> %.1fs at %s (golden sub-region)\n",
+			c.OriginalDuration.Seconds(),
+			formatTimestamp(c.OriginalStart),
+			c.Region.Duration.Seconds(),
+			formatTimestamp(c.Region.Start))
+	}
+
+	rows := []analysisMetricSpec{
+		{"Score", fmt.Sprintf("%.2f", c.Score)},
+		{"RMS Level", fmt.Sprintf("%.1f dBFS", c.RMSLevel)},
+		{"Crest", fmt.Sprintf("%.1f dB", c.CrestFactor)},
+		{"Centroid", fmt.Sprintf("%.0f Hz (%s)", c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))},
+		{"Kurtosis", fmt.Sprintf("%.1f (%s)", c.Spectral.Kurtosis, interpretKurtosis(c.Spectral.Kurtosis))},
+	}
+	if c.VoicingDensity > 0 {
+		rows = append(rows, analysisMetricSpec{"Voicing", fmt.Sprintf("%.0f%%", c.VoicingDensity*100)})
+	}
+	writeAnalysisMetricRows(w, "      ", 12, rows)
 }
 
 func writeCompactAnalysisSilenceCandidateRow(w io.Writer, index int, c processor.SilenceCandidateMetrics) {
@@ -341,23 +444,6 @@ func noiseFloorSourceLabel(source string) string {
 // writeAnalysisSection writes a section header for analysis output.
 func writeAnalysisSection(w io.Writer, title string) {
 	fmt.Fprintln(w, title)
-}
-
-// formatDurationHMS formats duration as "Xh Ym Zs" or "Ym Zs" or "Z.Xs".
-func formatDurationHMS(seconds float64) string {
-	if seconds < 60 {
-		return fmt.Sprintf("%.1fs", seconds)
-	}
-
-	totalSeconds := int(seconds)
-	hours := totalSeconds / 3600
-	minutes := (totalSeconds % 3600) / 60
-	secs := totalSeconds % 60
-
-	if hours > 0 {
-		return fmt.Sprintf("%dh %dm %ds", hours, minutes, secs)
-	}
-	return fmt.Sprintf("%dm %ds", minutes, secs)
 }
 
 // formatTimestamp formats a duration as a timestamp string (e.g., "1m 32s" or "24.0s").

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -35,6 +35,102 @@ func makeMinimalMetadata() *audio.Metadata {
 	}
 }
 
+func makeFullAnalysisMeasurements() *processor.AudioMeasurements {
+	m := makeMinimalMeasurements()
+	m.InputI = -18.4
+	m.InputTP = -2.1
+	m.InputLRA = 7.8
+	m.RMSLevel = -28.2
+	m.PeakLevel = -7.4
+	m.DynamicRange = 20.8
+	m.CrestFactor = 11.4
+	m.PreScanNoiseFloor = -58.4
+	m.SilenceDetectLevel = -57.4
+	m.NoiseFloor = -58.4
+	m.NoiseFloorSource = "silence_profile"
+	m.SuggestedGateThreshold = processor.DbToLinear(-52.4)
+	m.NoiseReductionHeadroom = 24.6
+	m.SpectralCentroid = 2450
+	m.SpectralSpread = 1800
+	m.SpectralRolloff = 7200
+	m.SpectralFlatness = 0.210
+	m.SpectralKurtosis = 9.7
+	m.SpectralSkewness = 0.82
+	m.SpectralCrest = 12.6
+	m.SpectralSlope = -1.20e-03
+	m.SpectralDecrease = -0.0123
+	m.SpectralEntropy = 0.365
+	m.SpectralFlux = 0.0820
+	m.NoiseProfile = &processor.NoiseProfile{
+		Start:              6 * time.Second,
+		Duration:           4 * time.Second,
+		MeasuredNoiseFloor: -58.4,
+		PeakLevel:          -44.0,
+		CrestFactor:        14.4,
+		Entropy:            0.365,
+		SpectralFlatness:   0.210,
+		SpectralKurtosis:   9.7,
+		WasRefined:         true,
+		OriginalStart:      5 * time.Second,
+		OriginalDuration:   8 * time.Second,
+	}
+	m.SilenceCandidates = []processor.SilenceCandidateMetrics{
+		{
+			Region:      processor.SilenceRegion{Start: 5 * time.Second, Duration: 8 * time.Second},
+			RMSLevel:    -58.4,
+			PeakLevel:   -44.0,
+			CrestFactor: 14.4,
+			Spectral: processor.SpectralMetrics{
+				Entropy:  0.365,
+				Flatness: 0.210,
+				Kurtosis: 9.7,
+				Centroid: 2450,
+			},
+			Score: 0.910,
+		},
+		{
+			Region:      processor.SilenceRegion{Start: 40 * time.Second, Duration: 3 * time.Second},
+			RMSLevel:    -56.1,
+			CrestFactor: 10.2,
+			Spectral:    processor.SpectralMetrics{Entropy: 0.620},
+			Score:       0.420,
+		},
+		{
+			Region:           processor.SilenceRegion{Start: 70 * time.Second, Duration: 2 * time.Second},
+			TransientWarning: "rejected: digital silence",
+			Score:            0,
+		},
+	}
+	m.SpeechCandidates = []processor.SpeechCandidateMetrics{
+		{
+			Region:      processor.SpeechRegion{Start: 15 * time.Second, Duration: 60 * time.Second},
+			RMSLevel:    -33.8,
+			PeakLevel:   -9.0,
+			CrestFactor: 12.8,
+			Spectral: processor.SpectralMetrics{
+				Centroid: 2450,
+				Kurtosis: 9.7,
+				Rolloff:  7200,
+			},
+			VoicingDensity: 0.76,
+			Score:          0.88,
+		},
+		{
+			Region:      processor.SpeechRegion{Start: 90 * time.Second, Duration: 20 * time.Second},
+			RMSLevel:    -35.2,
+			CrestFactor: 11.0,
+			Spectral:    processor.SpectralMetrics{Centroid: 3100},
+			Score:       0.55,
+		},
+		{
+			Region: processor.SpeechRegion{Start: 115 * time.Second, Duration: 5 * time.Second},
+			Score:  0,
+		},
+	}
+	m.SpeechProfile = &m.SpeechCandidates[0]
+	return m
+}
+
 func TestDisplayAnalysisResults_VoiceActivated_NoElectedCandidate(t *testing.T) {
 	m := makeMinimalMeasurements()
 	m.VoiceActivated = true
@@ -53,6 +149,127 @@ func TestDisplayAnalysisResults_VoiceActivated_NoElectedCandidate(t *testing.T) 
 
 	if !strings.Contains(output, "Voice-activated recording detected") {
 		t.Error("expected 'Voice-activated recording detected' in output for voice-activated recording with no elected candidate")
+	}
+}
+
+func TestDisplayAnalysisResults_FullOutputFixture(t *testing.T) {
+	m := makeFullAnalysisMeasurements()
+	config := processor.DefaultFilterConfig()
+	config.NoiseRemoveCompandEnabled = true
+	config.NoiseRemoveCompandThreshold = -53
+	config.NoiseRemoveCompandExpansion = 7
+	config.DeessIntensity = 0.35
+	config.LA2AThreshold = -21
+	config.LA2ARatio = 2.5
+	config.DS201HPFreq = 85
+	config.DS201GateThreshold = processor.DbToLinear(-51.2)
+	config.DS201GateRatio = 3.0
+	timings := AnalysisTimings{
+		Analysis:     2*time.Minute + 3*time.Second,
+		Adaptation:   1500 * time.Millisecond,
+		ReportOutput: 250 * time.Millisecond,
+	}
+
+	var buf bytes.Buffer
+	DisplayAnalysisResults(&buf, "/tmp/full-fixture.wav", &audio.Metadata{
+		Duration:   3672.0,
+		SampleRate: 48000,
+		Channels:   2,
+	}, m, config, timings)
+
+	const want = `======================================================================
+ANALYSIS: full-fixture.wav
+======================================================================
+Duration:    1h 1m 12s
+Sample Rate: 48000 Hz
+Channels:    stereo
+
+LOUDNESS
+  Integrated:     -18.4 LUFS
+  True Peak:      -2.1 dBTP
+  Loudness Range: 7.8 LU
+
+DYNAMICS
+  RMS Level:      -28.2 dBFS
+  Peak Level:     -7.4 dBFS
+  Dynamic Range:  20.8 dB
+  Crest Factor:   12.8 dB (speech)
+
+SILENCE DETECTION
+  Threshold:      -57.4 dB (-58.4 dBFS room tone estimate + 1 dB)
+  Candidates:     3 evaluated
+  Displayed:      elected + 1 chronological (1 omitted)
+
+  #1: 8.0s at 5.0s (elected)
+      Refined:     4.0s at 6.0s (golden sub-region)
+      Score:       0.910
+      RMS Level:   -58.4 dBFS
+      Peak Level:  -44.0 dBFS
+      Crest:       14.4 dB
+      Entropy:     0.365 (mixed voiced/unvoiced)
+      Flatness:    0.210 (very tonal, strong harmonics)
+      Kurtosis:    9.7 (leptokurtic, clear harmonics)
+      Centroid:    2450 Hz
+
+  #2: 3.0s at 40.0s (score: 0.420)
+      RMS: -56.1 dBFS, Crest: 10.2 dB, Entropy: 0.620 (disordered, fricatives)
+
+  Rejected:       1 digital silence
+
+SPEECH DETECTION
+  Candidates:     3 evaluated
+  Displayed:      elected + 1 chronological (1 omitted)
+
+  #1: 60.0s at 15.0s (elected)
+      Score:       0.88
+      RMS Level:   -33.8 dBFS
+      Crest:       12.8 dB
+      Centroid:    2450 Hz (forward, clear)
+      Kurtosis:    9.7 (leptokurtic, clear harmonics)
+      Voicing:     76%
+
+  #2: 20.0s at 1m 30s (score: 0.55)
+      RMS: -35.2 dBFS, Crest: 11.0 dB, Centroid: 3100 Hz (bright, articulate)
+
+  Rejected:       1 zero score
+
+DERIVED MEASUREMENTS
+  Noise Floor:    -58.4 dBFS (from elected silence)
+  Gate Baseline:  -52.4 dB (noise floor + margin)
+  NR Headroom:    24.6 dB (noise-to-speech gap)
+
+FILTER ADAPTATION
+  Highpass:       85 Hz (from spectral analysis)
+  Gate Threshold: -51.2 dB (with breath reduction)
+  Gate Ratio:     3.0:1
+  NR Threshold:   -53 dB
+  NR Expansion:   7 dB
+  De-esser:       35% intensity
+  LA-2A Thresh:   -21 dB
+  LA-2A Ratio:    2.5:1
+SPECTRAL SUMMARY
+  Centroid:       2450 Hz (forward, clear)
+  Spread:         1800 Hz (moderate, natural speech)
+  Rolloff:        7200 Hz (good articulation)
+  Flatness:       0.210 (very tonal, strong harmonics)
+  Kurtosis:       9.7 (leptokurtic, clear harmonics)
+  Skewness:       0.82 (LF emphasis with HF tail (typical voice))
+  Crest:          12.6 (moderate peaks)
+  Slope:          -1.20e-03 (very steep slope, dark/warm)
+  Decrease:       -0.0123 (strong bass emphasis)
+  Entropy:        0.365 (mixed voiced/unvoiced)
+  Flux:           0.0820 (high variation, transients)
+
+RECORDING TIPS
+  ✓ Your recording setup looks good. No issues detected.
+
+ANALYSIS TIMINGS
+  Analysis:      2m 3s
+  Adaptation:    1.5s
+  Report Output: 0.2s
+`
+	if got := buf.String(); got != want {
+		t.Fatalf("DisplayAnalysisResults output mismatch\nwant:\n%s\ngot:\n%s", want, got)
 	}
 }
 

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -554,8 +554,6 @@ func formatFilter(f *os.File, filterID processor.FilterID, cfg *processor.Filter
 		formatLA2ACompressorFilter(f, cfg, m, prefix)
 	case processor.FilterDeesser:
 		formatDeesserFilter(f, cfg, m, prefix)
-	case processor.FilterVolumax:
-		formatVolumaxFilter(f, cfg, m, prefix)
 	default:
 		fmt.Fprintf(f, "%s%s: (unknown filter)\n", prefix, filterID)
 	}
@@ -929,73 +927,6 @@ func formatDeesserFilter(f *os.File, cfg *processor.FilterChainConfig, m *proces
 		fmt.Fprintf(f, "        Rationale: %s voice\n", voiceType)
 		fmt.Fprintf(f, "        spectral centroid: %.0f Hz (%s)\n", centroid, centroidSource)
 		fmt.Fprintf(f, "        spectral rolloff: %.0f Hz (%s)\n", rolloff, rolloffSource)
-	}
-}
-
-// formatVolumaxFilter outputs CBS Volumax-inspired limiter filter details with rationale
-func formatVolumaxFilter(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
-	if !cfg.VolumaxEnabled {
-		fmt.Fprintf(f, "%sCBS Volumax limiter: DISABLED\n", prefix)
-		return
-	}
-
-	// Header with ceiling
-	fmt.Fprintf(f, "%sCBS Volumax limiter: ceiling %.1f dBTP\n", prefix, cfg.VolumaxCeiling)
-
-	// Timing with classification
-	attackClass := classifyVolumaxAttack(cfg.VolumaxAttack)
-	releaseClass := classifyVolumaxRelease(cfg.VolumaxRelease)
-	fmt.Fprintf(f, "        Timing: attack %.1fms (%s), release %.0fms (%s)\n",
-		cfg.VolumaxAttack, attackClass, cfg.VolumaxRelease, releaseClass)
-
-	// ASC mode
-	if cfg.VolumaxASC {
-		fmt.Fprintf(f, "        ASC: enabled (level %.2f) — program-dependent release\n", cfg.VolumaxASCLevel)
-	} else {
-		fmt.Fprintln(f, "        ASC: disabled — direct limiting")
-	}
-
-	// Gain staging (only show if not unity)
-	if cfg.VolumaxInputLevel != 1.0 || cfg.VolumaxOutputLevel != 1.0 {
-		inputDB := processor.LinearToDb(cfg.VolumaxInputLevel)
-		outputDB := processor.LinearToDb(cfg.VolumaxOutputLevel)
-		fmt.Fprintf(f, "        Gain: input %.1f dB, output %.1f dB\n", inputDB, outputDB)
-	}
-
-	// Rationale from measurements
-	if m != nil {
-		// Normalize MaxDifference to percentage (from sample units 0-32768)
-		maxDiffPct := (m.MaxDifference / 32768.0) * 100
-		fmt.Fprintf(f, "        Rationale: MaxDiff %.1f%%, Crest %.1f dB, DR %.1f dB, Flux %.4f\n",
-			maxDiffPct, m.SpectralCrest, m.DynamicRange, m.SpectralFlux)
-	}
-}
-
-// classifyVolumaxAttack returns a human-readable attack classification
-func classifyVolumaxAttack(attack float64) string {
-	switch {
-	case attack <= 2:
-		return "fast (may introduce artifacts)"
-	case attack <= 5:
-		return "transparent"
-	case attack <= 10:
-		return "very gentle"
-	default:
-		return "slow"
-	}
-}
-
-// classifyVolumaxRelease returns a human-readable release classification
-func classifyVolumaxRelease(release float64) string {
-	switch {
-	case release >= 150:
-		return "very smooth"
-	case release >= 100:
-		return "smooth"
-	case release >= 50:
-		return "moderate"
-	default:
-		return "fast (may pump)"
 	}
 }
 

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -17,14 +17,9 @@ import (
 
 const candidateDisplayLimit = 10
 
-type silenceCandidateDisplayEntry struct {
+type candidateDisplayEntry[T any] struct {
 	index     int
-	candidate processor.SilenceCandidateMetrics
-}
-
-type speechCandidateDisplayEntry struct {
-	index     int
-	candidate processor.SpeechCandidateMetrics
+	candidate T
 }
 
 // ============================================================================
@@ -1025,95 +1020,25 @@ func writeLoudnessTable(f *os.File, input *processor.AudioMeasurements, filtered
 
 	table := NewMetricTable()
 
-	// Integrated Loudness
-	inputI := math.NaN()
-	filteredI := math.NaN()
-	finalI := math.NaN()
-	if input != nil {
-		inputI = input.InputI
+	v := func(inputField func(*processor.AudioMeasurements) float64, outputField func(*processor.OutputMeasurements) float64) [3]float64 {
+		return [3]float64{
+			valOr(input, inputField),
+			valOr(filtered, outputField),
+			valOr(final, outputField),
+		}
 	}
-	if filtered != nil {
-		filteredI = filtered.OutputI
-	}
-	if final != nil {
-		finalI = final.OutputI
-	}
-	table.AddMetricRow("Integrated Loudness", inputI, filteredI, finalI, 1, "LUFS", "")
 
-	// True Peak
-	inputTP := math.NaN()
-	filteredTP := math.NaN()
-	finalTP := math.NaN()
-	if input != nil {
-		inputTP = input.InputTP
+	specs := []threeColMetricSpec{
+		{"Integrated Loudness", v(func(m *processor.AudioMeasurements) float64 { return m.InputI }, func(m *processor.OutputMeasurements) float64 { return m.OutputI }), 1, "LUFS", 0, nil},
+		{"True Peak", v(func(m *processor.AudioMeasurements) float64 { return m.InputTP }, func(m *processor.OutputMeasurements) float64 { return m.OutputTP }), 1, "dBTP", 0, nil},
+		{"Loudness Range", v(func(m *processor.AudioMeasurements) float64 { return m.InputLRA }, func(m *processor.OutputMeasurements) float64 { return m.OutputLRA }), 1, "LU", 0, nil},
+		{"Sample Peak", v(func(m *processor.AudioMeasurements) float64 { return m.SamplePeak }, func(m *processor.OutputMeasurements) float64 { return m.SamplePeak }), 1, "dBFS", 0, nil},
+		{"Momentary Loudness", v(func(m *processor.AudioMeasurements) float64 { return m.MomentaryLoudness }, func(m *processor.OutputMeasurements) float64 { return m.MomentaryLoudness }), 1, "LUFS", 0, nil},
+		{"Short-term Loudness", v(func(m *processor.AudioMeasurements) float64 { return m.ShortTermLoudness }, func(m *processor.OutputMeasurements) float64 { return m.ShortTermLoudness }), 1, "LUFS", 0, nil},
 	}
-	if filtered != nil {
-		filteredTP = filtered.OutputTP
+	for _, s := range specs {
+		table.AddMetricRow(s.label, s.vals[0], s.vals[1], s.vals[2], s.decimals, s.unit, "")
 	}
-	if final != nil {
-		finalTP = final.OutputTP
-	}
-	table.AddMetricRow("True Peak", inputTP, filteredTP, finalTP, 1, "dBTP", "")
-
-	// Loudness Range
-	inputLRA := math.NaN()
-	filteredLRA := math.NaN()
-	finalLRA := math.NaN()
-	if input != nil {
-		inputLRA = input.InputLRA
-	}
-	if filtered != nil {
-		filteredLRA = filtered.OutputLRA
-	}
-	if final != nil {
-		finalLRA = final.OutputLRA
-	}
-	table.AddMetricRow("Loudness Range", inputLRA, filteredLRA, finalLRA, 1, "LU", "")
-
-	// Sample Peak
-	inputSP := math.NaN()
-	filteredSP := math.NaN()
-	finalSP := math.NaN()
-	if input != nil {
-		inputSP = input.SamplePeak
-	}
-	if filtered != nil {
-		filteredSP = filtered.SamplePeak
-	}
-	if final != nil {
-		finalSP = final.SamplePeak
-	}
-	table.AddMetricRow("Sample Peak", inputSP, filteredSP, finalSP, 1, "dBFS", "")
-
-	// Momentary Loudness
-	inputML := math.NaN()
-	filteredML := math.NaN()
-	finalML := math.NaN()
-	if input != nil {
-		inputML = input.MomentaryLoudness
-	}
-	if filtered != nil {
-		filteredML = filtered.MomentaryLoudness
-	}
-	if final != nil {
-		finalML = final.MomentaryLoudness
-	}
-	table.AddMetricRow("Momentary Loudness", inputML, filteredML, finalML, 1, "LUFS", "")
-
-	// Short-term Loudness
-	inputSTL := math.NaN()
-	filteredSTL := math.NaN()
-	finalSTL := math.NaN()
-	if input != nil {
-		inputSTL = input.ShortTermLoudness
-	}
-	if filtered != nil {
-		filteredSTL = filtered.ShortTermLoudness
-	}
-	if final != nil {
-		finalSTL = final.ShortTermLoudness
-	}
-	table.AddMetricRow("Short-term Loudness", inputSTL, filteredSTL, finalSTL, 1, "LUFS", "")
 
 	fmt.Fprint(f, table.String())
 	fmt.Fprintln(f, "")
@@ -1684,42 +1609,17 @@ func writeReportRejectionSummary(f *os.File, candidates []processor.SilenceCandi
 	writeReportCandidateRejectionSummary(f, silenceRejectionSummary(candidates))
 }
 
-func rankedSilenceCandidateEntries(measurements *processor.AudioMeasurements) (*silenceCandidateDisplayEntry, []silenceCandidateDisplayEntry) {
+func rankedSilenceCandidateEntries(measurements *processor.AudioMeasurements) (*candidateDisplayEntry[processor.SilenceCandidateMetrics], []candidateDisplayEntry[processor.SilenceCandidateMetrics]) {
 	if measurements == nil || len(measurements.SilenceCandidates) == 0 {
 		return nil, nil
 	}
 
-	entries := make([]silenceCandidateDisplayEntry, 0, len(measurements.SilenceCandidates))
-	var elected *silenceCandidateDisplayEntry
-	for i, c := range measurements.SilenceCandidates {
-		entry := silenceCandidateDisplayEntry{index: i, candidate: c}
-		if isSelectedSilenceCandidate(c, measurements) {
-			electedEntry := entry
-			elected = &electedEntry
-			continue
-		}
-		if c.Score == 0.0 {
-			continue
-		}
-		entries = append(entries, entry)
-	}
-
-	sort.SliceStable(entries, func(i, j int) bool {
-		if entries[i].candidate.Region.Start == entries[j].candidate.Region.Start {
-			return entries[i].index < entries[j].index
-		}
-		return entries[i].candidate.Region.Start < entries[j].candidate.Region.Start
-	})
-
-	return elected, selectSilenceCandidateEntries(entries)
-}
-
-func selectSilenceCandidateEntries(entries []silenceCandidateDisplayEntry) []silenceCandidateDisplayEntry {
-	displayCount := min(candidateDisplayLimit, len(entries))
-
-	displayed := make([]silenceCandidateDisplayEntry, displayCount)
-	copy(displayed, entries[:displayCount])
-	return displayed
+	return rankedCandidateEntries(
+		measurements.SilenceCandidates,
+		func(c processor.SilenceCandidateMetrics) bool { return isSelectedSilenceCandidate(c, measurements) },
+		func(c processor.SilenceCandidateMetrics) time.Duration { return c.Region.Start },
+		func(c processor.SilenceCandidateMetrics) float64 { return c.Score },
+	)
 }
 
 func isSelectedSilenceCandidate(c processor.SilenceCandidateMetrics, measurements *processor.AudioMeasurements) bool {
@@ -1831,40 +1731,51 @@ func writeReportCompactSpeechCandidateRow(f io.Writer, index int, c processor.Sp
 		c.RMSLevel, c.CrestFactor, c.Spectral.Centroid, interpretCentroid(c.Spectral.Centroid))
 }
 
-func rankedSpeechCandidateEntries(measurements *processor.AudioMeasurements) (*speechCandidateDisplayEntry, []speechCandidateDisplayEntry) {
+func rankedSpeechCandidateEntries(measurements *processor.AudioMeasurements) (*candidateDisplayEntry[processor.SpeechCandidateMetrics], []candidateDisplayEntry[processor.SpeechCandidateMetrics]) {
 	if measurements == nil || len(measurements.SpeechCandidates) == 0 {
 		return nil, nil
 	}
 
-	entries := make([]speechCandidateDisplayEntry, 0, len(measurements.SpeechCandidates))
-	var elected *speechCandidateDisplayEntry
-	for i, c := range measurements.SpeechCandidates {
-		entry := speechCandidateDisplayEntry{index: i, candidate: c}
-		if isSelectedSpeechCandidate(c, measurements) {
+	return rankedCandidateEntries(
+		measurements.SpeechCandidates,
+		func(c processor.SpeechCandidateMetrics) bool { return isSelectedSpeechCandidate(c, measurements) },
+		func(c processor.SpeechCandidateMetrics) time.Duration { return c.Region.Start },
+		func(c processor.SpeechCandidateMetrics) float64 { return c.Score },
+	)
+}
+
+func rankedCandidateEntries[T any](candidates []T, isSelected func(T) bool, start func(T) time.Duration, score func(T) float64) (*candidateDisplayEntry[T], []candidateDisplayEntry[T]) {
+	entries := make([]candidateDisplayEntry[T], 0, len(candidates))
+	var elected *candidateDisplayEntry[T]
+	for i, c := range candidates {
+		entry := candidateDisplayEntry[T]{index: i, candidate: c}
+		if isSelected(c) {
 			electedEntry := entry
 			elected = &electedEntry
 			continue
 		}
-		if c.Score == 0.0 {
+		if score(c) == 0.0 {
 			continue
 		}
 		entries = append(entries, entry)
 	}
 
 	sort.SliceStable(entries, func(i, j int) bool {
-		if entries[i].candidate.Region.Start == entries[j].candidate.Region.Start {
+		leftStart := start(entries[i].candidate)
+		rightStart := start(entries[j].candidate)
+		if leftStart == rightStart {
 			return entries[i].index < entries[j].index
 		}
-		return entries[i].candidate.Region.Start < entries[j].candidate.Region.Start
+		return leftStart < rightStart
 	})
 
-	return elected, selectSpeechCandidateEntries(entries)
+	return elected, selectCandidateEntries(entries)
 }
 
-func selectSpeechCandidateEntries(entries []speechCandidateDisplayEntry) []speechCandidateDisplayEntry {
+func selectCandidateEntries[T any](entries []candidateDisplayEntry[T]) []candidateDisplayEntry[T] {
 	displayCount := min(candidateDisplayLimit, len(entries))
 
-	displayed := make([]speechCandidateDisplayEntry, displayCount)
+	displayed := make([]candidateDisplayEntry[T], displayCount)
 	copy(displayed, entries[:displayCount])
 	return displayed
 }

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -548,7 +548,7 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 
 	// Extract noise profile from best silence region (if available)
 	// Uses interval data for all measurements - no file re-reading required
-	silenceResult := findBestSilenceRegion(measurements.SilenceRegions, silenceIntervals, totalDuration)
+	silenceResult := findBestSilenceRegion(measurements.SilenceRegions, silenceIntervals)
 
 	// Store all evaluated candidates for reporting/debugging
 	measurements.SilenceCandidates = silenceResult.Candidates

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -280,23 +280,234 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 	// Default fallback threshold if interval analysis yields insufficient data
 	const defaultNoiseFloor = -50.0
 
-	// Open audio file
+	collection, err := collectAnalysisFrames(filename, config, progressCallback)
+	if err != nil {
+		return nil, err
+	}
+
+	intervals := collection.intervals
+	silenceIntervals := collection.silenceIntervals
+	silMedians := collection.silenceMedians
+
+	measurements, err := buildInputMeasurements(filename, collection, config, defaultNoiseFloor)
+	if err != nil {
+		return nil, err
+	}
+
+	noiseSelection := selectNoiseProfile(measurements, intervals, silenceIntervals, silMedians)
+	selectSpeechProfile(measurements, intervals, noiseSelection)
+
+	assignInputMeasurementSuggestions(measurements)
+
+	return measurements, nil
+}
+
+type noiseProfileSelection struct {
+	silenceResult *findBestSilenceRegionResult
+	noiseProfile  *NoiseProfile
+}
+
+func selectNoiseProfile(measurements *AudioMeasurements, intervals, silenceIntervals []IntervalSample, silMedians silenceMedians) noiseProfileSelection {
+	measurements.SilenceRegions = findSilenceCandidatesFromIntervals(silenceIntervals, measurements.SilenceDetectLevel, silMedians)
+
+	silenceResult := findBestSilenceRegion(measurements.SilenceRegions, silenceIntervals)
+	measurements.SilenceCandidates = silenceResult.Candidates
+	measurements.VoiceActivated = detectVoiceActivated(silenceResult.Candidates)
+
+	selection := noiseProfileSelection{silenceResult: silenceResult}
+	if silenceResult.BestRegion == nil {
+		return selection
+	}
+
+	originalRegion := silenceResult.BestRegion
+	refinedRegion := refineToGoldenSubregion(originalRegion, intervals)
+	wasRefined := refinedRegion.Start != originalRegion.Start || refinedRegion.Duration != originalRegion.Duration
+
+	profile := extractNoiseProfileFromIntervals(refinedRegion, silenceIntervals)
+	if profile == nil {
+		return selection
+	}
+
+	selection.noiseProfile = profile
+	measurements.NoiseProfile = profile
+
+	if wasRefined {
+		profile.WasRefined = true
+		profile.OriginalStart = originalRegion.Start
+		profile.OriginalDuration = originalRegion.Duration
+	}
+
+	if profile.MeasuredNoiseFloor != 0 && !math.IsInf(profile.MeasuredNoiseFloor, -1) {
+		measurements.NoiseFloor = profile.MeasuredNoiseFloor
+		measurements.NoiseFloorSource = "silence_profile"
+	}
+
+	return selection
+}
+
+func selectSpeechProfile(measurements *AudioMeasurements, intervals []IntervalSample, noiseSelection noiseProfileSelection) {
+	speechSearchStart := 30 * time.Second
+	switch {
+	case noiseSelection.silenceResult != nil && noiseSelection.silenceResult.BestRegion != nil:
+		speechSearchStart = noiseSelection.silenceResult.BestRegion.End
+	case len(measurements.SilenceRegions) > 0:
+		speechSearchStart = measurements.SilenceRegions[0].End
+	}
+
+	measurements.SpeechRegions = findSpeechCandidatesFromIntervals(intervals, speechSearchStart, measurements.VoiceActivated, measurements.RMSLevel, measurements.NoiseFloor)
+
+	speechResult := findBestSpeechRegion(measurements.SpeechRegions, intervals, noiseSelection.noiseProfile)
+	measurements.SpeechCandidates = speechResult.Candidates
+
+	if speechResult.BestRegion == nil {
+		return
+	}
+
+	for i := range speechResult.Candidates {
+		if speechResult.Candidates[i].Region.Start == speechResult.BestRegion.Start {
+			measurements.SpeechProfile = &speechResult.Candidates[i]
+			return
+		}
+	}
+}
+
+func buildInputMeasurements(filename string, collection *analysisFrameCollection, config *FilterChainConfig, defaultNoiseFloor float64) (*AudioMeasurements, error) {
+	acc := collection.accumulators
+
+	noiseFloorEstimate, silenceThreshold, ok := estimateNoiseFloorAndThreshold(collection.silenceIntervals, collection.silenceMedians)
+	if !ok {
+		noiseFloorEstimate = defaultNoiseFloor
+		silenceThreshold = calculateAdaptiveSilenceThreshold(defaultNoiseFloor)
+	}
+
+	measurements := &AudioMeasurements{
+		PreScanNoiseFloor:  noiseFloorEstimate,
+		SilenceDetectLevel: silenceThreshold,
+		IntervalSamples:    collection.intervals,
+	}
+
+	if !acc.ebur128Found {
+		return nil, fmt.Errorf("ebur128 measurements not found in metadata for file: %s", filename)
+	}
+
+	measurements.InputI = acc.ebur128InputI
+	measurements.InputTP = acc.ebur128InputTP
+	measurements.InputLRA = acc.ebur128InputLRA
+	measurements.InputThresh = acc.ebur128InputI - 10.0
+	measurements.TargetOffset = config.TargetI - acc.ebur128InputI
+	measurements.MomentaryLoudness = acc.ebur128InputM
+	measurements.ShortTermLoudness = acc.ebur128InputS
+	measurements.SamplePeak = acc.ebur128InputSP
+
+	acc.finalizeSpectral().writeSpectralTo(&measurements.BaseMeasurements)
+	assignAstatsMeasurements(measurements, acc)
+	assignInputNoiseFloor(measurements, acc)
+
+	return measurements, nil
+}
+
+func assignAstatsMeasurements(measurements *AudioMeasurements, acc *metadataAccumulators) {
+	if !acc.astatsFound {
+		return
+	}
+
+	measurements.DynamicRange = acc.astatsDynamicRange
+	measurements.RMSLevel = acc.astatsRMSLevel
+	measurements.PeakLevel = acc.astatsPeakLevel
+	measurements.RMSTrough = acc.astatsRMSTrough
+	measurements.RMSPeak = acc.astatsRMSPeak
+	measurements.DCOffset = acc.astatsDCOffset
+	measurements.FlatFactor = acc.astatsFlatFactor
+	measurements.CrestFactor = acc.astatsCrestFactor
+	measurements.ZeroCrossingsRate = acc.astatsZeroCrossingsRate
+	measurements.ZeroCrossings = acc.astatsZeroCrossings
+	measurements.MaxDifference = acc.astatsMaxDifference
+	measurements.MinDifference = acc.astatsMinDifference
+	measurements.MeanDifference = acc.astatsMeanDifference
+	measurements.RMSDifference = acc.astatsRMSDifference
+	measurements.Entropy = acc.astatsEntropy
+	measurements.MinLevel = acc.astatsMinLevel
+	measurements.MaxLevel = acc.astatsMaxLevel
+	measurements.AstatsNoiseFloor = acc.astatsNoiseFloor
+	measurements.NoiseFloorCount = acc.astatsNoiseFloorCount
+	measurements.BitDepth = acc.astatsBitDepth
+	measurements.NumberOfSamples = acc.astatsNumberOfSamples
+}
+
+func assignInputNoiseFloor(measurements *AudioMeasurements, acc *metadataAccumulators) {
+	switch {
+	case acc.astatsRMSTrough != 0 && !math.IsInf(acc.astatsRMSTrough, -1):
+		measurements.NoiseFloor = acc.astatsRMSTrough
+		measurements.NoiseFloorSource = "astats"
+	case acc.astatsRMSLevel != 0 && !math.IsInf(acc.astatsRMSLevel, -1):
+		measurements.NoiseFloor = acc.astatsRMSLevel - 15.0
+		measurements.NoiseFloorSource = "rms_estimate"
+	default:
+		var noiseFloorOffset float64
+		switch {
+		case measurements.InputI > -20:
+			noiseFloorOffset = 18.0
+		case measurements.InputI > -30:
+			noiseFloorOffset = 12.0
+		default:
+			noiseFloorOffset = 8.0
+		}
+		measurements.NoiseFloor = measurements.InputThresh - noiseFloorOffset
+		measurements.NoiseFloorSource = "ebur128_estimate"
+	}
+
+	if measurements.NoiseFloor < -90.0 {
+		measurements.NoiseFloor = -90.0
+	} else if measurements.NoiseFloor > -30.0 {
+		measurements.NoiseFloor = -30.0
+	}
+}
+
+func assignInputMeasurementSuggestions(measurements *AudioMeasurements) {
+	gateThresholdDB := calculateAdaptiveDS201GateThreshold(measurements.NoiseFloor, measurements.RMSTrough)
+	measurements.SuggestedGateThreshold = math.Pow(10, gateThresholdDB/20.0)
+
+	if measurements.RMSLevel != 0 && measurements.NoiseFloor != 0 {
+		measurements.NoiseReductionHeadroom = measurements.RMSLevel - measurements.NoiseFloor
+		if measurements.NoiseReductionHeadroom < 0 {
+			measurements.NoiseReductionHeadroom = 0
+		}
+		if measurements.NoiseReductionHeadroom > 60 {
+			measurements.NoiseReductionHeadroom = 60
+		}
+		return
+	}
+
+	switch {
+	case measurements.InputI > -20:
+		measurements.NoiseReductionHeadroom = 40.0
+	case measurements.InputI > -30:
+		measurements.NoiseReductionHeadroom = 25.0
+	default:
+		measurements.NoiseReductionHeadroom = 15.0
+	}
+}
+
+type analysisFrameCollection struct {
+	metadata         *audio.Metadata
+	accumulators     *metadataAccumulators
+	intervals        []IntervalSample
+	silenceIntervals []IntervalSample
+	silenceMedians   silenceMedians
+}
+
+func collectAnalysisFrames(filename string, config *FilterChainConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*analysisFrameCollection, error) {
 	reader, metadata, err := audio.OpenAudioFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open audio file: %w", err)
 	}
 	defer reader.Close()
 
-	// Get total duration for progress calculation
 	totalDuration := metadata.Duration
 	sampleRate := float64(metadata.SampleRate)
-
-	// Calculate total frames estimate (duration * sample_rate / samples_per_frame)
-	// For FLAC, typical frame size is 4096 samples
 	samplesPerFrame := 4096.0
 	estimatedTotalFrames := (totalDuration * sampleRate) / samplesPerFrame
 
-	// Create filter graph for Pass 1 analysis (astats + aspectralstats + ebur128)
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := createAnalysisFilterGraph(
 		reader.GetDecoderContext(),
 		config,
@@ -304,9 +515,6 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 	if err != nil {
 		return nil, fmt.Errorf("failed to create filter graph: %w", err)
 	}
-	// NOTE: filterGraph is explicitly freed at the end (not in defer) to ensure
-	// measurements are output via av_log before we try to extract them.
-	// On error paths, we still free it immediately
 	var filterFreed bool
 	defer func() {
 		if !filterFreed && filterGraph != nil {
@@ -314,32 +522,21 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 		}
 	}()
 
-	// Track frames for periodic progress updates
 	frameCount := 0
-	updateInterval := 100 // Send progress update every N frames
+	updateInterval := 100
 	currentLevel := 0.0
 
-	// Accumulators for frame metadata extraction
 	acc := &metadataAccumulators{}
 
-	// Interval sampling for silence detection (250ms windows)
 	const intervalDuration = 250 * time.Millisecond
 	var intervals []IntervalSample
-	// silenceIntervals is the prefix-restricted view fed to the silence pipeline
-	// (room-tone election, noise profile). When config.SilenceScanDuration is zero
-	// (no cap), it is aliased to intervals after the loop. When a cap is set, only
-	// intervals whose start time is before the cap are appended here. The whole-file
-	// intervals slice continues to feed speech detection and measurements.IntervalSamples
-	// so loudness, spectral, and reporting remain whole-file.
 	var silenceIntervals []IntervalSample
 	var intervalAcc intervalAccumulator
 	var intervalStartTime time.Duration
 
-	// Track input frame time (before filter graph, which upsamples to 192kHz)
 	var inputSamplesProcessed int64
 	inputSampleRate := float64(reader.GetDecoderContext().SampleRate())
 
-	// Process all frames through the filter graph
 	if err := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnReadError: func(err error) error {
 			return fmt.Errorf("failed to read frame: %w", err)
@@ -351,19 +548,13 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 			return fmt.Errorf("failed to get filtered frame: %w", err)
 		},
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
-			// Calculate audio level from frame
 			currentLevel = calculateFrameLevel(inputFrame)
 
-			// Calculate input frame time based on samples processed (before filter graph upsampling)
 			inputFrameTime := time.Duration(float64(inputSamplesProcessed) / inputSampleRate * float64(time.Second))
 			inputSamplesProcessed += int64(inputFrame.NbSamples())
-			// Accumulate RMS and peak from INPUT frame (before filter graph which upsamples to 192kHz)
-			// This gives accurate RMS and peak values matching the original audio levels
 			intervalAcc.addFrameRMSAndPeak(inputFrame)
 
-			// Check if interval complete (250ms elapsed) based on input time
 			if inputFrameTime-intervalStartTime >= intervalDuration {
-				// Finalize and store completed interval
 				finalised := intervalAcc.finalize(intervalStartTime)
 				intervals = append(intervals, finalised)
 				if config.SilenceScanDuration > 0 && intervalStartTime < config.SilenceScanDuration {
@@ -373,7 +564,6 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 				intervalAcc.reset()
 			}
 
-			// Send periodic progress updates based on frame count
 			if frameCount%updateInterval == 0 && progressCallback != nil && estimatedTotalFrames > 0 {
 				progress := float64(frameCount) / estimatedTotalFrames
 				if progress > 1.0 {
@@ -383,25 +573,19 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 			}
 			frameCount++
 		},
-		OnFrame: func(_, filteredFrame *ffmpeg.AVFrame) (FrameAction, error) {
-			// Extract spectral metrics once, reuse for both whole-file and interval accumulators
+		OnFrame: func(_, filteredFrame *ffmpeg.AVFrame) error {
 			metadata := filteredFrame.Metadata()
 			spectral := extractSpectralMetrics(metadata)
 
-			// Extract measurements from frame metadata (whole-file accumulators)
 			extractFrameMetadata(metadata, acc, spectral)
-
-			// Also accumulate into current interval for per-interval spectral data
-			// Filtered frames roughly correspond to input timing (just at higher sample rate)
 			intervalAcc.add(extractIntervalFrameMetrics(metadata, spectral))
 
-			return FrameDiscard, nil
+			return nil
 		},
 	}); err != nil {
 		return nil, err
 	}
 
-	// Finalize any remaining partial interval (if it has data)
 	if intervalAcc.rawSampleCount > 0 {
 		finalised := intervalAcc.finalize(intervalStartTime)
 		intervals = append(intervals, finalised)
@@ -410,258 +594,20 @@ func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback f
 		}
 	}
 
-	// When no cap is set, the silence pipeline reads the same whole-file slice as
-	// the rest of the analysis. Aliasing avoids duplicating every append above.
 	if config.SilenceScanDuration == 0 {
 		silenceIntervals = intervals
 	}
 
-	// Note: We intentionally discard partial intervals with no data
-
-	// Free the filter graph
 	ffmpeg.AVFilterGraphFree(&filterGraph)
 	filterFreed = true
 
-	// Estimate noise floor and silence threshold from interval data
-	// This replaces the previous separate pre-scan pass
-
-	// Pre-compute silence detection medians (shared by noise estimation and candidate detection)
-	silMedians := computeSilenceMedians(silenceIntervals)
-
-	noiseFloorEstimate, silenceThreshold, ok := estimateNoiseFloorAndThreshold(silenceIntervals, silMedians)
-	if !ok {
-		// Fallback if insufficient interval data (very short recordings)
-		noiseFloorEstimate = defaultNoiseFloor
-		silenceThreshold = calculateAdaptiveSilenceThreshold(defaultNoiseFloor)
-	}
-
-	// Create measurements struct and populate from accumulators
-	measurements := &AudioMeasurements{
-		// Noise floor estimated from interval data (replaces pre-scan)
-		PreScanNoiseFloor:  noiseFloorEstimate,
-		SilenceDetectLevel: silenceThreshold,
-	}
-
-	// Populate ebur128 loudness measurements
-	if acc.ebur128Found {
-		measurements.InputI = acc.ebur128InputI
-		measurements.InputTP = acc.ebur128InputTP
-		measurements.InputLRA = acc.ebur128InputLRA
-		// Calculate threshold based on integrated loudness (ebur128 doesn't provide this directly)
-		// Threshold is typically around 10 LU below the integrated loudness
-		measurements.InputThresh = acc.ebur128InputI - 10.0
-		// Target offset for normalization (difference between measured and target)
-		measurements.TargetOffset = config.TargetI - acc.ebur128InputI
-	} else {
-		return nil, fmt.Errorf("ebur128 measurements not found in metadata for file: %s", filename)
-	}
-
-	// Calculate average spectral statistics from aspectralstats
-	acc.finalizeSpectral().writeSpectralTo(&measurements.BaseMeasurements)
-
-	// Store astats measurements (if captured)
-	if acc.astatsFound {
-		measurements.DynamicRange = acc.astatsDynamicRange
-		measurements.RMSLevel = acc.astatsRMSLevel
-		measurements.PeakLevel = acc.astatsPeakLevel
-		measurements.RMSTrough = acc.astatsRMSTrough
-		measurements.RMSPeak = acc.astatsRMSPeak
-
-		// Additional astats measurements for adaptive processing
-		measurements.DCOffset = acc.astatsDCOffset
-		measurements.FlatFactor = acc.astatsFlatFactor
-		measurements.CrestFactor = acc.astatsCrestFactor
-		measurements.ZeroCrossingsRate = acc.astatsZeroCrossingsRate
-		measurements.ZeroCrossings = acc.astatsZeroCrossings
-		measurements.MaxDifference = acc.astatsMaxDifference
-		measurements.MinDifference = acc.astatsMinDifference
-		measurements.MeanDifference = acc.astatsMeanDifference
-		measurements.RMSDifference = acc.astatsRMSDifference
-		measurements.Entropy = acc.astatsEntropy
-		measurements.MinLevel = acc.astatsMinLevel
-		measurements.MaxLevel = acc.astatsMaxLevel
-		measurements.AstatsNoiseFloor = acc.astatsNoiseFloor
-		measurements.NoiseFloorCount = acc.astatsNoiseFloorCount
-		measurements.BitDepth = acc.astatsBitDepth
-		measurements.NumberOfSamples = acc.astatsNumberOfSamples
-	}
-
-	// Store ebur128 momentary/short-term loudness
-	if acc.ebur128Found {
-		measurements.MomentaryLoudness = acc.ebur128InputM
-		measurements.ShortTermLoudness = acc.ebur128InputS
-		measurements.SamplePeak = acc.ebur128InputSP
-	}
-
-	// Derive noise floor using three-tier approach based on audio engineering best practices:
-	// Tier 1 (Primary): RMS_trough from astats - most accurate
-	//   - Measures RMS level during quietest segments (inter-word silence in speech)
-	//   - These quiet periods contain primarily room noise, HVAC, electronics noise
-	//   - Directly represents the actual noise floor of the recording environment
-	// Tier 2 (Secondary): Estimate from RMS_level - 15dB
-	//   - Based on typical speech crest factor where quiet segments are 12-18dB below average RMS
-	//   - Reasonable approximation when RMS_trough unavailable
-	// Tier 3 (Tertiary): Estimate from ebur128 InputThresh with loudness-based offset
-	//   - Fallback for when astats data is completely unavailable
-	//   - Uses integrated loudness to infer likely noise floor characteristics
-
-	switch {
-	case acc.astatsRMSTrough != 0 && !math.IsInf(acc.astatsRMSTrough, -1):
-		// Tier 1: Use RMS_trough (best - actual measurement of quiet segments)
-		measurements.NoiseFloor = acc.astatsRMSTrough
-		measurements.NoiseFloorSource = "astats"
-	case acc.astatsRMSLevel != 0 && !math.IsInf(acc.astatsRMSLevel, -1):
-		// Tier 2: Estimate from overall RMS level
-		// Typical speech has quiet segments 12-18dB below average RMS; use 15dB as balanced estimate
-		measurements.NoiseFloor = acc.astatsRMSLevel - 15.0
-		measurements.NoiseFloorSource = "rms_estimate"
-	default:
-		// Tier 3: Estimate from ebur128 integrated loudness threshold
-		// Louder recordings typically have better SNR (lower relative noise floor)
-		var noiseFloorOffset float64
-		switch {
-		case measurements.InputI > -20:
-			noiseFloorOffset = 18.0 // Professional: very low noise floor
-		case measurements.InputI > -30:
-			noiseFloorOffset = 12.0 // Typical podcast: moderate noise floor
-		default:
-			noiseFloorOffset = 8.0 // Quiet source: higher relative noise
-		}
-		measurements.NoiseFloor = measurements.InputThresh - noiseFloorOffset
-		measurements.NoiseFloorSource = "ebur128_estimate"
-	}
-
-	// Safety clamp: -90dB (digital silence) to -30dB (very noisy environment)
-	// Prevents extreme values while allowing wide range of recording quality
-	if measurements.NoiseFloor < -90.0 {
-		measurements.NoiseFloor = -90.0
-	} else if measurements.NoiseFloor > -30.0 {
-		measurements.NoiseFloor = -30.0
-	}
-
-	// Store 250ms interval samples for data-driven silence candidate detection
-	measurements.IntervalSamples = intervals
-
-	// Detect silence regions using threshold already computed from interval distribution
-	// The silenceThreshold was calculated above via estimateNoiseFloorAndThreshold()
-	measurements.SilenceRegions = findSilenceCandidatesFromIntervals(silenceIntervals, silenceThreshold, silMedians)
-
-	// Extract noise profile from best silence region (if available)
-	// Uses interval data for all measurements - no file re-reading required
-	silenceResult := findBestSilenceRegion(measurements.SilenceRegions, silenceIntervals)
-
-	// Store all evaluated candidates for reporting/debugging
-	measurements.SilenceCandidates = silenceResult.Candidates
-
-	// Detect voice-activated recordings from digital silence candidate fraction
-	measurements.VoiceActivated = detectVoiceActivated(silenceResult.Candidates)
-
-	// Extract noise profile from best silence region BEFORE speech region selection.
-	// This allows the SNR margin check in findBestSpeechRegion to penalise candidates
-	// that are too close to the noise floor.
-	var noiseProfile *NoiseProfile
-	if silenceResult.BestRegion != nil {
-		// Refine to golden sub-region: find cleanest 10s window within the candidate.
-		// This isolates optimal noise profile from long candidates that may span
-		// both pre-intentional (noisier) and intentional (cleaner) silence.
-		originalRegion := silenceResult.BestRegion
-		refinedRegion := refineToGoldenSubregion(originalRegion, intervals)
-		wasRefined := refinedRegion.Start != originalRegion.Start || refinedRegion.Duration != originalRegion.Duration
-
-		// Extract noise profile from interval data (no file re-read)
-		if profile := extractNoiseProfileFromIntervals(refinedRegion, silenceIntervals); profile != nil {
-			noiseProfile = profile
-			measurements.NoiseProfile = profile
-
-			// Store refinement info for logging/debugging
-			if wasRefined {
-				profile.WasRefined = true
-				profile.OriginalStart = originalRegion.Start
-				profile.OriginalDuration = originalRegion.Duration
-			}
-
-			// If we got a noise profile measurement, use it as the primary noise floor
-			// This is more accurate than the overall RMS_trough because it's from pure silence
-			if profile.MeasuredNoiseFloor != 0 && !math.IsInf(profile.MeasuredNoiseFloor, -1) {
-				measurements.NoiseFloor = profile.MeasuredNoiseFloor
-				measurements.NoiseFloorSource = "silence_profile"
-			}
-		}
-	}
-
-	// Detect speech candidates (must come after elected silence)
-	var speechSearchStart time.Duration
-	switch {
-	case silenceResult.BestRegion != nil:
-		speechSearchStart = silenceResult.BestRegion.End
-	case len(measurements.SilenceRegions) > 0:
-		// Fallback: use end of first silence region
-		speechSearchStart = measurements.SilenceRegions[0].End
-	default:
-		// No silence found - start speech search after 30 seconds
-		speechSearchStart = 30 * time.Second
-	}
-
-	measurements.SpeechRegions = findSpeechCandidatesFromIntervals(intervals, speechSearchStart, measurements.VoiceActivated, measurements.RMSLevel, measurements.NoiseFloor)
-
-	// Select best speech region (passing noiseProfile for SNR margin checking)
-	speechResult := findBestSpeechRegion(measurements.SpeechRegions, intervals, noiseProfile)
-	measurements.SpeechCandidates = speechResult.Candidates
-
-	if speechResult.BestRegion != nil {
-		// Store elected speech profile
-		for i := range speechResult.Candidates {
-			if speechResult.Candidates[i].Region.Start == speechResult.BestRegion.Start {
-				measurements.SpeechProfile = &speechResult.Candidates[i]
-				break
-			}
-		}
-	}
-
-	// Calculate derived suggestions for Pass 2 adaptive processing
-	// These are data-driven values based on actual measurements
-
-	// SuggestedGateThreshold: linear amplitude threshold for gate
-	// Data-driven calculation based on actual noise floor and quiet speech measurements
-	// Gate should open above noise floor but below quiet speech
-	//
-	// Strategy:
-	// - Use RMSTrough (quietest segments with speech) as reference for quiet speech
-	// - Calculate adaptive offset based on gap between noise floor and quiet speech
-	// - Smaller gap = smaller offset (preserve speech in noisy recordings)
-	// - Larger gap = larger offset (more aggressive gating for clean recordings)
-	gateThresholdDB := calculateAdaptiveDS201GateThreshold(measurements.NoiseFloor, measurements.RMSTrough)
-	measurements.SuggestedGateThreshold = math.Pow(10, gateThresholdDB/20.0)
-
-	// NoiseReductionHeadroom: dB gap between noise floor and quiet speech
-	// This determines how aggressively we can apply noise reduction
-	// RMS_trough represents the quietest RMS segments (should be near noise floor)
-	// RMS_level represents average level (speech)
-	// The gap tells us how much "room" we have to reduce noise without affecting speech
-	if measurements.RMSLevel != 0 && measurements.NoiseFloor != 0 {
-		// Headroom is the gap between average speech level and noise floor
-		// Larger headroom = more aggressive NR possible
-		measurements.NoiseReductionHeadroom = measurements.RMSLevel - measurements.NoiseFloor
-		if measurements.NoiseReductionHeadroom < 0 {
-			measurements.NoiseReductionHeadroom = 0 // Sanity check
-		}
-		if measurements.NoiseReductionHeadroom > 60 {
-			measurements.NoiseReductionHeadroom = 60 // Cap at 60dB (very clean recording)
-		}
-	} else {
-		// Fallback: estimate based on integrated loudness
-		// Louder recordings typically have better SNR
-		switch {
-		case measurements.InputI > -20:
-			measurements.NoiseReductionHeadroom = 40.0 // Professional recording
-		case measurements.InputI > -30:
-			measurements.NoiseReductionHeadroom = 25.0 // Typical podcast
-		default:
-			measurements.NoiseReductionHeadroom = 15.0 // Quiet recording
-		}
-	}
-
-	return measurements, nil
+	return &analysisFrameCollection{
+		metadata:         metadata,
+		accumulators:     acc,
+		intervals:        intervals,
+		silenceIntervals: silenceIntervals,
+		silenceMedians:   computeSilenceMedians(silenceIntervals),
+	}, nil
 }
 
 // calculateAdaptiveDS201GateThreshold computes a data-driven gate threshold based on

--- a/internal/processor/analyzer_candidates.go
+++ b/internal/processor/analyzer_candidates.go
@@ -1034,7 +1034,7 @@ func detectVoiceActivated(candidates []SilenceCandidateMetrics) bool {
 	return fraction >= voiceActivatedDigitalSilenceThreshold
 }
 
-func findBestSilenceRegion(regions []SilenceRegion, intervals []IntervalSample, _ float64) *findBestSilenceRegionResult {
+func findBestSilenceRegion(regions []SilenceRegion, intervals []IntervalSample) *findBestSilenceRegionResult {
 	result := &findBestSilenceRegionResult{}
 
 	if len(regions) == 0 {

--- a/internal/processor/analyzer_output.go
+++ b/internal/processor/analyzer_output.go
@@ -61,7 +61,7 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 	var spectralAcc SpectralMetrics
 	var spectralFrameCount int64
 
-	extractMeasurements := func(_ *ffmpeg.AVFrame, filteredFrame *ffmpeg.AVFrame) (FrameAction, error) {
+	extractMeasurements := func(_ *ffmpeg.AVFrame, filteredFrame *ffmpeg.AVFrame) error {
 		if metadata := filteredFrame.Metadata(); metadata != nil {
 			if value, ok := getFloatMetadata(metadata, metaKeyOverallRMSLevel); ok {
 				rmsLevel = value
@@ -95,7 +95,7 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 		}
 
 		framesProcessed++
-		return FrameDiscard, nil
+		return nil
 	}
 
 	lenientHandler := func(err error) error { return nil }

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -519,7 +519,7 @@ func TestFindBestSilenceRegion_HighestScoreWinsAfterDip(t *testing.T) {
 
 	allIntervals := append(append(intervalsA, intervalsB...), intervalsC...)
 
-	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
+	result := findBestSilenceRegion(regions, allIntervals)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -557,7 +557,7 @@ func TestFindBestSilenceRegion_EarlierCandidatePreferredWithinTolerance(t *testi
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
+	result := findBestSilenceRegion(regions, allIntervals)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -596,7 +596,7 @@ func TestFindBestSilenceRegion_AllBelowMinAcceptableScoreFallsBack(t *testing.T)
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
+	result := findBestSilenceRegion(regions, allIntervals)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected fallback BestRegion when candidates exist below minAcceptableScore")
@@ -634,7 +634,7 @@ func TestFindBestSilenceRegion_AllRejectedCandidatesDoNotFallback(t *testing.T) 
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
+	result := findBestSilenceRegion(regions, allIntervals)
 
 	if result.BestRegion != nil {
 		t.Fatalf("BestRegion = %+v, want nil for all rejected candidates", result.BestRegion)
@@ -660,7 +660,7 @@ func TestFindBestSilenceRegion_SingleAcceptableCandidateElected(t *testing.T) {
 	intervals := makeSilenceTestIntervals(0, 10*time.Second,
 		-65.0, -60.0, 100.0, 0.8, 2.0, 0.0)
 
-	result := findBestSilenceRegion(regions, intervals, 3600.0)
+	result := findBestSilenceRegion(regions, intervals)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -695,7 +695,7 @@ func TestFindBestSilenceRegion_LaterCandidateWinsWhenGapExceedsTolerance(t *test
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
+	result := findBestSilenceRegion(regions, allIntervals)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -725,7 +725,7 @@ func TestFindBestSilenceRegion_LateCandidateDiscoverable(t *testing.T) {
 	intervals := makeSilenceTestIntervals(1800*time.Second, 10*time.Second,
 		-75.0, -70.0, 100.0, 0.9, 1.0, 0.0)
 
-	result := findBestSilenceRegion(regions, intervals, 3600.0)
+	result := findBestSilenceRegion(regions, intervals)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected candidate at t=1800s to be elected")
@@ -2355,7 +2355,7 @@ func TestFindBestSilenceRegion_BoundaryTransientSurvivesAfterRefinement(t *testi
 	allIntervals = append(allIntervals, transientIntervals...)
 	allIntervals = append(allIntervals, cleanIntervals...)
 
-	result := findBestSilenceRegion(regions, allIntervals, 3600.0)
+	result := findBestSilenceRegion(regions, allIntervals)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected candidate to be elected after pre-scoring refinement trims boundary transient")

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -2258,9 +2258,9 @@ func TestRunFilterGraph(t *testing.T) {
 		OnInputFrame: func(_ *ffmpeg.AVFrame) {
 			inputFrameCount++
 		},
-		OnFrame: func(_, _ *ffmpeg.AVFrame) (FrameAction, error) {
+		OnFrame: func(_, _ *ffmpeg.AVFrame) error {
 			filteredFrameCount++
-			return FrameDiscard, nil
+			return nil
 		},
 	})
 	if err != nil {
@@ -2310,9 +2310,9 @@ func TestRunFilterGraphLenientErrors(t *testing.T) {
 	var frameCount int
 	err = runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnPushError: func(_ error) error { return nil }, // lenient: continue
-		OnFrame: func(_, _ *ffmpeg.AVFrame) (FrameAction, error) {
+		OnFrame: func(_, _ *ffmpeg.AVFrame) error {
 			frameCount++
-			return FrameDiscard, nil
+			return nil
 		},
 	})
 	if err != nil {

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -202,17 +202,17 @@ func runFullbenchFilterSpecCore(tb testing.TB, inputPath, outputPath, filterSpec
 		OnPullError: func(err error) error {
 			return fmt.Errorf("failed to pull frame from filter: %w", err)
 		},
-		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) (FrameAction, error) {
+		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) error {
 			if outputAcc != nil {
 				extractOutputFrameMetadata(filteredFrame.Metadata(), outputAcc)
 			}
 
 			filteredFrame.SetTimeBase(ffmpeg.AVBuffersinkGetTimeBase(bufferSinkCtx))
 			if err := encoder.WriteFrame(filteredFrame); err != nil {
-				return FrameDiscard, fmt.Errorf("failed to write frame: %w", err)
+				return fmt.Errorf("failed to write frame: %w", err)
 			}
 
-			return FrameDiscard, nil
+			return nil
 		},
 	}); err != nil {
 		tb.Fatalf("fullbench filter graph failed: %v", err)

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -34,8 +34,7 @@ const (
 	// Processing filters (Pass 2 only)
 	FilterLA2ACompressor FilterID = "la2a_compressor" // Teletronix LA-2A style optical compressor
 	FilterDeesser        FilterID = "deesser"
-	FilterVolumax        FilterID = "volumax_limiter" // CBS Volumax-inspired transparent limiter
-	FilterAdeclick       FilterID = "adeclick"        // Click/pop repair via interpolation
+	FilterAdeclick       FilterID = "adeclick" // Click/pop repair via interpolation
 )
 
 // Pass1FilterOrder defines the filter chain for analysis pass.
@@ -114,7 +113,6 @@ var filterBuilders = map[FilterID]filterBuilderFunc{
 	FilterDS201Gate:      (*FilterChainConfig).buildDS201GateFilter,
 	FilterLA2ACompressor: (*FilterChainConfig).buildLA2ACompressorFilter,
 	FilterDeesser:        (*FilterChainConfig).buildDeesserFilter,
-	FilterVolumax:        (*FilterChainConfig).buildVolumaxFilter,
 	FilterAdeclick:       (*FilterChainConfig).buildAdeclickFilter,
 }
 
@@ -246,18 +244,6 @@ type FilterChainConfig struct {
 	TargetTP  float64 // dBTP, true peak ceiling reference
 	TargetLRA float64 // LU, loudness range reference
 
-	// CBS Volumax-Inspired Limiter - transparent peak protection
-	// Designed for maximum transparency with gentle, program-dependent limiting
-	// that is essentially inaudible
-	VolumaxEnabled     bool    // Enable Volumax-inspired limiter
-	VolumaxCeiling     float64 // dBTP - peak ceiling (-1.0 = podcast standard)
-	VolumaxAttack      float64 // ms - attack time (5ms for transparency)
-	VolumaxRelease     float64 // ms - release time (100ms for smooth recovery)
-	VolumaxASC         bool    // Enable Auto Soft Clipping (program-dependent release)
-	VolumaxASCLevel    float64 // 0.0-1.0 - ASC release influence (0.8 for high smoothing)
-	VolumaxInputLevel  float64 // Linear - input gain (default 1.0)
-	VolumaxOutputLevel float64 // Linear - output gain (default 1.0)
-
 	// Filter chain order - controls the sequence of filters in the processing chain
 	// Use Pass2FilterOrder or customise for experimentation
 	FilterOrder []FilterID
@@ -375,16 +361,6 @@ func DefaultFilterConfig() *FilterChainConfig {
 		TargetI:   -16.0, // Reference LUFS target (not enforced)
 		TargetTP:  -0.3,  // Reference true peak (not enforced, alimiter does real limiting at -1.5)
 		TargetLRA: 7.0,   // Reference loudness range (EBU R128 default)
-
-		// CBS Volumax-Inspired Limiter - enabled by default as final safety net
-		VolumaxEnabled:     true,
-		VolumaxCeiling:     -1.0,  // -1.0 dBTP (podcast standard)
-		VolumaxAttack:      5.0,   // 5ms - gentle attack preserves transient shape
-		VolumaxRelease:     100.0, // 100ms - smooth recovery eliminates pumping
-		VolumaxASC:         true,
-		VolumaxASCLevel:    0.8, // High value = more program-dependent smoothing
-		VolumaxInputLevel:  1.0, // Unity input
-		VolumaxOutputLevel: 1.0, // Unity output
 
 		// Adeclick - click/pop repair (Pass 4 only)
 		// Tuned for transparent repair at lower CPU cost
@@ -718,48 +694,6 @@ func (cfg *FilterChainConfig) buildDeesserFilter() string {
 		cfg.DeessAmount,
 		cfg.DeessFreq,
 	)
-}
-
-// buildVolumaxFilter builds the CBS Volumax-inspired limiter filter specification.
-// Uses FFmpeg's alimiter with parameters tuned for maximum transparency.
-// The CBS Volumax was the broadcast standard for transparent, program-dependent
-// limiting that was essentially inaudible.
-func (cfg *FilterChainConfig) buildVolumaxFilter() string {
-	if !cfg.VolumaxEnabled {
-		return ""
-	}
-
-	// Convert ceiling from dBTP to linear (0.0-1.0)
-	ceiling := math.Pow(10, cfg.VolumaxCeiling/20.0)
-
-	// Default input/output levels to unity if not set (0.0 would mute audio)
-	inputLevel := cfg.VolumaxInputLevel
-	if inputLevel == 0.0 {
-		inputLevel = 1.0
-	}
-	outputLevel := cfg.VolumaxOutputLevel
-	if outputLevel == 0.0 {
-		outputLevel = 1.0
-	}
-
-	// Build filter with Volumax-style parameters
-	spec := fmt.Sprintf(
-		"alimiter=limit=%.6f:attack=%.1f:release=%.1f:level_in=%.4f:level_out=%.4f:level=0:latency=1",
-		ceiling,
-		cfg.VolumaxAttack,
-		cfg.VolumaxRelease,
-		inputLevel,
-		outputLevel,
-	)
-
-	// Add ASC parameters
-	if cfg.VolumaxASC {
-		spec += fmt.Sprintf(":asc=1:asc_level=%.2f", cfg.VolumaxASCLevel)
-	} else {
-		spec += ":asc=0"
-	}
-
-	return spec
 }
 
 // buildAdeclickFilter builds the click/pop repair filter specification.

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -34,7 +34,6 @@ const (
 	// Processing filters (Pass 2 only)
 	FilterLA2ACompressor FilterID = "la2a_compressor" // Teletronix LA-2A style optical compressor
 	FilterDeesser        FilterID = "deesser"
-	FilterAdeclick       FilterID = "adeclick" // Click/pop repair via interpolation
 )
 
 // Pass1FilterOrder defines the filter chain for analysis pass.
@@ -113,7 +112,6 @@ var filterBuilders = map[FilterID]filterBuilderFunc{
 	FilterDS201Gate:      (*FilterChainConfig).buildDS201GateFilter,
 	FilterLA2ACompressor: (*FilterChainConfig).buildLA2ACompressorFilter,
 	FilterDeesser:        (*FilterChainConfig).buildDeesserFilter,
-	FilterAdeclick:       (*FilterChainConfig).buildAdeclickFilter,
 }
 
 // PassNumber identifies which processing pass is being executed.

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -475,6 +475,13 @@ func (cfg *FilterChainConfig) buildResampleFilter() string {
 	if !cfg.ResampleEnabled {
 		return ""
 	}
+	return cfg.buildRequiredOutputFormatFilter()
+}
+
+// buildRequiredOutputFormatFilter builds the mandatory output format filter.
+// Use this when a pass must restore encoder-compatible audio regardless of
+// ResampleEnabled.
+func (cfg *FilterChainConfig) buildRequiredOutputFormatFilter() string {
 	return fmt.Sprintf("aformat=sample_rates=%d:channel_layouts=mono:sample_fmts=%s,asetnsamples=n=%d",
 		cfg.ResampleSampleRate, cfg.ResampleFormat, cfg.ResampleFrameSize)
 }

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -26,7 +26,6 @@ func newTestConfig() *FilterChainConfig {
 		DS201GateEnabled:   false,
 		LA2AEnabled:        false,
 		DeessEnabled:       false,
-		VolumaxEnabled:     false,
 
 		// Sensible defaults for parameters (used when filter is enabled)
 		DS201HPFreq:        80.0,
@@ -54,14 +53,6 @@ func newTestConfig() *FilterChainConfig {
 		TargetI:            -16.0,
 		TargetTP:           -0.3,
 		TargetLRA:          7.0,
-
-		VolumaxCeiling:     -1.0,
-		VolumaxAttack:      5.0,
-		VolumaxRelease:     100.0,
-		VolumaxASC:         true,
-		VolumaxASCLevel:    0.8,
-		VolumaxInputLevel:  1.0,
-		VolumaxOutputLevel: 1.0,
 
 		// NoiseRemove defaults (anlmdn + compand)
 		NoiseRemoveCompandEnabled:   true,
@@ -135,7 +126,6 @@ func TestBuildFilterSpec(t *testing.T) {
 		config.DS201GateEnabled = true
 		config.LA2AEnabled = true
 		config.DeessEnabled = true
-		config.VolumaxEnabled = true
 		config.ResampleEnabled = true // Required for output format filters
 
 		spec := config.BuildFilterSpec()
@@ -149,7 +139,6 @@ func TestBuildFilterSpec(t *testing.T) {
 			{"agate=threshold=", "agate"},
 			{"acompressor=threshold=", "acompressor"},
 			{"deesser=i=", "deesser"},
-			// alimiter (Volumax) moved to Pass 3 for peak protection after gain normalisation
 			{"aformat=sample_rates=44100", "aformat (output)"},
 		}
 
@@ -167,7 +156,6 @@ func TestBuildFilterSpec(t *testing.T) {
 		config.DS201GateEnabled = true
 		config.LA2AEnabled = true
 		config.DeessEnabled = true
-		config.VolumaxEnabled = true
 
 		spec := config.BuildFilterSpec()
 
@@ -183,7 +171,6 @@ func TestBuildFilterSpec(t *testing.T) {
 		config.DS201GateEnabled = true
 		config.LA2AEnabled = true
 		config.DeessEnabled = true
-		config.VolumaxEnabled = true
 
 		spec := config.BuildFilterSpec()
 
@@ -687,57 +674,6 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 	})
 }
 
-func TestBuildVolumaxFilter(t *testing.T) {
-	t.Run("typical podcast limiter", func(t *testing.T) {
-		config := newTestConfig()
-		config.VolumaxEnabled = true
-		config.VolumaxCeiling = -1.0
-		config.VolumaxAttack = 5.0
-		config.VolumaxRelease = 100.0
-		config.VolumaxASC = true
-		config.VolumaxASCLevel = 0.8
-
-		spec := config.buildVolumaxFilter()
-
-		wantIn := []string{
-			"alimiter=",
-			"limit=",      // dBTP ceiling converted to linear
-			"attack=5",    // attack in ms
-			"release=100", // release in ms
-			"asc=1",       // ASC enabled for program-dependent release
-			"asc_level=0.8",
-		}
-
-		for _, want := range wantIn {
-			if !strings.Contains(spec, want) {
-				t.Errorf("buildVolumaxFilter() = %q, want to contain %q", spec, want)
-			}
-		}
-	})
-
-	t.Run("ASC disabled", func(t *testing.T) {
-		config := newTestConfig()
-		config.VolumaxEnabled = true
-		config.VolumaxASC = false
-
-		spec := config.buildVolumaxFilter()
-
-		if !strings.Contains(spec, "asc=0") {
-			t.Errorf("buildVolumaxFilter() = %q, want to contain asc=0", spec)
-		}
-	})
-
-	t.Run("disabled returns empty", func(t *testing.T) {
-		config := newTestConfig()
-		config.VolumaxEnabled = false
-
-		spec := config.buildVolumaxFilter()
-		if spec != "" {
-			t.Errorf("buildVolumaxFilter() = %q, want empty when disabled", spec)
-		}
-	})
-}
-
 func TestBuildAdeclickFilter(t *testing.T) {
 	t.Run("default config emits production clause", func(t *testing.T) {
 		config := DefaultFilterConfig()
@@ -809,7 +745,6 @@ func TestFilterOrderRespected(t *testing.T) {
 	// Enable filters that appear at start and end
 	config.DS201HPEnabled = true
 	config.DS201GateEnabled = true
-	// Volumax moved to Pass 3 for peak protection after gain normalisation
 	config.DeessEnabled = true
 	config.DeessIntensity = 0.5
 	config.ResampleEnabled = true // Required for aformat output filter
@@ -824,7 +759,6 @@ func TestFilterOrderRespected(t *testing.T) {
 	aformatPos := strings.Index(spec, "aformat=sample_rates=")
 
 	// Verify order: highpass < gate < deesser < aformat
-	// Note: alimiter (Volumax) is now in Pass 3, not Pass 2
 	if highpassPos >= gatePos {
 		t.Errorf("highpass (pos %d) should come before agate (pos %d)", highpassPos, gatePos)
 	}
@@ -1073,7 +1007,6 @@ func TestPass2FilterOrder(t *testing.T) {
 			FilterDS201Gate,
 			FilterLA2ACompressor,
 			FilterDeesser,
-			// FilterVolumax moved to Pass 3
 			FilterAnalysis,
 			FilterResample,
 		}
@@ -1086,15 +1019,6 @@ func TestPass2FilterOrder(t *testing.T) {
 		for _, required := range requiredFilters {
 			if !filterSet[required] {
 				t.Errorf("Pass2FilterOrder missing required filter %q", required)
-			}
-		}
-	})
-
-	t.Run("Volumax not in Pass2FilterOrder", func(t *testing.T) {
-		// Volumax has been moved to Pass 3 for peak protection after gain normalisation
-		for _, id := range Pass2FilterOrder {
-			if id == FilterVolumax {
-				t.Errorf("FilterVolumax should not be in Pass2FilterOrder (moved to Pass 3)")
 			}
 		}
 	})

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -947,6 +947,21 @@ func TestBuildResampleFilter(t *testing.T) {
 	})
 }
 
+func TestBuildRequiredOutputFormatFilter(t *testing.T) {
+	config := newTestConfig()
+	config.ResampleEnabled = false
+	config.ResampleSampleRate = 48000
+	config.ResampleFormat = "s32"
+	config.ResampleFrameSize = 2048
+
+	result := config.buildRequiredOutputFormatFilter()
+
+	expected := "aformat=sample_rates=48000:channel_layouts=mono:sample_fmts=s32,asetnsamples=n=2048"
+	if result != expected {
+		t.Errorf("buildRequiredOutputFormatFilter() = %q, want %q", result, expected)
+	}
+}
+
 func TestPass1FilterOrder(t *testing.T) {
 	t.Run("includes correct filters in order", func(t *testing.T) {
 		// Pass 1 now uses interval sampling for silence detection (no silencedetect filter)

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -119,6 +119,16 @@ func TestBuildFilterSpec(t *testing.T) {
 		}
 	})
 
+	t.Run("default pass 2 chain omits pass 4 adeclick", func(t *testing.T) {
+		config := DefaultFilterConfig()
+
+		spec := config.BuildFilterSpec()
+
+		if strings.Contains(spec, "adeclick=") {
+			t.Errorf("BuildFilterSpec() emitted Pass 4 adeclick in Pass 2 chain: %s", spec)
+		}
+	})
+
 	t.Run("enabled filters appear in spec", func(t *testing.T) {
 		config := newTestConfig()
 		// Enable specific filters for this test
@@ -1020,6 +1030,17 @@ func TestPass2FilterOrder(t *testing.T) {
 			if !filterSet[required] {
 				t.Errorf("Pass2FilterOrder missing required filter %q", required)
 			}
+		}
+	})
+
+	t.Run("omits Pass 4 adeclick registry entry", func(t *testing.T) {
+		for _, id := range Pass2FilterOrder {
+			if id == FilterID("adeclick") {
+				t.Error("Pass2FilterOrder should not include Pass 4 adeclick")
+			}
+		}
+		if _, ok := filterBuilders[FilterID("adeclick")]; ok {
+			t.Error("filterBuilders should not register Pass 4 adeclick for Pass 2")
 		}
 	})
 }

--- a/internal/processor/frame_processor.go
+++ b/internal/processor/frame_processor.go
@@ -9,14 +9,6 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
 
-// FrameAction controls what runFilterGraph does with a filtered frame after OnFrame returns.
-type FrameAction int
-
-const (
-	// FrameDiscard unrefs and discards the filtered frame.
-	FrameDiscard FrameAction = iota
-)
-
 // FrameLoopConfig controls the behaviour of runFilterGraph.
 type FrameLoopConfig struct {
 	// OnReadError is called when reader.ReadFrame returns an error.
@@ -39,9 +31,8 @@ type FrameLoopConfig struct {
 	// OnFrame is called for each filtered frame pulled from the sink.
 	// inputFrame is the most recently read input frame (before filtering).
 	// filteredFrame is the frame pulled from the filter graph output.
-	// Return FrameDiscard to have runFilterGraph unref the filtered frame.
 	// A non-nil error aborts both loops.
-	OnFrame func(inputFrame, filteredFrame *ffmpeg.AVFrame) (FrameAction, error)
+	OnFrame func(inputFrame, filteredFrame *ffmpeg.AVFrame) error
 
 	// OnInputFrame is called for each input frame before it is pushed into
 	// the filter graph. Use for pre-filter work (progress tracking, RMS accumulation).
@@ -81,12 +72,10 @@ func runFilterGraph(
 			}
 
 			if config.OnFrame != nil {
-				action, err := config.OnFrame(inputFrame, filteredFrame)
+				err := config.OnFrame(inputFrame, filteredFrame)
+				ffmpeg.AVFrameUnref(filteredFrame)
 				if err != nil {
 					return err
-				}
-				if action == FrameDiscard {
-					ffmpeg.AVFrameUnref(filteredFrame)
 				}
 			} else {
 				ffmpeg.AVFrameUnref(filteredFrame)

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -761,15 +761,7 @@ func buildLoudnormFilterSpec(config *FilterChainConfig, measurement *LoudnormMea
 	// 3. adeclick for click/pop repair
 	// Repairs waveform discontinuities from limiter/loudnorm gain transitions
 	// Must come after loudnorm (catches its clicks) and before measurement filters
-	if config.AdeclickEnabled {
-		spec := fmt.Sprintf("adeclick=t=%.1f:w=%.0f:o=%.0f",
-			config.AdeclickThreshold,
-			config.AdeclickWindow,
-			config.AdeclickOverlap,
-		)
-		if config.AdeclickMethod != "" {
-			spec += ":m=" + config.AdeclickMethod
-		}
+	if spec := config.buildAdeclickFilter(); spec != "" {
 		filters = append(filters, spec)
 	}
 

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -634,14 +634,13 @@ func applyLoudnormAndMeasure(
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
 			samplesProcessed += int64(inputFrame.NbSamples())
 		},
-		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) (FrameAction, error) {
+		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) error {
 			// Extract validation measurements using Pass 2's function
 			extractOutputFrameMetadata(filteredFrame.Metadata(), &acc)
 
 			// Encode frame
 			if err := encoder.WriteFrame(filteredFrame); err != nil {
-				ffmpeg.AVFrameUnref(filteredFrame)
-				return FrameDiscard, fmt.Errorf("encoding failed: %w", err)
+				return fmt.Errorf("encoding failed: %w", err)
 			}
 
 			framesProcessed++
@@ -652,7 +651,7 @@ func applyLoudnormAndMeasure(
 				progressCallback(PassNormalising, "Normalising", progress, acc.ebur128OutputI, nil)
 			}
 
-			return FrameDiscard, nil
+			return nil
 		},
 	})
 	if loopErr != nil {

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -781,9 +781,7 @@ func buildLoudnormFilterSpec(config *FilterChainConfig, measurement *LoudnormMea
 
 	// 7. Resample back to output format (44.1kHz/s16/mono)
 	// Required because ebur128 outputs f64 at 192kHz; encoder expects s16 at 44.1kHz
-	// Built directly rather than via buildResampleFilter() which is gated on ResampleEnabled
-	filters = append(filters, fmt.Sprintf("aformat=sample_rates=%d:channel_layouts=mono:sample_fmts=%s,asetnsamples=n=%d",
-		config.ResampleSampleRate, config.ResampleFormat, config.ResampleFrameSize))
+	filters = append(filters, config.buildRequiredOutputFormatFilter())
 
 	return strings.Join(filters, ",")
 }

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -485,6 +485,9 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 	config := DefaultFilterConfig()
 	config.ResampleEnabled = false
+	config.ResampleSampleRate = 48000
+	config.ResampleFormat = "s32"
+	config.ResampleFrameSize = 2048
 
 	measurement := &LoudnormMeasurement{
 		InputI:       -24.0,
@@ -494,10 +497,15 @@ func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 		TargetOffset: -0.5,
 	}
 
-	_ = buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
+	filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
 
 	if config.ResampleEnabled {
 		t.Error("buildLoudnormFilterSpec mutated config.ResampleEnabled")
+	}
+
+	want := "aformat=sample_rates=48000:channel_layouts=mono:sample_fmts=s32,asetnsamples=n=2048"
+	if !strings.Contains(filterSpec, want) {
+		t.Errorf("buildLoudnormFilterSpec() missing required output format %q\nfilterSpec: %s", want, filterSpec)
 	}
 }
 

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -501,6 +501,38 @@ func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 	}
 }
 
+func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
+	measurement := &LoudnormMeasurement{
+		InputI:       -24.0,
+		InputTP:      -5.0,
+		InputLRA:     6.0,
+		InputThresh:  -34.0,
+		TargetOffset: -0.5,
+	}
+
+	t.Run("uses Pass 4 adeclick helper", func(t *testing.T) {
+		config := DefaultFilterConfig()
+
+		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
+
+		const want = "adeclick=t=2.0:w=55:o=50:m=s"
+		if !strings.Contains(filterSpec, want) {
+			t.Errorf("buildLoudnormFilterSpec() missing %q\nfilterSpec: %s", want, filterSpec)
+		}
+	})
+
+	t.Run("omits disabled adeclick", func(t *testing.T) {
+		config := DefaultFilterConfig()
+		config.AdeclickEnabled = false
+
+		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
+
+		if strings.Contains(filterSpec, "adeclick=") {
+			t.Errorf("buildLoudnormFilterSpec() emitted disabled adeclick\nfilterSpec: %s", filterSpec)
+		}
+	})
+}
+
 func TestPreGainCeilingRederivation(t *testing.T) {
 	// Validates the mathematical invariant: applying the deficit as pre-gain
 	// converts a clamped scenario into a non-clamped scenario, with the

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -13,19 +13,6 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
 
-// AnalyzeOnly performs Pass 1 analysis without processing.
-// Returns measurements and the adapted filter configuration.
-// Useful for rapid testing of silence detection algorithms without full processing.
-func AnalyzeOnly(inputPath string, config *FilterChainConfig,
-	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
-) (*AudioMeasurements, *FilterChainConfig, error) {
-	result, err := AnalyzeOnlyDetailed(inputPath, config, progressCallback)
-	if err != nil {
-		return nil, nil, err
-	}
-	return result.Measurements, result.Config, nil
-}
-
 // AnalysisResult contains analysis-only measurements and stage timings.
 type AnalysisResult struct {
 	Measurements       *AudioMeasurements

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -275,7 +275,7 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 				progressCallback(PassProcessing, "Processing", progress, currentLevel, measurements)
 			}
 		},
-		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) (FrameAction, error) {
+		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) error {
 			// Calculate audio level from FILTERED frame (shows processed audio in VU meter)
 			currentLevel = calculateFrameLevel(filteredFrame)
 
@@ -289,10 +289,10 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 
 			// Encode and write the filtered frame
 			if err := encoder.WriteFrame(filteredFrame); err != nil {
-				return FrameDiscard, fmt.Errorf("failed to write frame: %w", err)
+				return fmt.Errorf("failed to write frame: %w", err)
 			}
 
-			return FrameDiscard, nil
+			return nil
 		},
 	}); err != nil {
 		return InputMetadata{}, err

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -87,7 +87,6 @@ func TestProcessAudio(t *testing.T) {
 	config.AnalysisEnabled = true
 	config.ResampleEnabled = true
 	config.DS201HPEnabled = true // Basic processing
-	config.VolumaxEnabled = true // CBS Volumax-style limiter
 
 	// Process the audio with a no-op progress callback
 	result, err := ProcessAudio(testFile, config, func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
@@ -318,7 +317,6 @@ func TestFilterChainBuilder(t *testing.T) {
 
 	// Enable additional filters for Pass 2 test
 	config.DS201HPEnabled = true
-	config.VolumaxEnabled = true
 
 	filterSpec = config.BuildFilterSpec()
 	t.Logf("Pass 2 filter spec: %s", filterSpec)

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -113,14 +113,17 @@ func TestProcessAudio(t *testing.T) {
 		t.Errorf("Output extension = %q, want %q (path: %s)", ext, ".flac", result.OutputPath)
 	}
 
-	// Verify the output container is the FLAC demuxer (not WAV with FLAC payload)
-	reader, _, err := audio.OpenAudioFile(result.OutputPath)
+	// Verify output metadata is readable through the supported audio metadata API.
+	reader, outputMetadata, err := audio.OpenAudioFile(result.OutputPath)
 	if err != nil {
 		t.Fatalf("Failed to reopen output file: %v", err)
 	}
 	defer reader.Close()
-	if got := reader.FormatName(); got != "flac" {
-		t.Errorf("Output FormatName = %q, want %q", got, "flac")
+	if outputMetadata.SampleRate != config.ResampleSampleRate {
+		t.Errorf("Output sample rate = %d, want %d", outputMetadata.SampleRate, config.ResampleSampleRate)
+	}
+	if outputMetadata.Channels != 1 {
+		t.Errorf("Output channels = %d, want 1", outputMetadata.Channels)
 	}
 
 	// Verify the file starts with the FLAC magic bytes ("fLaC")
@@ -259,32 +262,6 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	}
 	if result.AdaptationDuration <= 0 {
 		t.Errorf("AdaptationDuration = %s, want > 0", result.AdaptationDuration)
-	}
-}
-
-func TestAnalyzeOnlyWrapper(t *testing.T) {
-	testFile := generateTestAudio(t, TestAudioOptions{
-		DurationSecs: 1.0,
-		SampleRate:   44100,
-		ToneFreq:     440.0,
-		ToneLevel:    -18.0,
-		NoiseLevel:   -55.0,
-	})
-	defer cleanupTestAudio(t, testFile)
-
-	config := newTestConfig()
-	config.DownmixEnabled = true
-	config.AnalysisEnabled = true
-
-	measurements, config, err := AnalyzeOnly(testFile, config, nil)
-	if err != nil {
-		t.Fatalf("AnalyzeOnly failed: %v", err)
-	}
-	if measurements == nil {
-		t.Fatal("AnalyzeOnly returned nil measurements")
-	}
-	if config == nil {
-		t.Fatal("AnalyzeOnly returned nil config")
 	}
 }
 


### PR DESCRIPTION
## Summary
Clean up the audio processing and reporting internals by removing obsolete Pass 2 surfaces, simplifying frame and analysis flow, and making analysis/report output easier to maintain.

## Changes
- Remove unused audio analysis helpers and obsolete Pass 2 Volumax and adeclick surfaces
- Simplify processor frame handling, silence region duration flow, and related tests
- Consolidate report candidate display helpers and reduce duplicated reporting code
- Split analysis display output into focused sections with test coverage
- Update stale analysis-only documentation references

## Testing
- Not run in this PR creation step; branch was created from committed changes and working tree was clean before push

## Related Issues
None