### PR TITLE
fix(processor): isolate adaptive processing state

### DIFF
--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -70,6 +71,77 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("analysis-only output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
+	files := []string{"first.wav", "second.wav"}
+	baseConfig := processor.DefaultFilterConfig()
+	var output bytes.Buffer
+	resultConfigs := []*processor.FilterChainConfig{
+		processor.DefaultFilterConfig(),
+		processor.DefaultFilterConfig(),
+	}
+	resultConfigs[0].DS201HPFreq = 60.0
+	resultConfigs[1].DS201HPFreq = 100.0
+
+	var analyzedConfigs []*processor.FilterChainConfig
+	var displayedConfigs []*processor.FilterChainConfig
+
+	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, analysisOnlyDeps{
+		stdout: &output,
+		hasTTY: func() bool {
+			return false
+		},
+		openMetadata: func(path string) (*audio.Metadata, error) {
+			return &audio.Metadata{
+				Duration:   120,
+				SampleRate: 48000,
+				Channels:   1,
+			}, nil
+		},
+		runWithTUI: func(string, *processor.FilterChainConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
+			t.Fatal("runWithTUI should not be called for non-TTY output")
+			return nil, nil
+		},
+		analyzeDetailed: func(path string, cfg *processor.FilterChainConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
+			if cfg != baseConfig {
+				t.Fatalf("analyzeDetailed config = %p, want shared base %p", cfg, baseConfig)
+			}
+			analyzedConfigs = append(analyzedConfigs, cfg)
+
+			index := len(analyzedConfigs) - 1
+			return &processor.AnalysisResult{
+				Measurements:       makeAnalysisOnlyTestMeasurements(),
+				Config:             resultConfigs[index],
+				AnalysisDuration:   2 * time.Second,
+				AdaptationDuration: 100 * time.Millisecond,
+			}, nil
+		},
+		displayResults: func(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig, timings ...logging.AnalysisTimings) {
+			displayedConfigs = append(displayedConfigs, config)
+		},
+		printError: func(message string) {
+			t.Fatalf("printError called: %s", message)
+		},
+	})
+
+	if len(analyzedConfigs) != len(files) {
+		t.Fatalf("analyzed config count = %d, want %d", len(analyzedConfigs), len(files))
+	}
+	if analyzedConfigs[0] != baseConfig || analyzedConfigs[1] != baseConfig {
+		t.Fatal("analysis-only did not reuse the shared base config pointer for analysis calls")
+	}
+	if len(displayedConfigs) != len(resultConfigs) {
+		t.Fatalf("displayed config count = %d, want %d", len(displayedConfigs), len(resultConfigs))
+	}
+	for i := range resultConfigs {
+		if displayedConfigs[i] != resultConfigs[i] {
+			t.Fatalf("displayed config %d = %p, want AnalysisResult.Config %p", i, displayedConfigs[i], resultConfigs[i])
+		}
+	}
+	if baseConfig.DS201HPFreq == resultConfigs[0].DS201HPFreq || baseConfig.DS201HPFreq == resultConfigs[1].DS201HPFreq {
+		t.Fatal("test setup failed: result configs should differ from the shared base seed")
 	}
 }
 

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -79,11 +80,12 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	baseConfig := processor.DefaultFilterConfig()
 	var output bytes.Buffer
 	resultConfigs := []*processor.FilterChainConfig{
-		processor.DefaultFilterConfig(),
-		processor.DefaultFilterConfig(),
+		processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements()),
+		processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements()),
 	}
 	resultConfigs[0].DS201HPFreq = 60.0
 	resultConfigs[1].DS201HPFreq = 100.0
+	secondFilterOrder := append([]processor.FilterID(nil), resultConfigs[1].FilterOrder...)
 
 	var analyzedConfigs []*processor.FilterChainConfig
 	var displayedConfigs []*processor.FilterChainConfig
@@ -120,6 +122,9 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 		},
 		displayResults: func(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig, timings ...logging.AnalysisTimings) {
 			displayedConfigs = append(displayedConfigs, config)
+			if len(displayedConfigs) == 1 {
+				config.FilterOrder[0] = processor.FilterAnalysis
+			}
 		},
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
@@ -139,6 +144,9 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 		if displayedConfigs[i] != resultConfigs[i] {
 			t.Fatalf("displayed config %d = %p, want AnalysisResult.Config %p", i, displayedConfigs[i], resultConfigs[i])
 		}
+	}
+	if !reflect.DeepEqual(resultConfigs[1].FilterOrder, secondFilterOrder) {
+		t.Fatalf("second result config FilterOrder = %v, want unaffected %v", resultConfigs[1].FilterOrder, secondFilterOrder)
 	}
 	if baseConfig.DS201HPFreq == resultConfigs[0].DS201HPFreq || baseConfig.DS201HPFreq == resultConfigs[1].DS201HPFreq {
 		t.Fatal("test setup failed: result configs should differ from the shared base seed")

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -442,6 +442,11 @@ func AdaptConfig(config *FilterChainConfig, measurements *AudioMeasurements) {
 // - High entropy indicates broadband noise → skip notch filter
 // - Voice-aware: reduces harmonics for warm voices to protect vocal fundamentals
 func tuneDS201HighPass(config *FilterChainConfig, measurements *AudioMeasurements) {
+	config.DS201HPPoles = ds201HPDefaultPoles
+	config.DS201HPWidth = ds201HPDefaultWidth
+	config.DS201HPMix = ds201HPDefaultMix
+	config.DS201HPTransform = ds201HPDefaultTransform
+
 	if measurements.SpectralCentroid <= 0 {
 		// No spectral analysis available - keep default
 		return
@@ -513,7 +518,7 @@ func tuneDS201HighPass(config *FilterChainConfig, measurements *AudioMeasurement
 	}
 
 	// Set TDII transform for all highpass (best floating-point accuracy)
-	config.DS201HPTransform = "tdii"
+	config.DS201HPTransform = ds201HPDefaultTransform
 
 	// Protect warm voices with significant LF body
 	// Instead of disabling highpass, we use gentler settings:
@@ -856,6 +861,9 @@ func tuneDeesserCentroidOnly(config *FilterChainConfig, measurements *AudioMeasu
 //   - Detection: RMS for tonal bleed/noisy silence, peak for clean recordings
 //   - Makeup: 1.0 (loudness normalisation handles level compensation)
 func tuneDS201Gate(config *FilterChainConfig, measurements *AudioMeasurements) {
+	config.DS201GateGentleMode = false
+	resetDS201GateDiagnostics(config)
+
 	// Extract silence sample characteristics for gate tuning
 	var silenceEntropy, silenceCrest, silencePeak float64
 

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -398,26 +398,33 @@ func detectContentType(m *AudioMeasurements) ContentType {
 
 // AdaptConfig tunes all filter parameters based on Pass 1 measurements.
 // This is the main entry point for adaptive configuration.
-// It updates config in-place based on the audio characteristics measured in analysis.
-func AdaptConfig(config *FilterChainConfig, measurements *AudioMeasurements) {
+// It returns a per-file effective config without mutating the caller's base seed.
+func AdaptConfig(config *FilterChainConfig, measurements *AudioMeasurements) *FilterChainConfig {
+	effectiveConfig := derivePerFileConfig(config)
+	if effectiveConfig == nil {
+		return nil
+	}
+
 	// Store measurements reference
-	config.Measurements = measurements
+	effectiveConfig.Measurements = measurements
 
 	// Tune each filter adaptively based on measurements
 	// Order matters: gate threshold calculated BEFORE denoise filters
-	tuneDS201HighPass(config, measurements) // Composite: highpass + hum notch
-	tuneDS201LowPass(config, measurements)  // Ultrasonic rejection (adaptive)
+	tuneDS201HighPass(effectiveConfig, measurements) // Composite: highpass + hum notch
+	tuneDS201LowPass(effectiveConfig, measurements)  // Ultrasonic rejection (adaptive)
 
 	// NoiseRemove: anlmdn + compand (primary noise reduction)
-	tuneNoiseRemove(config, measurements)
+	tuneNoiseRemove(effectiveConfig, measurements)
 
-	tuneDS201Gate(config, measurements) // DS201-style soft expander gate
-	tuneDeesser(config, measurements)
-	tuneLA2ACompressor(config, measurements)
+	tuneDS201Gate(effectiveConfig, measurements) // DS201-style soft expander gate
+	tuneDeesser(effectiveConfig, measurements)
+	tuneLA2ACompressor(effectiveConfig, measurements)
 	// tuneVolumaxLimiter removed - limiter moved to Pass 4, tuned from Pass 3 measurements
 
 	// Final safety checks
-	sanitizeConfig(config)
+	sanitizeConfig(effectiveConfig)
+
+	return effectiveConfig
 }
 
 // tuneDS201HighPass adapts DS201-inspired highpass composite filter based on:

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -2,8 +2,88 @@ package processor
 
 import (
 	"math"
+	"reflect"
 	"testing"
 )
+
+func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
+	staleMeasurements := &AudioMeasurements{InputI: -12.0}
+	measurements := &AudioMeasurements{
+		BaseMeasurements: BaseMeasurements{
+			SpectralCentroid: 5000,
+			SpectralDecrease: -0.12,
+			SpectralSkewness: 1.2,
+			DynamicRange:     32.0,
+			SpectralKurtosis: 4.0,
+			SpectralFlux:     0.01,
+			PeakLevel:        -8.0,
+		},
+		InputI:     -28.0,
+		InputTP:    -4.0,
+		InputLRA:   9.0,
+		NoiseFloor: -60.0,
+		NoiseProfile: &NoiseProfile{
+			MeasuredNoiseFloor: -50.0,
+			Entropy:            0.8,
+		},
+	}
+
+	base := newTestConfig()
+	base.Pass = PassProcessing
+	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
+	base.Measurements = staleMeasurements
+	base.OutputAnalysisEnabled = true
+	base.DS201HPEnabled = true
+	base.DS201HPFreq = 95.0
+	base.TargetI = -18.0
+
+	effective := AdaptConfig(base, measurements)
+	if effective == nil {
+		t.Fatal("AdaptConfig returned nil")
+	}
+	if effective == base {
+		t.Fatal("AdaptConfig returned the base pointer")
+	}
+	if effective.Measurements != measurements {
+		t.Fatal("effective Measurements was not set to Pass 1 measurements")
+	}
+
+	if base.Pass != PassProcessing {
+		t.Errorf("base Pass = %d, want %d", base.Pass, PassProcessing)
+	}
+	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) {
+		t.Errorf("base FilterOrder = %v, want unchanged custom order", base.FilterOrder)
+	}
+	if base.Measurements != staleMeasurements {
+		t.Fatal("base Measurements was mutated")
+	}
+	if !base.OutputAnalysisEnabled {
+		t.Fatal("base OutputAnalysisEnabled was mutated")
+	}
+	if base.DS201HPFreq != 95.0 {
+		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", base.DS201HPFreq)
+	}
+	if base.TargetI != -18.0 {
+		t.Errorf("base TargetI = %.1f, want unchanged -18.0", base.TargetI)
+	}
+
+	if effective.Pass != 0 {
+		t.Errorf("effective Pass = %d, want cleared pass state", effective.Pass)
+	}
+	if effective.OutputAnalysisEnabled {
+		t.Fatal("effective OutputAnalysisEnabled = true, want cleared pass state")
+	}
+	if !reflect.DeepEqual(effective.FilterOrder, base.FilterOrder) {
+		t.Errorf("effective FilterOrder = %v, want copied base order %v", effective.FilterOrder, base.FilterOrder)
+	}
+	effective.FilterOrder[0] = FilterDownmix
+	if base.FilterOrder[0] == FilterDownmix {
+		t.Fatal("effective FilterOrder mutation changed base FilterOrder")
+	}
+	if effective.DS201HPFreq == 95.0 {
+		t.Fatal("effective DS201HPFreq did not adapt from base seed value")
+	}
+}
 
 func TestTuneDS201HighPass(t *testing.T) {
 	// Helper to create noise profile with given characteristics

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -302,6 +302,46 @@ func TestTuneDS201HighPass(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("resets adaptive baseline after warm tuning", func(t *testing.T) {
+		config := newTestConfig()
+		config.DS201HPEnabled = true
+
+		tuneDS201HighPass(config, &AudioMeasurements{
+			BaseMeasurements: BaseMeasurements{
+				SpectralCentroid: 5000,
+				SpectralDecrease: -0.12,
+			},
+			NoiseProfile: makeNoiseProfile(-50.0, 0.8),
+		})
+
+		if config.DS201HPPoles != 1 || config.DS201HPWidth != ds201HPVeryWarmWidth || config.DS201HPMix != ds201HPVeryWarmMix {
+			t.Fatalf("warm tuning did not enter gentle baseline: poles=%d width=%.3f mix=%.2f",
+				config.DS201HPPoles, config.DS201HPWidth, config.DS201HPMix)
+		}
+
+		tuneDS201HighPass(config, &AudioMeasurements{
+			BaseMeasurements: BaseMeasurements{
+				SpectralCentroid: 5000,
+			},
+		})
+
+		if config.DS201HPFreq != ds201HPBrightFreq {
+			t.Errorf("DS201HPFreq = %.1f, want %.1f", config.DS201HPFreq, ds201HPBrightFreq)
+		}
+		if config.DS201HPPoles != ds201HPDefaultPoles {
+			t.Errorf("DS201HPPoles = %d, want %d", config.DS201HPPoles, ds201HPDefaultPoles)
+		}
+		if config.DS201HPWidth != ds201HPDefaultWidth {
+			t.Errorf("DS201HPWidth = %.3f, want %.3f", config.DS201HPWidth, ds201HPDefaultWidth)
+		}
+		if config.DS201HPMix != ds201HPDefaultMix {
+			t.Errorf("DS201HPMix = %.2f, want %.2f", config.DS201HPMix, ds201HPDefaultMix)
+		}
+		if config.DS201HPTransform != ds201HPDefaultTransform {
+			t.Errorf("DS201HPTransform = %q, want %q", config.DS201HPTransform, ds201HPDefaultTransform)
+		}
+	})
 }
 
 func TestDetectContentType(t *testing.T) {
@@ -1286,6 +1326,63 @@ func TestTuneDS201Gate(t *testing.T) {
 						config.DS201GateRelease, tt.lra, tt.wantReleaseMin, tt.wantReleaseMax, tt.desc)
 				}
 			})
+		}
+	})
+
+	t.Run("resets gentle mode and diagnostics without speech metrics", func(t *testing.T) {
+		config := newTestConfig()
+
+		tuneDS201Gate(config, &AudioMeasurements{
+			BaseMeasurements: BaseMeasurements{
+				SpectralFlux:  0.02,
+				SpectralCrest: 20.0,
+			},
+			InputI:     -48.0,
+			InputLRA:   6.0,
+			NoiseFloor: -70.0,
+			NoiseProfile: &NoiseProfile{
+				PeakLevel:   -65.0,
+				CrestFactor: 12.0,
+				Entropy:     0.5,
+			},
+			SpeechProfile: &SpeechCandidateMetrics{
+				RMSLevel:    -35.0,
+				CrestFactor: 10.0,
+			},
+		})
+
+		if !config.DS201GateGentleMode {
+			t.Fatal("expected first tuning to enable gentle mode")
+		}
+		if config.DS201GateAggression == 0 ||
+			config.DS201GateDynamicRange == 0 ||
+			config.DS201GateQuietSpeechEstimate == 0 ||
+			config.DS201GateSpeechSeparation == 0 ||
+			config.DS201GateThresholdUnclamped == 0 ||
+			config.DS201GateClampReason == "" {
+			t.Fatalf("expected first tuning to populate gate diagnostics: %+v", config)
+		}
+
+		tuneDS201Gate(config, &AudioMeasurements{
+			BaseMeasurements: BaseMeasurements{
+				SpectralFlux: 0.02,
+			},
+			InputI:     -20.0,
+			InputLRA:   16.0,
+			NoiseFloor: -55.0,
+		})
+
+		if config.DS201GateGentleMode {
+			t.Error("DS201GateGentleMode = true, want false")
+		}
+		if config.DS201GateAggression != 0 ||
+			config.DS201GateDynamicRange != 0 ||
+			config.DS201GateQuietSpeechEstimate != 0 ||
+			config.DS201GateSpeechSeparation != 0 ||
+			config.DS201GateSpeechHeadroom != 0 ||
+			config.DS201GateThresholdUnclamped != 0 ||
+			config.DS201GateClampReason != "" {
+			t.Errorf("gate diagnostics retained without speech metrics: %+v", config)
 		}
 	})
 }

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -85,6 +85,158 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	}
 }
 
+func TestAdaptConfigOrderIndependence(t *testing.T) {
+	sharedSeed := newOrderIndependenceSeed()
+	fileA := orderIndependenceWarmNoProfileMeasurements()
+	fileB := orderIndependenceBrightSpeechMeasurements()
+
+	firstEffective := AdaptConfig(sharedSeed, fileA)
+	if firstEffective == nil {
+		t.Fatal("AdaptConfig returned nil for file A")
+	}
+	if !firstEffective.DS201GateGentleMode {
+		t.Fatal("file A setup failed: expected gentle gate mode")
+	}
+	if firstEffective.NoiseRemoveCompandEnabled {
+		t.Fatal("file A setup failed: expected compand disabled without a noise profile")
+	}
+	if !firstEffective.LA2AHighCrestActive {
+		t.Fatal("file A setup failed: expected high-crest diagnostics active")
+	}
+
+	afterA := AdaptConfig(sharedSeed, fileB)
+	alone := AdaptConfig(newOrderIndependenceSeed(), fileB)
+	if afterA == nil || alone == nil {
+		t.Fatal("AdaptConfig returned nil for file B")
+	}
+
+	if afterA == sharedSeed {
+		t.Fatal("AdaptConfig returned shared seed for file B after file A")
+	}
+	if alone == sharedSeed {
+		t.Fatal("AdaptConfig returned shared seed for file B alone")
+	}
+
+	assertOrderIndependentAdaptiveFields(t, afterA, alone)
+
+	if sharedSeed.DS201GateGentleMode {
+		t.Fatal("shared seed retained file A gentle gate state")
+	}
+	if !sharedSeed.NoiseRemoveCompandEnabled {
+		t.Fatal("shared seed retained file A compand disabled state")
+	}
+	if sharedSeed.LA2AHighCrestActive {
+		t.Fatal("shared seed retained file A high-crest state")
+	}
+}
+
+func newOrderIndependenceSeed() *FilterChainConfig {
+	config := newTestConfig()
+	config.DS201HPEnabled = true
+	config.DS201LPEnabled = true
+	config.NoiseRemoveEnabled = true
+	config.DS201GateEnabled = true
+	config.LA2AEnabled = true
+	config.LoudnormTargetTP = -2.0
+	return config
+}
+
+func orderIndependenceWarmNoProfileMeasurements() *AudioMeasurements {
+	return &AudioMeasurements{
+		BaseMeasurements: BaseMeasurements{
+			SpectralCentroid: 6500,
+			SpectralDecrease: -0.12,
+			SpectralSkewness: 1.6,
+			SpectralKurtosis: 4.0,
+			SpectralFlatness: 0.62,
+			SpectralFlux:     0.008,
+			SpectralCrest:    20.0,
+			SpectralRolloff:  18000,
+			DynamicRange:     90.0,
+			PeakLevel:        -10.0,
+		},
+		InputI:     -42.1,
+		InputTP:    -4.9,
+		InputLRA:   6.0,
+		NoiseFloor: -58.0,
+	}
+}
+
+func orderIndependenceBrightSpeechMeasurements() *AudioMeasurements {
+	return &AudioMeasurements{
+		BaseMeasurements: BaseMeasurements{
+			SpectralCentroid:  5000,
+			SpectralDecrease:  0.0,
+			SpectralSkewness:  0.0,
+			SpectralKurtosis:  9.0,
+			SpectralFlatness:  0.38,
+			SpectralFlux:      0.002,
+			SpectralCrest:     45.0,
+			SpectralRolloff:   15000,
+			DynamicRange:      32.0,
+			PeakLevel:         -6.0,
+			ZeroCrossingsRate: 0.05,
+		},
+		InputI:     -20.0,
+		InputTP:    -2.5,
+		InputLRA:   12.0,
+		NoiseFloor: -60.0,
+		NoiseProfile: &NoiseProfile{
+			MeasuredNoiseFloor: -60.0,
+			PeakLevel:          -45.0,
+			CrestFactor:        15.0,
+			Entropy:            0.8,
+		},
+		SpeechProfile: &SpeechCandidateMetrics{
+			RMSLevel:    -24.0,
+			CrestFactor: 12.0,
+			Spectral: SpectralMetrics{
+				Centroid: 5000,
+				Decrease: 0.0,
+				Skewness: 0.0,
+				Kurtosis: 9.0,
+				Flux:     0.002,
+				Rolloff:  15000,
+			},
+		},
+	}
+}
+
+func assertOrderIndependentAdaptiveFields(t *testing.T, got, want *FilterChainConfig) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"DS201HPFreq", got.DS201HPFreq, want.DS201HPFreq},
+		{"DS201HPPoles", got.DS201HPPoles, want.DS201HPPoles},
+		{"DS201HPWidth", got.DS201HPWidth, want.DS201HPWidth},
+		{"DS201HPMix", got.DS201HPMix, want.DS201HPMix},
+		{"DS201HPTransform", got.DS201HPTransform, want.DS201HPTransform},
+		{"DS201GateGentleMode", got.DS201GateGentleMode, want.DS201GateGentleMode},
+		{"NoiseRemoveCompandEnabled", got.NoiseRemoveCompandEnabled, want.NoiseRemoveCompandEnabled},
+		{"NoiseRemoveCompandThreshold", got.NoiseRemoveCompandThreshold, want.NoiseRemoveCompandThreshold},
+		{"NoiseRemoveCompandExpansion", got.NoiseRemoveCompandExpansion, want.NoiseRemoveCompandExpansion},
+		{"DS201LPEnabled", got.DS201LPEnabled, want.DS201LPEnabled},
+		{"DS201LPFreq", got.DS201LPFreq, want.DS201LPFreq},
+		{"DS201LPContentType", got.DS201LPContentType, want.DS201LPContentType},
+		{"DS201LPReason", got.DS201LPReason, want.DS201LPReason},
+		{"DS201LPRolloffRatio", got.DS201LPRolloffRatio, want.DS201LPRolloffRatio},
+		{"LA2AHighCrestActive", got.LA2AHighCrestActive, want.LA2AHighCrestActive},
+		{"LA2AHighCrestDeficit", got.LA2AHighCrestDeficit, want.LA2AHighCrestDeficit},
+		{"LA2AHighCrestSeverity", got.LA2AHighCrestSeverity, want.LA2AHighCrestSeverity},
+		{"LA2AHighCrestProjectedTP", got.LA2AHighCrestProjectedTP, want.LA2AHighCrestProjectedTP},
+	}
+
+	for _, tt := range tests {
+		if !reflect.DeepEqual(tt.got, tt.want) {
+			t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+		}
+	}
+}
+
 func TestTuneDS201HighPass(t *testing.T) {
 	// Helper to create noise profile with given characteristics
 	makeNoiseProfile := func(noiseFloor, entropy float64) *NoiseProfile {

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -682,8 +682,9 @@ func createAnalysisFilterGraph(
 	// Configure for Pass 1 analysis
 	// Uses unified BuildFilterSpec() with Pass1FilterOrder:
 	// Downmix → Analysis
-	config.Pass = PassAnalysis
-	config.FilterOrder = Pass1FilterOrder
+	analysisConfig := derivePerFileConfig(config)
+	analysisConfig.Pass = PassAnalysis
+	analysisConfig.FilterOrder = Pass1FilterOrder
 
-	return setupFilterGraph(decCtx, config.BuildFilterSpec())
+	return setupFilterGraph(decCtx, analysisConfig.BuildFilterSpec())
 }

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -91,6 +91,48 @@ func TestAnalyzeAudio(t *testing.T) {
 	})
 }
 
+func TestAnalyzeAudioDoesNotMutateCallerConfig(t *testing.T) {
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 1.0,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -23.0,
+		NoiseLevel:   -60.0,
+	})
+	defer cleanupTestAudio(t, testFile)
+
+	seedMeasurements := &AudioMeasurements{InputI: -30.0}
+	config := DefaultFilterConfig()
+	config.Pass = PassProcessing
+	config.FilterOrder = []FilterID{FilterNoiseRemove, FilterAnalysis}
+	config.Measurements = seedMeasurements
+	config.OutputAnalysisEnabled = true
+
+	originalOrder := append([]FilterID(nil), config.FilterOrder...)
+
+	if _, err := AnalyzeAudio(testFile, config, nil); err != nil {
+		t.Fatalf("AnalyzeAudio failed: %v", err)
+	}
+
+	if config.Pass != PassProcessing {
+		t.Errorf("Pass = %d, want %d", config.Pass, PassProcessing)
+	}
+	if len(config.FilterOrder) != len(originalOrder) {
+		t.Fatalf("FilterOrder length = %d, want %d", len(config.FilterOrder), len(originalOrder))
+	}
+	for i := range originalOrder {
+		if config.FilterOrder[i] != originalOrder[i] {
+			t.Errorf("FilterOrder[%d] = %q, want %q", i, config.FilterOrder[i], originalOrder[i])
+		}
+	}
+	if config.Measurements != seedMeasurements {
+		t.Errorf("Measurements = %p, want %p", config.Measurements, seedMeasurements)
+	}
+	if !config.OutputAnalysisEnabled {
+		t.Error("OutputAnalysisEnabled = false, want true")
+	}
+}
+
 func TestCalculateAdaptiveGateThreshold(t *testing.T) {
 	// Tests for the data-driven gate threshold calculation
 	// The function uses noise floor and RMS trough (quiet speech) to calculate

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -96,6 +96,13 @@ const (
 	noiseRemoveProductionSmooth      = 3.0
 )
 
+const (
+	ds201HPDefaultPoles     = 2
+	ds201HPDefaultWidth     = 0.707
+	ds201HPDefaultMix       = 1.0
+	ds201HPDefaultTransform = "tdii"
+)
+
 // filterBuilderFunc is a function that builds a filter spec from config.
 // Returns the FFmpeg filter specification string, or empty string if disabled.
 type filterBuilderFunc func(*FilterChainConfig) string
@@ -294,11 +301,11 @@ func DefaultFilterConfig() *FilterChainConfig {
 
 		// DS201-Inspired High-pass - remove subsonic rumble (part of DS201 side-chain)
 		DS201HPEnabled:   true,
-		DS201HPFreq:      80.0,   // 80Hz cutoff
-		DS201HPPoles:     2,      // 12dB/oct standard slope (1=gentle 6dB/oct for warm voices)
-		DS201HPWidth:     0.707,  // Butterworth Q (maximally flat passband)
-		DS201HPMix:       1.0,    // Full wet signal (reduce for warm voice protection)
-		DS201HPTransform: "tdii", // Transposed Direct Form II - best floating-point accuracy
+		DS201HPFreq:      80.0,                    // 80Hz cutoff
+		DS201HPPoles:     ds201HPDefaultPoles,     // 12dB/oct standard slope (1=gentle 6dB/oct for warm voices)
+		DS201HPWidth:     ds201HPDefaultWidth,     // Butterworth Q (maximally flat passband)
+		DS201HPMix:       ds201HPDefaultMix,       // Full wet signal (reduce for warm voice protection)
+		DS201HPTransform: ds201HPDefaultTransform, // Transposed Direct Form II - best floating-point accuracy
 
 		// DS201-Inspired Low-pass Filter - removes ultrasonic noise (part of DS201 side-chain)
 		DS201LPEnabled:   true,
@@ -381,6 +388,48 @@ func DefaultFilterConfig() *FilterChainConfig {
 		LoudnormDualMono:  true,  // CRITICAL for mono recordings
 		LoudnormLinear:    true,  // Prefer linear (transparent) mode
 	}
+}
+
+func derivePerFileConfig(base *FilterChainConfig) *FilterChainConfig {
+	if base == nil {
+		return nil
+	}
+
+	derived := *base
+	if base.FilterOrder != nil {
+		derived.FilterOrder = append([]FilterID(nil), base.FilterOrder...)
+	}
+
+	derived.Pass = 0
+	derived.Measurements = nil
+	derived.OutputAnalysisEnabled = false
+	resetAdaptiveDiagnostics(&derived)
+
+	return &derived
+}
+
+func resetAdaptiveDiagnostics(config *FilterChainConfig) {
+	config.DS201LPContentType = 0
+	config.DS201LPReason = ""
+	config.DS201LPRolloffRatio = 0
+
+	config.DS201GateGentleMode = false
+	resetDS201GateDiagnostics(config)
+
+	config.LA2AHighCrestActive = false
+	config.LA2AHighCrestDeficit = 0
+	config.LA2AHighCrestSeverity = 0
+	config.LA2AHighCrestProjectedTP = 0
+}
+
+func resetDS201GateDiagnostics(config *FilterChainConfig) {
+	config.DS201GateAggression = 0
+	config.DS201GateDynamicRange = 0
+	config.DS201GateQuietSpeechEstimate = 0
+	config.DS201GateSpeechSeparation = 0
+	config.DS201GateSpeechHeadroom = 0
+	config.DS201GateThresholdUnclamped = 0
+	config.DS201GateClampReason = ""
 }
 
 // DbToLinear converts decibel value to linear amplitude.

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -3,8 +3,10 @@ package processor
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestConfig creates a minimal FilterChainConfig for testing.
@@ -777,6 +779,104 @@ func TestFilterOrderRespected(t *testing.T) {
 	}
 	if deesserPos >= aformatPos {
 		t.Errorf("deesser (pos %d) should come before aformat (pos %d)", deesserPos, aformatPos)
+	}
+}
+
+func TestDerivePerFileConfig(t *testing.T) {
+	measurements := &AudioMeasurements{InputI: -24.0}
+	base := DefaultFilterConfig()
+	base.Pass = PassProcessing
+	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
+	base.Measurements = measurements
+	base.OutputAnalysisEnabled = true
+	base.TargetI = -18.0
+	base.SilenceScanDuration = 2 * time.Second
+	base.NoiseRemoveCompandThreshold = -48.0
+
+	base.DS201LPContentType = ContentMusic
+	base.DS201LPReason = "stale lowpass reason"
+	base.DS201LPRolloffRatio = 3.5
+	base.DS201GateGentleMode = true
+	base.DS201GateAggression = 0.45
+	base.DS201GateDynamicRange = 12.0
+	base.DS201GateQuietSpeechEstimate = -42.0
+	base.DS201GateSpeechSeparation = 18.0
+	base.DS201GateSpeechHeadroom = 7.0
+	base.DS201GateThresholdUnclamped = -35.0
+	base.DS201GateClampReason = "speech_rms"
+	base.LA2AHighCrestActive = true
+	base.LA2AHighCrestDeficit = 2.5
+	base.LA2AHighCrestSeverity = 0.4
+	base.LA2AHighCrestProjectedTP = 1.2
+
+	derived := derivePerFileConfig(base)
+	if derived == nil {
+		t.Fatal("derivePerFileConfig returned nil")
+	}
+	if derived == base {
+		t.Fatal("derivePerFileConfig returned the base pointer")
+	}
+
+	if derived.Pass != 0 {
+		t.Errorf("Pass = %d, want 0", derived.Pass)
+	}
+	if derived.Measurements != nil {
+		t.Errorf("Measurements = %p, want nil", derived.Measurements)
+	}
+	if derived.OutputAnalysisEnabled {
+		t.Error("OutputAnalysisEnabled = true, want false")
+	}
+
+	if !reflect.DeepEqual(derived.FilterOrder, base.FilterOrder) {
+		t.Errorf("FilterOrder = %v, want %v", derived.FilterOrder, base.FilterOrder)
+	}
+	derived.FilterOrder[0] = FilterDownmix
+	if base.FilterOrder[0] == FilterDownmix {
+		t.Error("derived FilterOrder mutation changed base FilterOrder")
+	}
+
+	if derived.TargetI != base.TargetI {
+		t.Errorf("TargetI = %.1f, want %.1f", derived.TargetI, base.TargetI)
+	}
+	if derived.SilenceScanDuration != base.SilenceScanDuration {
+		t.Errorf("SilenceScanDuration = %s, want %s", derived.SilenceScanDuration, base.SilenceScanDuration)
+	}
+	if derived.NoiseRemoveCompandThreshold != base.NoiseRemoveCompandThreshold {
+		t.Errorf("NoiseRemoveCompandThreshold = %.1f, want %.1f",
+			derived.NoiseRemoveCompandThreshold, base.NoiseRemoveCompandThreshold)
+	}
+
+	if derived.DS201LPContentType != 0 || derived.DS201LPReason != "" || derived.DS201LPRolloffRatio != 0 {
+		t.Errorf("low-pass diagnostics not reset: type=%v reason=%q ratio=%.2f",
+			derived.DS201LPContentType, derived.DS201LPReason, derived.DS201LPRolloffRatio)
+	}
+	if derived.DS201GateGentleMode ||
+		derived.DS201GateAggression != 0 ||
+		derived.DS201GateDynamicRange != 0 ||
+		derived.DS201GateQuietSpeechEstimate != 0 ||
+		derived.DS201GateSpeechSeparation != 0 ||
+		derived.DS201GateSpeechHeadroom != 0 ||
+		derived.DS201GateThresholdUnclamped != 0 ||
+		derived.DS201GateClampReason != "" {
+		t.Errorf("gate diagnostics not reset: %+v", derived)
+	}
+	if derived.LA2AHighCrestActive ||
+		derived.LA2AHighCrestDeficit != 0 ||
+		derived.LA2AHighCrestSeverity != 0 ||
+		derived.LA2AHighCrestProjectedTP != 0 {
+		t.Errorf("LA-2A diagnostics not reset: active=%v deficit=%.2f severity=%.2f projected=%.2f",
+			derived.LA2AHighCrestActive,
+			derived.LA2AHighCrestDeficit,
+			derived.LA2AHighCrestSeverity,
+			derived.LA2AHighCrestProjectedTP)
+	}
+
+	if base.Pass != PassProcessing ||
+		base.Measurements != measurements ||
+		!base.OutputAnalysisEnabled ||
+		base.DS201GateClampReason != "speech_rms" ||
+		!base.LA2AHighCrestActive {
+		t.Error("derivePerFileConfig mutated the base config")
 	}
 }
 

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -45,11 +45,20 @@ type LoudnormStats struct {
 
 // loudnormLogCapture manages thread-safe capture of loudnorm's JSON output.
 var loudnormLogCapture = struct {
+	lifecycleMu  sync.Mutex
 	mu           sync.Mutex
 	buffer       strings.Builder
 	capturing    bool
 	prevLogLevel int
 }{}
+
+var (
+	loudnormAVLogGetLevel     = ffmpeg.AVLogGetLevel
+	loudnormAVLogSetLevel     = ffmpeg.AVLogSetLevel
+	loudnormAVLogSetCallback  = ffmpeg.AVLogSetCallback
+	loudnormAVFilterGraphFree = ffmpeg.AVFilterGraphFree
+	loudnormRunFilterGraph    = runFilterGraph
+)
 
 // loudnormLogCallback captures loudnorm JSON output from FFmpeg's logging system.
 // loudnorm outputs JSON at AV_LOG_INFO level when print_format=json is set.
@@ -65,26 +74,32 @@ func loudnormLogCallback(_ *ffmpeg.LogCtx, _ int, msg string) {
 // startLoudnormCapture begins capturing loudnorm log output.
 // Must be called before processing frames through the loudnorm filter.
 // Temporarily raises log level to INFO since loudnorm outputs JSON at that level.
+// FFmpeg logging is process-global, so capture is serialised from start through
+// stop for both Pass 3 measurement and Pass 4 application.
 func startLoudnormCapture() {
+	loudnormLogCapture.lifecycleMu.Lock()
+
 	loudnormLogCapture.mu.Lock()
 	defer loudnormLogCapture.mu.Unlock()
 
 	loudnormLogCapture.buffer.Reset()
 	loudnormLogCapture.capturing = true
-	loudnormLogCapture.prevLogLevel, _ = ffmpeg.AVLogGetLevel()
-	ffmpeg.AVLogSetLevel(ffmpeg.AVLogInfo) // loudnorm outputs JSON at INFO level
-	ffmpeg.AVLogSetCallback(loudnormLogCallback)
+	loudnormLogCapture.prevLogLevel, _ = loudnormAVLogGetLevel()
+	loudnormAVLogSetLevel(ffmpeg.AVLogInfo) // loudnorm outputs JSON at INFO level
+	loudnormAVLogSetCallback(loudnormLogCallback)
 }
 
 // stopLoudnormCapture ends capture, restores default logging, and parses the JSON.
 // Returns the parsed LoudnormStats or an error if JSON was not found/parseable.
 func stopLoudnormCapture() (*LoudnormStats, error) {
+	defer loudnormLogCapture.lifecycleMu.Unlock()
+
 	loudnormLogCapture.mu.Lock()
 	defer loudnormLogCapture.mu.Unlock()
 
 	loudnormLogCapture.capturing = false
-	ffmpeg.AVLogSetCallback(nil)                          // Restore default logging
-	ffmpeg.AVLogSetLevel(loudnormLogCapture.prevLogLevel) // Restore previous log level
+	loudnormAVLogSetCallback(nil)                          // Restore default logging
+	loudnormAVLogSetLevel(loudnormLogCapture.prevLogLevel) // Restore previous log level
 
 	// Extract JSON from captured log output
 	output := loudnormLogCapture.buffer.String()
@@ -181,7 +196,7 @@ func measureWithLoudnorm(inputPath string, config *FilterChainConfig, filterPref
 
 	// Process all frames through loudnorm (no encoding - just measurement)
 	lenientHandler := func(err error) error { return nil }
-	_ = runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	loopErr := loudnormRunFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnPushError: lenientHandler,
 		OnPullError: lenientHandler,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
@@ -195,10 +210,13 @@ func measureWithLoudnorm(inputPath string, config *FilterChainConfig, filterPref
 	})
 
 	// Free filter graph to trigger loudnorm JSON output
-	ffmpeg.AVFilterGraphFree(&filterGraph)
+	loudnormAVFilterGraphFree(&filterGraph)
 
 	// Capture loudnorm stats from log output
 	stats, err := stopLoudnormCapture()
+	if loopErr != nil {
+		return nil, fmt.Errorf("loudnorm measurement loop failed: %w", loopErr)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to capture loudnorm measurements: %w", err)
 	}
@@ -613,7 +631,7 @@ func applyLoudnormAndMeasure(
 	// Create output encoder (same format as input)
 	encoder, err := createOutputEncoder(tempPath, metadata, bufferSinkCtx)
 	if err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create encoder: %w", err)
 	}
 	defer encoder.Close()
@@ -628,7 +646,7 @@ func applyLoudnormAndMeasure(
 	const progressUpdateInterval = 100 // Send progress update every N frames
 
 	lenientHandler := func(err error) error { return nil }
-	loopErr := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	loopErr := loudnormRunFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnPushError: lenientHandler,
 		OnPullError: lenientHandler,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
@@ -655,30 +673,30 @@ func applyLoudnormAndMeasure(
 		},
 	})
 	if loopErr != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, loopErr
 	}
 
 	// Flush encoder
 	if err := encoder.Flush(); err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to flush encoder: %w", err)
 	}
 
 	// Close encoder before rename
 	if err := encoder.Close(); err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to close encoder: %w", err)
 	}
 
 	// Atomic rename: temp file → original file (in-place update)
 	if err := os.Rename(tempPath, inputPath); err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to rename output: %w", err)
 	}
 
 	// Free filter graph before getting stats — loudnorm outputs JSON on graph destruction
-	ffmpeg.AVFilterGraphFree(&filterGraph)
+	loudnormAVFilterGraphFree(&filterGraph)
 
 	// Capture loudnorm stats (JSON output captured during filter graph free)
 	stats := getLoudnormStats()

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -730,11 +730,11 @@ func applyLoudnormAndMeasure(
 	}
 
 	// Close encoder before rename
+	encoderClosed = true
 	if err := encoder.Close(); err != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to close encoder: %w", err)
 	}
-	encoderClosed = true
 
 	// Atomic rename: temp file → original file (in-place update)
 	if err := loudnormRename(tempPath, inputPath); err != nil {

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -675,7 +675,12 @@ func applyLoudnormAndMeasure(
 		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create encoder: %w", err)
 	}
-	defer encoder.Close()
+	encoderClosed := false
+	defer func() {
+		if !encoderClosed {
+			_ = encoder.Close()
+		}
+	}()
 
 	// Process frames and accumulate ebur128 measurements using Pass 2's extraction function
 	var acc outputMetadataAccumulators
@@ -729,6 +734,7 @@ func applyLoudnormAndMeasure(
 		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to close encoder: %w", err)
 	}
+	encoderClosed = true
 
 	// Atomic rename: temp file → original file (in-place update)
 	if err := loudnormRename(tempPath, inputPath); err != nil {

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -58,7 +58,18 @@ var (
 	loudnormAVLogSetCallback  = ffmpeg.AVLogSetCallback
 	loudnormAVFilterGraphFree = ffmpeg.AVFilterGraphFree
 	loudnormRunFilterGraph    = runFilterGraph
+	loudnormSetupFilterGraph  = setupFilterGraph
+	loudnormCreateEncoder     = func(outputPath string, metadata *audio.Metadata, bufferSinkCtx *ffmpeg.AVFilterContext) (loudnormOutputEncoder, error) {
+		return createOutputEncoder(outputPath, metadata, bufferSinkCtx)
+	}
+	loudnormRename = os.Rename
 )
+
+type loudnormOutputEncoder interface {
+	WriteFrame(*ffmpeg.AVFrame) error
+	Flush() error
+	Close() error
+}
 
 // loudnormLogCallback captures loudnorm JSON output from FFmpeg's logging system.
 // loudnorm outputs JSON at AV_LOG_INFO level when print_format=json is set.
@@ -121,6 +132,36 @@ func stopLoudnormCapture() (*LoudnormStats, error) {
 	return &stats, nil
 }
 
+type loudnormCaptureSession struct {
+	mu      sync.Mutex
+	stopped bool
+}
+
+func beginLoudnormCapture() *loudnormCaptureSession {
+	startLoudnormCapture()
+	return &loudnormCaptureSession{}
+}
+
+func (session *loudnormCaptureSession) Stop() (*LoudnormStats, error) {
+	if session == nil {
+		return nil, nil
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	if session.stopped {
+		return nil, nil
+	}
+	session.stopped = true
+
+	return stopLoudnormCapture()
+}
+
+func (session *loudnormCaptureSession) StopDiscard() {
+	_, _ = session.Stop()
+}
+
 // LoudnormMeasurement holds the results from loudnorm's first pass (measurement mode).
 // This is populated by measureWithLoudnorm() which reads the Pass 2 output file
 // and runs loudnorm without encoding to get the measurements needed for second pass.
@@ -152,12 +193,12 @@ type LoudnormMeasurement struct {
 //   - err: Error if measurement failed
 func measureWithLoudnorm(inputPath string, config *FilterChainConfig, filterPrefix string, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*LoudnormMeasurement, error) {
 	// Start capturing loudnorm log output
-	startLoudnormCapture()
+	capture := beginLoudnormCapture()
+	defer capture.StopDiscard()
 
 	// Open input file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
-		_, _ = stopLoudnormCapture() // Clean up capture
 		return nil, fmt.Errorf("failed to open input: %w", err)
 	}
 	defer reader.Close()
@@ -189,7 +230,6 @@ func measureWithLoudnorm(inputPath string, config *FilterChainConfig, filterPref
 		filterSpec,
 	)
 	if err != nil {
-		_, _ = stopLoudnormCapture() // Clean up capture
 		return nil, fmt.Errorf("failed to create filter graph: %w", err)
 	}
 	// Note: We free the filter graph explicitly to trigger loudnorm JSON output
@@ -213,7 +253,7 @@ func measureWithLoudnorm(inputPath string, config *FilterChainConfig, filterPref
 	loudnormAVFilterGraphFree(&filterGraph)
 
 	// Capture loudnorm stats from log output
-	stats, err := stopLoudnormCapture()
+	stats, err := capture.Stop()
 	if loopErr != nil {
 		return nil, fmt.Errorf("loudnorm measurement loop failed: %w", loopErr)
 	}
@@ -596,11 +636,12 @@ func applyLoudnormAndMeasure(
 	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
 ) (float64, float64, *OutputMeasurements, *LoudnormStats, time.Duration, error) {
 	// Start capturing loudnorm's JSON output for diagnostics
-	startLoudnormCapture()
+	capture := beginLoudnormCapture()
+	defer capture.StopDiscard()
 
 	// Helper to stop capture and return stats (may be nil if capture failed)
 	getLoudnormStats := func() *LoudnormStats {
-		stats, _ := stopLoudnormCapture()
+		stats, _ := capture.Stop()
 		return stats
 	}
 
@@ -618,7 +659,7 @@ func applyLoudnormAndMeasure(
 	filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, ceiling, needsLimiting)
 
 	// Create filter graph
-	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(
+	filterGraph, bufferSrcCtx, bufferSinkCtx, err := loudnormSetupFilterGraph(
 		reader.GetDecoderContext(),
 		filterSpec,
 	)
@@ -629,7 +670,7 @@ func applyLoudnormAndMeasure(
 	// loudnorm outputs its JSON when the filter graph is freed.
 
 	// Create output encoder (same format as input)
-	encoder, err := createOutputEncoder(tempPath, metadata, bufferSinkCtx)
+	encoder, err := loudnormCreateEncoder(tempPath, metadata, bufferSinkCtx)
 	if err != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create encoder: %w", err)
@@ -690,7 +731,7 @@ func applyLoudnormAndMeasure(
 	}
 
 	// Atomic rename: temp file → original file (in-place update)
-	if err := os.Rename(tempPath, inputPath); err != nil {
+	if err := loudnormRename(tempPath, inputPath); err != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to rename output: %w", err)
 	}

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -118,6 +119,113 @@ func TestLoudnormCaptureSerialisesFullLifecycle(t *testing.T) {
 	}
 }
 
+func TestLoudnormCaptureSessionStopDiscardAfterStopDoesNotDoubleStop(t *testing.T) {
+	var callbackStops int
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(int) {},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				callbackStops++
+			}
+		},
+	)
+
+	capture := beginLoudnormCapture()
+	defer capture.StopDiscard()
+
+	loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+	if _, err := capture.Stop(); err != nil {
+		t.Fatalf("capture.Stop() error = %v", err)
+	}
+
+	capture.StopDiscard()
+
+	if callbackStops != 1 {
+		t.Fatalf("stop callback count = %d, want 1", callbackStops)
+	}
+}
+
+func TestLoudnormCaptureSessionSerialisesFullLifecycle(t *testing.T) {
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(int) {},
+		func(ffmpeg.LogCallback) {},
+	)
+
+	first := beginLoudnormCapture()
+	defer first.StopDiscard()
+
+	secondStarted := make(chan *loudnormCaptureSession, 1)
+	go func() {
+		secondStarted <- beginLoudnormCapture()
+	}()
+
+	select {
+	case second := <-secondStarted:
+		second.StopDiscard()
+		t.Fatal("second capture started before first capture stopped")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+	if _, err := first.Stop(); err != nil {
+		t.Fatalf("first capture.Stop() error = %v", err)
+	}
+
+	var second *loudnormCaptureSession
+	select {
+	case second = <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second capture did not start after first capture stopped")
+	}
+	defer second.StopDiscard()
+
+	loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+	if _, err := second.Stop(); err != nil {
+		t.Fatalf("second capture.Stop() error = %v", err)
+	}
+}
+
+func TestLoudnormCaptureSessionMalformedJSONRestoresLogOps(t *testing.T) {
+	var (
+		callbackStops int
+		levels        []int
+	)
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(level int) {
+			levels = append(levels, level)
+		},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				callbackStops++
+			}
+		},
+	)
+
+	capture := beginLoudnormCapture()
+	defer capture.StopDiscard()
+
+	loudnormLogCallback(nil, ffmpeg.AVLogInfo, "{not-json}")
+	_, err := capture.Stop()
+	if err == nil {
+		t.Fatal("capture.Stop() error = nil, want malformed JSON error")
+	}
+	if !strings.Contains(err.Error(), "failed to parse loudnorm JSON") {
+		t.Fatalf("capture.Stop() error = %q, want malformed JSON context", err.Error())
+	}
+	if callbackStops != 1 {
+		t.Fatalf("stop callback count = %d, want 1", callbackStops)
+	}
+
+	gotLevels := fmt.Sprint(levels)
+	wantLevels := fmt.Sprintf("[%d 7]", ffmpeg.AVLogInfo)
+	if gotLevels != wantLevels {
+		t.Fatalf("log levels = %s, want %s", gotLevels, wantLevels)
+	}
+}
+
 func TestMeasureWithLoudnormStopsCaptureOnOpenError(t *testing.T) {
 	var callbackStops int
 	replaceLoudnormLogOps(t,
@@ -204,6 +312,476 @@ func TestMeasureWithLoudnormLoopErrorFreesGraphBeforeStoppingCapture(t *testing.
 	if gotOrder != "free,stop" {
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
+}
+
+type loudnormCleanupRecorder struct {
+	mu     sync.Mutex
+	order  []string
+	levels []int
+	stops  int
+}
+
+func (r *loudnormCleanupRecorder) record(value string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.order = append(r.order, value)
+}
+
+func (r *loudnormCleanupRecorder) recordLevel(level int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.levels = append(r.levels, level)
+}
+
+func (r *loudnormCleanupRecorder) recordStop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stops++
+	r.order = append(r.order, "stop")
+}
+
+func (r *loudnormCleanupRecorder) freeCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var total int
+	for _, entry := range r.order {
+		if entry == "free" {
+			total++
+		}
+	}
+	return total
+}
+
+func (r *loudnormCleanupRecorder) orderString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return strings.Join(r.order, ",")
+}
+
+func (r *loudnormCleanupRecorder) stopCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stops
+}
+
+func (r *loudnormCleanupRecorder) levelString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return fmt.Sprint(r.levels)
+}
+
+func installLoudnormCleanupRecorder(t *testing.T) *loudnormCleanupRecorder {
+	t.Helper()
+
+	recorder := &loudnormCleanupRecorder{}
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(level int) {
+			recorder.recordLevel(level)
+		},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				recorder.recordStop()
+			}
+		},
+	)
+	return recorder
+}
+
+func requireLoudnormCaptureStoppedOnce(t *testing.T, recorder *loudnormCleanupRecorder) {
+	t.Helper()
+
+	if recorder.stopCount() != 1 {
+		t.Fatalf("capture stop count = %d, want 1", recorder.stopCount())
+	}
+
+	wantLevels := fmt.Sprintf("[%d 7]", ffmpeg.AVLogInfo)
+	if gotLevels := recorder.levelString(); gotLevels != wantLevels {
+		t.Fatalf("log levels = %s, want %s", gotLevels, wantLevels)
+	}
+}
+
+func replaceApplyLoudnormGraphFree(t *testing.T, recorder *loudnormCleanupRecorder, emitJSON bool) {
+	t.Helper()
+
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		recorder.record("free")
+		if emitJSON {
+			loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+		}
+		if graph != nil && *graph != nil {
+			oldFree(graph)
+		}
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+}
+
+func replaceApplyLoudnormSetupFilterGraph(
+	t *testing.T,
+	setup func(*ffmpeg.AVCodecContext, string) (*ffmpeg.AVFilterGraph, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, error),
+) {
+	t.Helper()
+
+	oldSetup := loudnormSetupFilterGraph
+	loudnormSetupFilterGraph = setup
+	t.Cleanup(func() {
+		loudnormSetupFilterGraph = oldSetup
+	})
+}
+
+func replaceApplyLoudnormCreateEncoder(
+	t *testing.T,
+	create func(string, *audio.Metadata, *ffmpeg.AVFilterContext) (loudnormOutputEncoder, error),
+) {
+	t.Helper()
+
+	oldCreate := loudnormCreateEncoder
+	loudnormCreateEncoder = create
+	t.Cleanup(func() {
+		loudnormCreateEncoder = oldCreate
+	})
+}
+
+func replaceApplyLoudnormRename(t *testing.T, rename func(string, string) error) {
+	t.Helper()
+
+	oldRename := loudnormRename
+	loudnormRename = rename
+	t.Cleanup(func() {
+		loudnormRename = oldRename
+	})
+}
+
+type loudnormTestEncoder struct {
+	flushErr error
+	closeErr error
+}
+
+func (e *loudnormTestEncoder) WriteFrame(*ffmpeg.AVFrame) error {
+	return nil
+}
+
+func (e *loudnormTestEncoder) Flush() error {
+	return e.flushErr
+}
+
+func (e *loudnormTestEncoder) Close() error {
+	return e.closeErr
+}
+
+func loudnormApplicationTestConfig() *FilterChainConfig {
+	config := DefaultFilterConfig()
+	config.AdeclickEnabled = false
+	return config
+}
+
+func loudnormApplicationTestMeasurement() *LoudnormMeasurement {
+	return &LoudnormMeasurement{
+		InputI:       -23.0,
+		InputTP:      -4.0,
+		InputLRA:     5.0,
+		InputThresh:  -33.0,
+		TargetOffset: 0.0,
+	}
+}
+
+func generateLoudnormApplicationTestAudio(t *testing.T) string {
+	t.Helper()
+
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 0.2,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -18.0,
+		Dir:          t.TempDir(),
+	})
+	t.Cleanup(func() {
+		cleanupTestAudio(t, testFile)
+	})
+	return testFile
+}
+
+func applyLoudnormTest(
+	t *testing.T,
+	inputPath string,
+) (float64, float64, *OutputMeasurements, *LoudnormStats, time.Duration, error) {
+	t.Helper()
+
+	return applyLoudnormAndMeasure(
+		inputPath,
+		loudnormApplicationTestConfig(),
+		loudnormApplicationTestMeasurement(),
+		nil,
+		0,
+		0,
+		false,
+		nil,
+	)
+}
+
+func TestApplyLoudnormAndMeasureStopsCaptureOnOpenError(t *testing.T) {
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, false)
+
+	_, _, _, _, _, err := applyLoudnormTest(t, "/does/not/exist.wav")
+	if err == nil {
+		t.Fatal("applyLoudnormAndMeasure() error = nil, want open error")
+	}
+	if !strings.Contains(err.Error(), "failed to open input") {
+		t.Fatalf("applyLoudnormAndMeasure() error = %q, want open context", err.Error())
+	}
+	if recorder.freeCount() != 0 {
+		t.Fatalf("graph free count = %d, want 0", recorder.freeCount())
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestApplyLoudnormAndMeasureSetupErrorStopsCaptureWithoutFree(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, false)
+
+	setupErr := errors.New("injected setup failure")
+	replaceApplyLoudnormSetupFilterGraph(t, func(
+		*ffmpeg.AVCodecContext,
+		string,
+	) (*ffmpeg.AVFilterGraph, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, error) {
+		return nil, nil, nil, setupErr
+	})
+
+	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	if !errors.Is(err, setupErr) {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped setup error", err)
+	}
+	if !strings.Contains(err.Error(), "failed to create filter graph") {
+		t.Fatalf("applyLoudnormAndMeasure() error = %q, want filter graph context", err.Error())
+	}
+	if recorder.freeCount() != 0 {
+		t.Fatalf("graph free count = %d, want 0", recorder.freeCount())
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestApplyLoudnormAndMeasureEncoderCreationErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+
+	createErr := errors.New("injected encoder creation failure")
+	replaceApplyLoudnormCreateEncoder(t, func(
+		string,
+		*audio.Metadata,
+		*ffmpeg.AVFilterContext,
+	) (loudnormOutputEncoder, error) {
+		return nil, createErr
+	})
+
+	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	if !errors.Is(err, createErr) {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped encoder creation error", err)
+	}
+	if !strings.Contains(err.Error(), "failed to create encoder") {
+		t.Fatalf("applyLoudnormAndMeasure() error = %q, want encoder context", err.Error())
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestApplyLoudnormAndMeasureLoopErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+	replaceApplyLoudnormCreateEncoder(t, func(
+		string,
+		*audio.Metadata,
+		*ffmpeg.AVFilterContext,
+	) (loudnormOutputEncoder, error) {
+		return &loudnormTestEncoder{}, nil
+	})
+
+	runErr := errors.New("injected application loop failure")
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return runErr
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v, want loop error", err)
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestApplyLoudnormAndMeasureFlushErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+
+	flushErr := errors.New("injected flush failure")
+	replaceApplyLoudnormCreateEncoder(t, func(
+		string,
+		*audio.Metadata,
+		*ffmpeg.AVFilterContext,
+	) (loudnormOutputEncoder, error) {
+		return &loudnormTestEncoder{flushErr: flushErr}, nil
+	})
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	if !errors.Is(err, flushErr) {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped flush error", err)
+	}
+	if !strings.Contains(err.Error(), "failed to flush encoder") {
+		t.Fatalf("applyLoudnormAndMeasure() error = %q, want flush context", err.Error())
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+
+	closeErr := errors.New("injected close failure")
+	replaceApplyLoudnormCreateEncoder(t, func(
+		string,
+		*audio.Metadata,
+		*ffmpeg.AVFilterContext,
+	) (loudnormOutputEncoder, error) {
+		return &loudnormTestEncoder{closeErr: closeErr}, nil
+	})
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped close error", err)
+	}
+	if !strings.Contains(err.Error(), "failed to close encoder") {
+		t.Fatalf("applyLoudnormAndMeasure() error = %q, want close context", err.Error())
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestApplyLoudnormAndMeasureRenameErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+	replaceApplyLoudnormCreateEncoder(t, func(
+		string,
+		*audio.Metadata,
+		*ffmpeg.AVFilterContext,
+	) (loudnormOutputEncoder, error) {
+		return &loudnormTestEncoder{}, nil
+	})
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	renameErr := errors.New("injected rename failure")
+	replaceApplyLoudnormRename(t, func(oldPath, newPath string) error {
+		if filepath.Dir(oldPath) != filepath.Dir(testFile) {
+			t.Fatalf("temp file dir = %q, want %q", filepath.Dir(oldPath), filepath.Dir(testFile))
+		}
+		if !strings.HasSuffix(oldPath, ".loudnorm.tmp.flac") {
+			t.Fatalf("temp file path = %q, want .loudnorm.tmp.flac suffix", oldPath)
+		}
+		if newPath != testFile {
+			t.Fatalf("rename target = %q, want %q", newPath, testFile)
+		}
+		return renameErr
+	})
+
+	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	if !errors.Is(err, renameErr) {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped rename error", err)
+	}
+	if !strings.Contains(err.Error(), "failed to rename output") {
+		t.Fatalf("applyLoudnormAndMeasure() error = %q, want rename context", err.Error())
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestApplyLoudnormAndMeasureSuccessFreesGraphBeforeStoppingCapture(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+
+	finalLUFS, _, finalMeasurements, stats, _, err := applyLoudnormTest(t, testFile)
+	if err != nil {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v", err)
+	}
+	if stats == nil {
+		t.Fatal("loudnorm stats = nil, want parsed stats")
+	}
+	if stats.OutputI != "-16.0" {
+		t.Fatalf("stats.OutputI = %q, want -16.0", stats.OutputI)
+	}
+	if finalMeasurements == nil {
+		t.Fatal("final measurements = nil, want measurements")
+	}
+	if math.IsNaN(finalLUFS) {
+		t.Fatal("final LUFS is NaN")
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
 }
 
 func TestCalculateLinearModeTarget(t *testing.T) {

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -459,6 +459,8 @@ func replaceApplyLoudnormRename(t *testing.T, rename func(string, string) error)
 type loudnormTestEncoder struct {
 	flushErr error
 	closeErr error
+	closed   bool
+	closeN   int
 }
 
 func (e *loudnormTestEncoder) WriteFrame(*ffmpeg.AVFrame) error {
@@ -470,6 +472,11 @@ func (e *loudnormTestEncoder) Flush() error {
 }
 
 func (e *loudnormTestEncoder) Close() error {
+	e.closeN++
+	if e.closed {
+		return nil
+	}
+	e.closed = true
 	return e.closeErr
 }
 
@@ -597,12 +604,13 @@ func TestApplyLoudnormAndMeasureLoopErrorFreesGraphBeforeStoppingCapture(t *test
 	testFile := generateLoudnormApplicationTestAudio(t)
 	recorder := installLoudnormCleanupRecorder(t)
 	replaceApplyLoudnormGraphFree(t, recorder, true)
+	encoder := &loudnormTestEncoder{}
 	replaceApplyLoudnormCreateEncoder(t, func(
 		string,
 		*audio.Metadata,
 		*ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
-		return &loudnormTestEncoder{}, nil
+		return encoder, nil
 	})
 
 	runErr := errors.New("injected application loop failure")
@@ -625,6 +633,9 @@ func TestApplyLoudnormAndMeasureLoopErrorFreesGraphBeforeStoppingCapture(t *test
 	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
+	if encoder.closeN != 1 {
+		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
+	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
 }
 
@@ -634,12 +645,13 @@ func TestApplyLoudnormAndMeasureFlushErrorFreesGraphBeforeStoppingCapture(t *tes
 	replaceApplyLoudnormGraphFree(t, recorder, true)
 
 	flushErr := errors.New("injected flush failure")
+	encoder := &loudnormTestEncoder{flushErr: flushErr}
 	replaceApplyLoudnormCreateEncoder(t, func(
 		string,
 		*audio.Metadata,
 		*ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
-		return &loudnormTestEncoder{flushErr: flushErr}, nil
+		return encoder, nil
 	})
 
 	oldRun := loudnormRunFilterGraph
@@ -664,6 +676,9 @@ func TestApplyLoudnormAndMeasureFlushErrorFreesGraphBeforeStoppingCapture(t *tes
 	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
+	if encoder.closeN != 1 {
+		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
+	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
 }
 
@@ -673,12 +688,13 @@ func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *tes
 	replaceApplyLoudnormGraphFree(t, recorder, true)
 
 	closeErr := errors.New("injected close failure")
+	encoder := &loudnormTestEncoder{closeErr: closeErr}
 	replaceApplyLoudnormCreateEncoder(t, func(
 		string,
 		*audio.Metadata,
 		*ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
-		return &loudnormTestEncoder{closeErr: closeErr}, nil
+		return encoder, nil
 	})
 
 	oldRun := loudnormRunFilterGraph
@@ -703,6 +719,9 @@ func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *tes
 	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
+	if encoder.closeN != 2 {
+		t.Fatalf("encoder close calls = %d, want 2", encoder.closeN)
+	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
 }
 
@@ -710,12 +729,13 @@ func TestApplyLoudnormAndMeasureRenameErrorFreesGraphBeforeStoppingCapture(t *te
 	testFile := generateLoudnormApplicationTestAudio(t)
 	recorder := installLoudnormCleanupRecorder(t)
 	replaceApplyLoudnormGraphFree(t, recorder, true)
+	encoder := &loudnormTestEncoder{}
 	replaceApplyLoudnormCreateEncoder(t, func(
 		string,
 		*audio.Metadata,
 		*ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
-		return &loudnormTestEncoder{}, nil
+		return encoder, nil
 	})
 
 	oldRun := loudnormRunFilterGraph
@@ -753,6 +773,9 @@ func TestApplyLoudnormAndMeasureRenameErrorFreesGraphBeforeStoppingCapture(t *te
 	}
 	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	if encoder.closeN != 1 {
+		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
 }

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -719,8 +719,8 @@ func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *tes
 	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
-	if encoder.closeN != 2 {
-		t.Fatalf("encoder close calls = %d, want 2", encoder.closeN)
+	if encoder.closeN != 1 {
+		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
 }

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -2,11 +2,209 @@
 package processor
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
+	"github.com/linuxmatters/jivetalking/internal/audio"
 )
+
+const loudnormCaptureTestJSON = `{"input_i":"-23.0","input_tp":"-4.0","input_lra":"5.0","input_thresh":"-33.0","output_i":"-16.0","output_tp":"-2.0","output_lra":"5.0","output_thresh":"-26.0","normalization_type":"linear","target_offset":"0.0"}`
+
+func replaceLoudnormLogOps(
+	t *testing.T,
+	getLevel func() (int, error),
+	setLevel func(int),
+	setCallback func(ffmpeg.LogCallback),
+) {
+	t.Helper()
+
+	oldGetLevel := loudnormAVLogGetLevel
+	oldSetLevel := loudnormAVLogSetLevel
+	oldSetCallback := loudnormAVLogSetCallback
+
+	loudnormAVLogGetLevel = getLevel
+	loudnormAVLogSetLevel = setLevel
+	loudnormAVLogSetCallback = setCallback
+
+	t.Cleanup(func() {
+		loudnormAVLogGetLevel = oldGetLevel
+		loudnormAVLogSetLevel = oldSetLevel
+		loudnormAVLogSetCallback = oldSetCallback
+	})
+}
+
+func TestLoudnormCaptureLogOperationSeams(t *testing.T) {
+	var calls []string
+	replaceLoudnormLogOps(t,
+		func() (int, error) {
+			calls = append(calls, "get-level")
+			return 7, nil
+		},
+		func(level int) {
+			calls = append(calls, fmt.Sprintf("set-level-%d", level))
+		},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				calls = append(calls, "set-callback-nil")
+				return
+			}
+			calls = append(calls, "set-callback-capture")
+		},
+	)
+
+	startLoudnormCapture()
+	loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+	stats, err := stopLoudnormCapture()
+	if err != nil {
+		t.Fatalf("stopLoudnormCapture() error = %v", err)
+	}
+	if stats.InputI != "-23.0" {
+		t.Fatalf("stats.InputI = %q, want -23.0", stats.InputI)
+	}
+
+	wantCalls := []string{
+		"get-level",
+		fmt.Sprintf("set-level-%d", ffmpeg.AVLogInfo),
+		"set-callback-capture",
+		"set-callback-nil",
+		"set-level-7",
+	}
+	if strings.Join(calls, ",") != strings.Join(wantCalls, ",") {
+		t.Fatalf("calls = %v, want %v", calls, wantCalls)
+	}
+}
+
+func TestLoudnormCaptureSerialisesFullLifecycle(t *testing.T) {
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(int) {},
+		func(ffmpeg.LogCallback) {},
+	)
+
+	startLoudnormCapture()
+
+	secondStarted := make(chan struct{})
+	go func() {
+		startLoudnormCapture()
+		close(secondStarted)
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second capture started before first capture stopped")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+	if _, err := stopLoudnormCapture(); err != nil {
+		t.Fatalf("first stopLoudnormCapture() error = %v", err)
+	}
+
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second capture did not start after first capture stopped")
+	}
+
+	loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+	if _, err := stopLoudnormCapture(); err != nil {
+		t.Fatalf("second stopLoudnormCapture() error = %v", err)
+	}
+}
+
+func TestMeasureWithLoudnormStopsCaptureOnOpenError(t *testing.T) {
+	var callbackStops int
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(int) {},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				callbackStops++
+			}
+		},
+	)
+
+	_, err := measureWithLoudnorm("/does/not/exist.wav", DefaultFilterConfig(), "", nil)
+	if err == nil {
+		t.Fatal("measureWithLoudnorm() error = nil, want open error")
+	}
+	if callbackStops != 1 {
+		t.Fatalf("stop callback count = %d, want 1", callbackStops)
+	}
+}
+
+func TestMeasureWithLoudnormLoopErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 0.2,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -18.0,
+		Dir:          t.TempDir(),
+	})
+	defer cleanupTestAudio(t, testFile)
+
+	var (
+		mu    sync.Mutex
+		order []string
+	)
+	record := func(value string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, value)
+	}
+
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(int) {},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				record("stop")
+			}
+		},
+	)
+
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		record("free")
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+		oldFree(graph)
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+
+	runErr := errors.New("injected frame loop failure")
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return runErr
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	_, err := measureWithLoudnorm(testFile, DefaultFilterConfig(), "", nil)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("measureWithLoudnorm() error = %v, want wrapped run error", err)
+	}
+	if !strings.Contains(err.Error(), "loudnorm measurement loop failed") {
+		t.Fatalf("measureWithLoudnorm() error = %q, want measurement loop context", err.Error())
+	}
+
+	gotOrder := strings.Join(order, ",")
+	if gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+}
 
 func TestCalculateLinearModeTarget(t *testing.T) {
 	// Note: calculateLinearModeTarget includes a 0.1 dB safety margin to ensure

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -43,12 +43,12 @@ func AnalyzeOnlyDetailed(inputPath string, config *FilterChainConfig,
 
 	// Adapt config to show what would be used in Pass 2
 	adaptationStart := time.Now()
-	AdaptConfig(config, measurements)
+	effectiveConfig := AdaptConfig(config, measurements)
 	adaptationDuration := time.Since(adaptationStart)
 
 	return &AnalysisResult{
 		Measurements:       measurements,
-		Config:             config,
+		Config:             effectiveConfig,
 		AnalysisDuration:   analysisDuration,
 		AdaptationDuration: adaptationDuration,
 	}, nil
@@ -77,7 +77,7 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 	}
 
 	// Adapt filter configuration based on Pass 1 measurements
-	AdaptConfig(config, measurements)
+	effectiveConfig := AdaptConfig(config, measurements)
 
 	// Pass 2: Processing
 	if progressCallback != nil {
@@ -88,17 +88,17 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 	outputPath := generateOutputPath(inputPath)
 
 	// Enable output analysis to measure processed audio characteristics
-	config.OutputAnalysisEnabled = true
+	effectiveConfig.OutputAnalysisEnabled = true
 
 	// Set Pass 2 configuration for filter chain
-	config.Pass = PassProcessing
-	config.FilterOrder = Pass2FilterOrder
+	effectiveConfig.Pass = PassProcessing
+	effectiveConfig.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
 
 	// Track output measurements from Pass 2 (filtered but not yet normalised)
 	var filteredMeasurements *OutputMeasurements
 	var regionTimings RegionMeasurementTimings
 
-	inputMetadata, err := processWithFilters(inputPath, outputPath, config, progressCallback, measurements, &filteredMeasurements)
+	inputMetadata, err := processWithFilters(inputPath, outputPath, effectiveConfig, progressCallback, measurements, &filteredMeasurements)
 	if err != nil {
 		return nil, fmt.Errorf("pass 2 failed: %w", err)
 	}
@@ -123,7 +123,7 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 	// The FinalMeasurements in the result include region measurements captured in Pass 4
 	var normResult *NormalisationResult
 	if filteredMeasurements != nil {
-		normResult, err = ApplyNormalisation(outputPath, config, filteredMeasurements, measurements, progressCallback)
+		normResult, err = ApplyNormalisation(outputPath, effectiveConfig, filteredMeasurements, measurements, progressCallback)
 		if err != nil {
 			return nil, fmt.Errorf("pass 3 failed: %w", err)
 		}
@@ -137,7 +137,7 @@ func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback 
 		OutputLUFS:           0.0, // Will be set to final value below
 		NoiseFloor:           measurements.NoiseFloor,
 		Measurements:         measurements,
-		Config:               config, // Include config for logging adaptive parameters
+		Config:               effectiveConfig, // Include per-file config for logging adaptive parameters
 		InputMetadata:        inputMetadata,
 		RegionTimings:        regionTimings,
 		FilteredMeasurements: filteredMeasurements,

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/linuxmatters/jivetalking/internal/audio"
@@ -87,6 +88,11 @@ func TestProcessAudio(t *testing.T) {
 	config.AnalysisEnabled = true
 	config.ResampleEnabled = true
 	config.DS201HPEnabled = true // Basic processing
+	config.DS201HPFreq = 95.0
+	basePass := config.Pass
+	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
+	baseMeasurements := config.Measurements
+	baseOutputAnalysisEnabled := config.OutputAnalysisEnabled
 
 	// Process the audio with a no-op progress callback
 	result, err := ProcessAudio(testFile, config, func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
@@ -138,6 +144,46 @@ func TestProcessAudio(t *testing.T) {
 	// Verify measurements are populated
 	if result.Measurements == nil {
 		t.Error("ProcessAudio returned nil measurements")
+	}
+	if config.Pass != basePass {
+		t.Errorf("base Pass = %d, want %d", config.Pass, basePass)
+	}
+	if !reflect.DeepEqual(config.FilterOrder, baseFilterOrder) {
+		t.Errorf("base FilterOrder = %v, want %v", config.FilterOrder, baseFilterOrder)
+	}
+	if config.Measurements != baseMeasurements {
+		t.Fatal("base Measurements was mutated")
+	}
+	if config.OutputAnalysisEnabled != baseOutputAnalysisEnabled {
+		t.Errorf("base OutputAnalysisEnabled = %v, want %v", config.OutputAnalysisEnabled, baseOutputAnalysisEnabled)
+	}
+	if config.DS201HPFreq != 95.0 {
+		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", config.DS201HPFreq)
+	}
+	if result.Config == nil {
+		t.Fatal("ProcessAudio returned nil config")
+	}
+	if result.Config == config {
+		t.Fatal("ProcessAudio returned the caller seed config")
+	}
+	if result.Config.Measurements != result.Measurements {
+		t.Fatal("result config Measurements does not point at Pass 1 measurements")
+	}
+	if result.Config.Pass != PassProcessing {
+		t.Errorf("result config Pass = %d, want %d", result.Config.Pass, PassProcessing)
+	}
+	if !reflect.DeepEqual(result.Config.FilterOrder, Pass2FilterOrder) {
+		t.Errorf("result config FilterOrder = %v, want %v", result.Config.FilterOrder, Pass2FilterOrder)
+	}
+	if !result.Config.OutputAnalysisEnabled {
+		t.Fatal("result config OutputAnalysisEnabled = false, want true")
+	}
+	if result.Config.DS201HPFreq == 95.0 {
+		t.Fatal("result config DS201HPFreq did not adapt from base seed value")
+	}
+	result.Config.FilterOrder[0] = FilterDeesser
+	if config.FilterOrder[0] == FilterDeesser {
+		t.Fatal("result config FilterOrder mutation changed base FilterOrder")
 	}
 
 	// Verify report-needed input metadata is populated from the processing path
@@ -245,6 +291,12 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	config := newTestConfig()
 	config.DownmixEnabled = true
 	config.AnalysisEnabled = true
+	config.DS201HPEnabled = true
+	config.DS201HPFreq = 95.0
+	basePass := config.Pass
+	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
+	baseMeasurements := config.Measurements
+	baseOutputAnalysisEnabled := config.OutputAnalysisEnabled
 
 	result, err := AnalyzeOnlyDetailed(testFile, config, nil)
 	if err != nil {
@@ -256,6 +308,27 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	}
 	if result.Config == nil {
 		t.Fatal("AnalyzeOnlyDetailed returned nil config")
+	}
+	if result.Config == config {
+		t.Fatal("AnalyzeOnlyDetailed returned the caller seed config")
+	}
+	if result.Config.Measurements != result.Measurements {
+		t.Fatal("result config Measurements does not point at Pass 1 measurements")
+	}
+	if config.Pass != basePass {
+		t.Errorf("base Pass = %d, want %d", config.Pass, basePass)
+	}
+	if !reflect.DeepEqual(config.FilterOrder, baseFilterOrder) {
+		t.Errorf("base FilterOrder = %v, want %v", config.FilterOrder, baseFilterOrder)
+	}
+	if config.Measurements != baseMeasurements {
+		t.Fatal("base Measurements was mutated")
+	}
+	if config.OutputAnalysisEnabled != baseOutputAnalysisEnabled {
+		t.Errorf("base OutputAnalysisEnabled = %v, want %v", config.OutputAnalysisEnabled, baseOutputAnalysisEnabled)
+	}
+	if config.DS201HPFreq != 95.0 {
+		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", config.DS201HPFreq)
 	}
 	if result.AnalysisDuration <= 0 {
 		t.Errorf("AnalysisDuration = %s, want > 0", result.AnalysisDuration)

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -60,6 +60,37 @@ func TestGenerateLUFSOutputPath(t *testing.T) {
 	}
 }
 
+func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
+	base := newTestConfig()
+	base.FilterOrder = []FilterID{FilterAnalysis, FilterDeesser}
+
+	first := AdaptConfig(base, &AudioMeasurements{
+		BaseMeasurements: BaseMeasurements{
+			SpectralCentroid: 5000,
+		},
+	})
+	second := AdaptConfig(base, &AudioMeasurements{
+		BaseMeasurements: BaseMeasurements{
+			SpectralCentroid: 2000,
+		},
+	})
+	if first == nil || second == nil {
+		t.Fatal("AdaptConfig returned nil")
+	}
+
+	first.FilterOrder[0] = FilterDownmix
+
+	if reflect.DeepEqual(first.FilterOrder, base.FilterOrder) {
+		t.Fatal("test setup failed: first effective FilterOrder did not change")
+	}
+	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterAnalysis, FilterDeesser}) {
+		t.Errorf("base FilterOrder = %v, want unchanged custom order", base.FilterOrder)
+	}
+	if !reflect.DeepEqual(second.FilterOrder, []FilterID{FilterAnalysis, FilterDeesser}) {
+		t.Errorf("second effective FilterOrder = %v, want independent copy", second.FilterOrder)
+	}
+}
+
 // TestProcessAudio tests the complete three-pass processing pipeline
 func TestProcessAudio(t *testing.T) {
 	// Generate synthetic test audio: 3-second 440Hz tone at -18 dBFS input level


### PR DESCRIPTION
## Summary
Fix processor state leakage across files by isolating adaptive filter configuration, tightening loudnorm log capture lifecycle management, and making encoder cleanup idempotent.

## Changes
- Return an effective adaptive configuration per processed file instead of sharing mutable filter state
- Serialise and scope loudnorm log capture cleanup so concurrent or repeated normalisation paths do not leak state
- Add application-path cleanup coverage for processor and CLI flows
- Avoid double-closing the loudnorm encoder
- Expand processor tests for adaptive config isolation, filters, analyser behaviour, normalisation cleanup, and encoder close handling

## Testing
- Existing branch commits include processor and CLI test coverage for the changed paths

## Related Issues
