### PR TITLE
refactor(processor): split filter config and diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,13 @@ cmd/jivetalking/main.go     # CLI entry, Kong flags, starts TUI + processing gor
 internal/
 ├── audio/reader.go         # FFmpeg demuxer/decoder wrapper (Reader, Metadata, OpenAudioFile)
 ├── processor/
-│   ├── adaptive.go         # AdaptConfig() - tunes FilterChainConfig from Pass 1 measurements
+│   ├── adaptive.go         # AdaptConfig() - derives effective filter settings + diagnostics from Pass 1 measurements
 │   ├── analyzer.go         # AnalyzeAudio() - Pass 1: ebur128 + astats + aspectralstats; silence/speech detection
 │   ├── analyzer_candidates.go  # Silence candidate scoring and election
 │   ├── analyzer_metrics.go     # IntervalSample, SpectralMetrics, per-250ms metric accumulation
 │   ├── analyzer_output.go      # MeasureOutputRegions() - before/after region comparison
 │   ├── encoder.go          # Output file encoder wrapper
-│   ├── filters.go          # FilterChainConfig, filter builder funcs, BuildFilterSpec(), DefaultFilterConfig()
+│   ├── filters.go          # BaseFilterConfig, EffectiveFilterConfig, AdaptiveDiagnostics, filter builders, BuildFilterSpec(), DefaultFilterConfig()
 │   ├── frame_processor.go  # runFilterGraph(), FrameLoopConfig - shared filter graph execution
 │   ├── normalise.go        # ApplyNormalisation() - Pass 3/4: loudnorm measurement + application
 │   └── processor.go        # ProcessAudio(), AnalyzeOnlyDetailed() - pass orchestration
@@ -120,7 +120,7 @@ Two separate message sets exist for the two TUI modes.
 
 ## Adaptive processing
 
-`AdaptConfig()` in `adaptive.go` tunes `FilterChainConfig` from Pass 1 `AudioMeasurements`:
+`AdaptConfig()` in `adaptive.go` derives per-file filter state from Pass 1 `AudioMeasurements`: it accepts caller-owned `BaseFilterConfig` defaults, returns `EffectiveFilterConfig` for filter building, and returns `AdaptiveDiagnostics` for report-only adaptation explanations. Do not reintroduce `FilterChainConfig` or store pass execution state in config; use `ProcessingFilterContext` for pass-local state.
 
 - **DS201 highpass frequency:** 60-120Hz based on spectral decrease (warm/thin voice detection) and silence noise floor; warm voices use gentler Q (0.5) and reduced wet/dry mix
 - **DS201 lowpass:** Enabled adaptively based on content type and HF noise indicators (rolloff/centroid ratio)

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ internal/
 ├── processor/
 │   ├── analyzer.go         # Pass 1: ebur128 + astats + aspectralstats
 │   ├── processor.go        # Pass 2: adaptive filter chain execution
-│   ├── filters.go          # FilterChainConfig, BuildFilterSpec()
+│   ├── filters.go          # BaseFilterConfig, EffectiveFilterConfig, BuildFilterSpec()
 │   └── adaptive.go         # Measurement-driven parameter tuning
 ├── ui/                     # Bubbletea model, views, messages
 └── cli/                    # Help styling, version output

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -191,8 +191,8 @@ type analysisOnlyDeps struct {
 	stdout          io.Writer
 	hasTTY          func() bool
 	openMetadata    func(string) (*audio.Metadata, error)
-	runWithTUI      func(string, *processor.FilterChainConfig, func(string, ...any)) (*processor.AnalysisResult, error)
-	analyzeDetailed func(string, *processor.FilterChainConfig, func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error)
+	runWithTUI      func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error)
+	analyzeDetailed func(string, *processor.BaseFilterConfig, func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error)
 	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.FilterChainConfig, ...logging.AnalysisTimings)
 	printError      func(string)
 }
@@ -269,11 +269,11 @@ func (ph *progressHandler) callback(pass processor.PassNumber, passName string, 
 
 // runAnalysisOnly performs Pass 1 analysis on each file with a progress UI,
 // then displays results to console. Skips full 4-pass processing.
-func runAnalysisOnly(files []string, config *processor.FilterChainConfig, log func(string, ...any)) {
+func runAnalysisOnly(files []string, config *processor.BaseFilterConfig, log func(string, ...any)) {
 	runAnalysisOnlyWithDeps(files, config, log, defaultAnalysisOnlyDeps())
 }
 
-func runAnalysisOnlyWithDeps(files []string, config *processor.FilterChainConfig, log func(string, ...any), deps analysisOnlyDeps) {
+func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig, log func(string, ...any), deps analysisOnlyDeps) {
 	// Check if we have a TTY for the progress UI
 	hasTTY := deps.hasTTY()
 
@@ -335,7 +335,7 @@ func isTTY() bool {
 }
 
 // runAnalysisWithTUI runs analysis with the Bubbletea progress UI.
-func runAnalysisWithTUI(inputPath string, config *processor.FilterChainConfig, log func(string, ...any)) (*processor.AnalysisResult, error) {
+func runAnalysisWithTUI(inputPath string, config *processor.BaseFilterConfig, log func(string, ...any)) (*processor.AnalysisResult, error) {
 	// Create the analysis UI model
 	model := ui.NewAnalysisModel()
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -321,7 +321,11 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 			Analysis:   analysisResult.AnalysisDuration,
 			Adaptation: analysisResult.AdaptationDuration,
 		}
-		deps.displayResults(deps.stdout, inputPath, metadata, analysisResult.Measurements, analysisResult.Config, timings)
+		var displayConfig *processor.FilterChainConfig
+		if analysisResult.Config != nil {
+			displayConfig = &analysisResult.Config.FilterChainConfig
+		}
+		deps.displayResults(deps.stdout, inputPath, metadata, analysisResult.Measurements, displayConfig, timings)
 	}
 }
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -193,7 +193,7 @@ type analysisOnlyDeps struct {
 	openMetadata    func(string) (*audio.Metadata, error)
 	runWithTUI      func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error)
 	analyzeDetailed func(string, *processor.BaseFilterConfig, func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error)
-	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.FilterChainConfig, ...logging.AnalysisTimings)
+	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.EffectiveFilterConfig, *processor.AdaptiveDiagnostics, ...logging.AnalysisTimings)
 	printError      func(string)
 }
 
@@ -204,7 +204,7 @@ func defaultAnalysisOnlyDeps() analysisOnlyDeps {
 		openMetadata:    openAudioMetadata,
 		runWithTUI:      runAnalysisWithTUI,
 		analyzeDetailed: processor.AnalyzeOnlyDetailed,
-		displayResults:  logging.DisplayAnalysisResults,
+		displayResults:  logging.DisplayAnalysisResultsWithDiagnostics,
 		printError:      cli.PrintError,
 	}
 }
@@ -321,11 +321,7 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 			Analysis:   analysisResult.AnalysisDuration,
 			Adaptation: analysisResult.AdaptationDuration,
 		}
-		var displayConfig *processor.FilterChainConfig
-		if analysisResult.Config != nil {
-			displayConfig = &analysisResult.Config.FilterChainConfig
-		}
-		deps.displayResults(deps.stdout, inputPath, metadata, analysisResult.Measurements, displayConfig, timings)
+		deps.displayResults(deps.stdout, inputPath, metadata, analysisResult.Measurements, analysisResult.Config, analysisResult.Diagnostics, timings)
 	}
 }
 

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -44,9 +44,10 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 			if progress != nil {
 				t.Fatal("progress callback should be nil for non-TTY output")
 			}
+			effective, _ := processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements())
 			return &processor.AnalysisResult{
 				Measurements:       makeAnalysisOnlyTestMeasurements(),
-				Config:             processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements()),
+				Config:             &effective.FilterChainConfig,
 				AnalysisDuration:   2 * time.Second,
 				AdaptationDuration: 100 * time.Millisecond,
 			}, nil
@@ -79,9 +80,11 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	files := []string{"first.wav", "second.wav"}
 	baseConfig := processor.DefaultFilterConfig()
 	var output bytes.Buffer
+	firstEffective, _ := processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements())
+	secondEffective, _ := processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements())
 	resultConfigs := []*processor.FilterChainConfig{
-		processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements()),
-		processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements()),
+		&firstEffective.FilterChainConfig,
+		&secondEffective.FilterChainConfig,
 	}
 	resultConfigs[0].DS201HPFreq = 60.0
 	resultConfigs[1].DS201HPFreq = 100.0

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -47,7 +47,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 			effective, _ := processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements())
 			return &processor.AnalysisResult{
 				Measurements:       makeAnalysisOnlyTestMeasurements(),
-				Config:             &effective.FilterChainConfig,
+				Config:             effective,
 				AnalysisDuration:   2 * time.Second,
 				AdaptationDuration: 100 * time.Millisecond,
 			}, nil
@@ -82,9 +82,9 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	var output bytes.Buffer
 	firstEffective, _ := processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements())
 	secondEffective, _ := processor.AdaptConfig(processor.DefaultFilterConfig(), makeAnalysisOnlyTestMeasurements())
-	resultConfigs := []*processor.FilterChainConfig{
-		&firstEffective.FilterChainConfig,
-		&secondEffective.FilterChainConfig,
+	resultConfigs := []*processor.EffectiveFilterConfig{
+		firstEffective,
+		secondEffective,
 	}
 	resultConfigs[0].DS201HPFreq = 60.0
 	resultConfigs[1].DS201HPFreq = 100.0
@@ -144,8 +144,8 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 		t.Fatalf("displayed config count = %d, want %d", len(displayedConfigs), len(resultConfigs))
 	}
 	for i := range resultConfigs {
-		if displayedConfigs[i] != resultConfigs[i] {
-			t.Fatalf("displayed config %d = %p, want AnalysisResult.Config %p", i, displayedConfigs[i], resultConfigs[i])
+		if displayedConfigs[i] != &resultConfigs[i].FilterChainConfig {
+			t.Fatalf("displayed config %d = %p, want AnalysisResult.Config %p", i, displayedConfigs[i], &resultConfigs[i].FilterChainConfig)
 		}
 	}
 	if !reflect.DeepEqual(resultConfigs[1].FilterOrder, secondFilterOrder) {

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -33,11 +33,11 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		runWithTUI: func(string, *processor.FilterChainConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
+		runWithTUI: func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
 			t.Fatal("runWithTUI should not be called for non-TTY output")
 			return nil, nil
 		},
-		analyzeDetailed: func(path string, cfg *processor.FilterChainConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
+		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
 			if path != inputPath {
 				t.Fatalf("analyzeDetailed path = %q, want %q", path, inputPath)
 			}
@@ -46,7 +46,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 			}
 			return &processor.AnalysisResult{
 				Measurements:       makeAnalysisOnlyTestMeasurements(),
-				Config:             cfg,
+				Config:             processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements()),
 				AnalysisDuration:   2 * time.Second,
 				AdaptationDuration: 100 * time.Millisecond,
 			}, nil
@@ -87,7 +87,7 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	resultConfigs[1].DS201HPFreq = 100.0
 	secondFilterOrder := append([]processor.FilterID(nil), resultConfigs[1].FilterOrder...)
 
-	var analyzedConfigs []*processor.FilterChainConfig
+	var analyzedConfigs []*processor.BaseFilterConfig
 	var displayedConfigs []*processor.FilterChainConfig
 
 	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, analysisOnlyDeps{
@@ -102,11 +102,11 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		runWithTUI: func(string, *processor.FilterChainConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
+		runWithTUI: func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
 			t.Fatal("runWithTUI should not be called for non-TTY output")
 			return nil, nil
 		},
-		analyzeDetailed: func(path string, cfg *processor.FilterChainConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
+		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
 			if cfg != baseConfig {
 				t.Fatalf("analyzeDetailed config = %p, want shared base %p", cfg, baseConfig)
 			}

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -44,15 +44,16 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 			if progress != nil {
 				t.Fatal("progress callback should be nil for non-TTY output")
 			}
-			effective, _ := processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements())
+			effective, diagnostics := processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements())
 			return &processor.AnalysisResult{
 				Measurements:       makeAnalysisOnlyTestMeasurements(),
 				Config:             effective,
+				Diagnostics:        diagnostics,
 				AnalysisDuration:   2 * time.Second,
 				AdaptationDuration: 100 * time.Millisecond,
 			}, nil
 		},
-		displayResults: logging.DisplayAnalysisResults,
+		displayResults: logging.DisplayAnalysisResultsWithDiagnostics,
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
 		},
@@ -89,9 +90,14 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	resultConfigs[0].DS201HPFreq = 60.0
 	resultConfigs[1].DS201HPFreq = 100.0
 	secondFilterOrder := append([]processor.FilterID(nil), resultConfigs[1].FilterOrder...)
+	resultDiagnostics := []*processor.AdaptiveDiagnostics{
+		{DS201LPReason: "first"},
+		{DS201LPReason: "second"},
+	}
 
 	var analyzedConfigs []*processor.BaseFilterConfig
-	var displayedConfigs []*processor.FilterChainConfig
+	var displayedConfigs []*processor.EffectiveFilterConfig
+	var displayedDiagnostics []*processor.AdaptiveDiagnostics
 
 	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, analysisOnlyDeps{
 		stdout: &output,
@@ -119,12 +125,14 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 			return &processor.AnalysisResult{
 				Measurements:       makeAnalysisOnlyTestMeasurements(),
 				Config:             resultConfigs[index],
+				Diagnostics:        resultDiagnostics[index],
 				AnalysisDuration:   2 * time.Second,
 				AdaptationDuration: 100 * time.Millisecond,
 			}, nil
 		},
-		displayResults: func(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig, timings ...logging.AnalysisTimings) {
+		displayResults: func(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, timings ...logging.AnalysisTimings) {
 			displayedConfigs = append(displayedConfigs, config)
+			displayedDiagnostics = append(displayedDiagnostics, diagnostics)
 			if len(displayedConfigs) == 1 {
 				config.FilterOrder[0] = processor.FilterAnalysis
 			}
@@ -144,8 +152,11 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 		t.Fatalf("displayed config count = %d, want %d", len(displayedConfigs), len(resultConfigs))
 	}
 	for i := range resultConfigs {
-		if displayedConfigs[i] != &resultConfigs[i].FilterChainConfig {
-			t.Fatalf("displayed config %d = %p, want AnalysisResult.Config %p", i, displayedConfigs[i], &resultConfigs[i].FilterChainConfig)
+		if displayedConfigs[i] != resultConfigs[i] {
+			t.Fatalf("displayed config %d = %p, want AnalysisResult.Config %p", i, displayedConfigs[i], resultConfigs[i])
+		}
+		if displayedDiagnostics[i] != resultDiagnostics[i] {
+			t.Fatalf("displayed diagnostics %d = %p, want AnalysisResult.Diagnostics %p", i, displayedDiagnostics[i], resultDiagnostics[i])
 		}
 	}
 	if !reflect.DeepEqual(resultConfigs[1].FilterOrder, secondFilterOrder) {

--- a/docs/FilterCompressor-Teletronix LA-2A.md
+++ b/docs/FilterCompressor-Teletronix LA-2A.md
@@ -142,34 +142,33 @@ Real LA-2As have no parallel compression—they're 100% wet. We default to full 
 | Home office | −65 to −45 dBFS | 0.93 |
 | Noisy environment | > −45 dBFS | 0.85 |
 
-### Makeup Gain: Conservative Compensation
+### Makeup Gain: Unity
 
-Makeup gain compensates for compression but shouldn't over-drive downstream processing:
-
-```
-overshoot = peak_level − threshold
-reduction = overshoot × (1 − 1/ratio)
-makeup = reduction × 0.65
-```
-
-Clamped to 1–5 dB. Let normalisation handle the rest.
+Makeup gain stays at 0 dB. Loudnorm handles final level adjustment after compression.
 
 ---
 
 ## Configuration
 
-### FilterChainConfig Fields
+### Configuration Fields
+
+`BaseFilterConfig` stores caller-owned LA-2A defaults. `AdaptConfig()` copies those defaults into an `EffectiveFilterConfig`, tunes them from Pass 1 measurements, and returns `AdaptiveDiagnostics` for report-only high-crest explanations.
 
 | Field | Type | Range | Default | Purpose |
 |-------|------|-------|---------|---------|
 | `LA2AEnabled` | bool | — | true | Enable/disable filter |
-| `LA2AThreshold` | float64 | −40 to −12 dB | −24 dB | Compression threshold |
+| `LA2AThreshold` | float64 | −40 to −12 dB | −18 dB | Compression threshold |
 | `LA2ARatio` | float64 | 2.0–5.0 | 3.0 | Compression ratio |
 | `LA2AAttack` | float64 | 8–12 ms | 10 ms | Attack time |
 | `LA2ARelease` | float64 | 150–350 ms | 200 ms | Release time |
-| `LA2AMakeup` | float64 | 1–5 dB | 2 dB | Makeup gain |
+| `LA2AMakeup` | float64 | 0 dB | 0 dB | Unity gain |
 | `LA2AKnee` | float64 | 3.5–6.0 | 4.0 | Knee softness |
 | `LA2AMix` | float64 | 0.85–1.0 | 1.0 | Wet/dry mix |
+
+### AdaptiveDiagnostics Fields
+
+| Field | Type | Range | Default | Purpose |
+|-------|------|-------|---------|---------|
 | `LA2AHighCrestActive` | bool | — | false | Whether high-crest overrides were applied |
 | `LA2AHighCrestDeficit` | float64 | dB | 0.0 | Predicted ceiling deficit |
 | `LA2AHighCrestSeverity` | float64 | 0.0–1.0 | 0.0 | Override scaling factor |

--- a/docs/FilterCompressor-Teletronix LA-2A.md
+++ b/docs/FilterCompressor-Teletronix LA-2A.md
@@ -176,8 +176,10 @@ Makeup gain stays at 0 dB. Loudnorm handles final level adjustment after compres
 
 ### FFmpeg Filter Specification
 
+`LA2AThreshold` and `LA2AMakeup` are configured in dB, then converted to FFmpeg's linear `acompressor` values:
+
 ```
-acompressor=threshold=-24dB:ratio=3:attack=10:release=200:makeup=2dB:knee=4:mix=1
+acompressor=threshold=0.125893:ratio=3.0:attack=10:release=200:makeup=1.00:knee=4.0:detection=rms:mix=1.00
 ```
 
 ---

--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -29,7 +29,14 @@ type analysisMetricSpec struct {
 
 // DisplayAnalysisResults outputs Pass 1 analysis results to the console.
 // Used by --analysis-only mode for rapid inspection without full processing.
-func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig, timings ...AnalysisTimings) {
+func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.EffectiveFilterConfig, timings ...AnalysisTimings) {
+	DisplayAnalysisResultsWithDiagnostics(w, inputPath, metadata, measurements, config, nil, timings...)
+}
+
+// DisplayAnalysisResultsWithDiagnostics outputs Pass 1 analysis results using
+// the effective per-file filter config and separately routed adaptive
+// diagnostics.
+func DisplayAnalysisResultsWithDiagnostics(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, timings ...AnalysisTimings) {
 	if measurements == nil {
 		fmt.Fprintf(w, "No analysis data available for %s\n", filepath.Base(inputPath))
 		return
@@ -41,7 +48,7 @@ func DisplayAnalysisResults(w io.Writer, inputPath string, metadata *audio.Metad
 	writeAnalysisSilenceDetection(w, measurements)
 	writeAnalysisSpeechDetection(w, measurements)
 	writeAnalysisDerivedMeasurements(w, measurements)
-	writeAnalysisFilterAdaptation(w, measurements, config)
+	writeAnalysisFilterAdaptation(w, measurements, config, diagnostics)
 	writeAnalysisSpectralSummary(w, measurements)
 	writeAnalysisTips(w, measurements, config)
 
@@ -118,12 +125,25 @@ func writeAnalysisDerivedMeasurements(w io.Writer, measurements *processor.Audio
 	fmt.Fprintln(w)
 }
 
-func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig) {
+func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMeasurements, config *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics) {
 	writeAnalysisSection(w, "FILTER ADAPTATION")
 	if config != nil {
 		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
 			{"Highpass", fmt.Sprintf("%.0f Hz (from spectral analysis)", config.DS201HPFreq)},
 		})
+		if config.DS201LPEnabled {
+			lowpassValue := fmt.Sprintf("%.0f Hz", config.DS201LPFreq)
+			if diagnostics != nil && diagnostics.DS201LPReason != "" {
+				lowpassValue += fmt.Sprintf(" (%s)", diagnostics.DS201LPReason)
+			}
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"Lowpass", lowpassValue},
+			})
+		} else if diagnostics != nil && diagnostics.DS201LPReason != "" {
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"Lowpass", fmt.Sprintf("disabled (%s)", diagnostics.DS201LPReason)},
+			})
+		}
 		if measurements.NoiseProfile != nil {
 			gateThresholdDB := processor.LinearToDb(config.DS201GateThreshold)
 			gateDesc := "(from noise floor)"
@@ -134,6 +154,11 @@ func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMea
 				{"Gate Threshold", fmt.Sprintf("%.1f dB %s", gateThresholdDB, gateDesc)},
 				{"Gate Ratio", fmt.Sprintf("%.1f:1", config.DS201GateRatio)},
 			})
+			if diagnostics != nil && diagnostics.DS201GateClampReason != "" && diagnostics.DS201GateClampReason != "none" {
+				writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+					{"Gate Clamp", fmt.Sprintf("%s (unclamped %.1f dB)", diagnostics.DS201GateClampReason, diagnostics.DS201GateThresholdUnclamped)},
+				})
+			}
 		}
 		if config.NoiseRemoveCompandEnabled {
 			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
@@ -158,6 +183,11 @@ func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMea
 			{"LA-2A Thresh", fmt.Sprintf("%.0f dB", config.LA2AThreshold)},
 			{"LA-2A Ratio", fmt.Sprintf("%.1f:1", config.LA2ARatio)},
 		})
+		if diagnostics != nil && diagnostics.LA2AHighCrestActive {
+			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
+				{"LA-2A Crest", fmt.Sprintf("high-crest override active (deficit %.1f dB, severity %.2f)", diagnostics.LA2AHighCrestDeficit, diagnostics.LA2AHighCrestSeverity)},
+			})
+		}
 	}
 }
 
@@ -178,7 +208,7 @@ func writeAnalysisSpectralSummary(w io.Writer, measurements *processor.AudioMeas
 	})
 }
 
-func writeAnalysisTips(w io.Writer, measurements *processor.AudioMeasurements, config *processor.FilterChainConfig) {
+func writeAnalysisTips(w io.Writer, measurements *processor.AudioMeasurements, config *processor.EffectiveFilterConfig) {
 	tips := GenerateRecordingTips(measurements, config)
 	fmt.Fprintln(w)
 	writeAnalysisSection(w, "RECORDING TIPS")

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -240,6 +240,7 @@ DERIVED MEASUREMENTS
 
 FILTER ADAPTATION
   Highpass:       85 Hz (from spectral analysis)
+  Lowpass:        16000 Hz
   Gate Threshold: -51.2 dB (with breath reduction)
   Gate Ratio:     3.0:1
   NR Threshold:   -53 dB
@@ -270,6 +271,54 @@ ANALYSIS TIMINGS
 `
 	if got := buf.String(); got != want {
 		t.Fatalf("DisplayAnalysisResults output mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestDisplayAnalysisResultsWithDiagnostics_UsesEffectiveConfigAndDiagnostics(t *testing.T) {
+	m := makeFullAnalysisMeasurements()
+	config := processor.DefaultEffectiveFilterConfig()
+	config.DS201LPEnabled = false
+	config.DeessIntensity = 0.62
+	config.DS201GateThreshold = processor.DbToLinear(-48.2)
+	config.DS201GateRatio = 3.5
+	config.LA2AThreshold = -26
+	config.LA2ARatio = 4.2
+	effective := config
+	diagnostics := &processor.AdaptiveDiagnostics{
+		DS201LPReason:               "rolloff/centroid gap",
+		DS201GateClampReason:        "quiet speech ceiling",
+		DS201GateThresholdUnclamped: -44.5,
+		LA2AHighCrestActive:         true,
+		LA2AHighCrestDeficit:        5.6,
+		LA2AHighCrestSeverity:       0.78,
+	}
+
+	var buf bytes.Buffer
+	DisplayAnalysisResultsWithDiagnostics(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, effective, diagnostics)
+	output := buf.String()
+
+	for _, want := range []string{
+		"Lowpass:        disabled (rolloff/centroid gap)",
+		"Gate Threshold: -48.2 dB (with breath reduction)",
+		"Gate Ratio:     3.5:1",
+		"Gate Clamp:     quiet speech ceiling (unclamped -44.5 dB)",
+		"De-esser:       62% intensity",
+		"LA-2A Thresh:   -26 dB",
+		"LA-2A Ratio:    4.2:1",
+		"LA-2A Crest:    high-crest override active (deficit 5.6 dB, severity 0.78)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("analysis output missing %q", want)
+		}
+	}
+
+	for _, stale := range []string{
+		"stale config lowpass reason",
+		"stale config gate clamp",
+	} {
+		if strings.Contains(output, stale) {
+			t.Errorf("analysis output used stale config diagnostics %q", stale)
+		}
 	}
 }
 

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -142,7 +142,7 @@ func TestDisplayAnalysisResults_VoiceActivated_NoElectedCandidate(t *testing.T) 
 		},
 	}
 
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
 	output := buf.String()
@@ -154,7 +154,7 @@ func TestDisplayAnalysisResults_VoiceActivated_NoElectedCandidate(t *testing.T) 
 
 func TestDisplayAnalysisResults_FullOutputFixture(t *testing.T) {
 	m := makeFullAnalysisMeasurements()
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	config.NoiseRemoveCompandEnabled = true
 	config.NoiseRemoveCompandThreshold = -53
 	config.NoiseRemoveCompandExpansion = 7
@@ -278,7 +278,7 @@ func TestDisplayAnalysisResults_VoiceActivated_NoSilence(t *testing.T) {
 	m.VoiceActivated = true
 	// No SilenceCandidates, no NoiseProfile
 
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
 	output := buf.String()
@@ -306,7 +306,7 @@ func TestDisplayAnalysisResults_Normal_NoVoiceActivated(t *testing.T) {
 		},
 	}
 
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
 	output := buf.String()
@@ -318,7 +318,7 @@ func TestDisplayAnalysisResults_Normal_NoVoiceActivated(t *testing.T) {
 
 func TestDisplayAnalysisResults_CompanderDisabled(t *testing.T) {
 	m := makeMinimalMeasurements()
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	config.NoiseRemoveCompandEnabled = false
 
 	var buf bytes.Buffer
@@ -338,7 +338,7 @@ func TestDisplayAnalysisResults_CompanderDisabled(t *testing.T) {
 
 func TestDisplayAnalysisResults_CompanderEnabled(t *testing.T) {
 	m := makeMinimalMeasurements()
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	config.NoiseRemoveCompandEnabled = true
 	config.NoiseRemoveCompandThreshold = -55
 	config.NoiseRemoveCompandExpansion = 6
@@ -360,7 +360,7 @@ func TestDisplayAnalysisResults_CompanderEnabled(t *testing.T) {
 
 func TestDisplayAnalysisResults_TimingLabels(t *testing.T) {
 	m := makeMinimalMeasurements()
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	timings := AnalysisTimings{
 		Analysis:     2 * time.Second,
 		Adaptation:   100 * time.Millisecond,
@@ -404,7 +404,7 @@ func TestCompleteAnalysisTimings_CapturesReportOutput(t *testing.T) {
 
 func TestDisplayAnalysisResults_ExcludesProcessingOnlyFields(t *testing.T) {
 	m := makeMinimalMeasurements()
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	timings := AnalysisTimings{
 		Analysis:   2 * time.Second,
 		Adaptation: 100 * time.Millisecond,
@@ -447,7 +447,7 @@ func TestDisplayAnalysisResults_CapsSilenceCandidatesChronologicallyWithElectedF
 		MeasuredNoiseFloor: m.SilenceCandidates[0].RMSLevel,
 	}
 
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
 	output := buf.String()
@@ -498,7 +498,7 @@ func TestDisplayAnalysisResults_CapsSpeechCandidatesChronologicallyWithElectedFi
 	m.SpeechCandidates[0].VoicingDensity = 0.82
 	m.SpeechProfile = &m.SpeechCandidates[0]
 
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
 	output := buf.String()
@@ -549,7 +549,7 @@ func TestDisplayAnalysisResults_SpeechRejectionSummaryIncludesZeroScore(t *testi
 	m.SpeechCandidates[1].Score = 0.0
 	m.SpeechProfile = &m.SpeechCandidates[0]
 
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
 	output := buf.String()
@@ -578,7 +578,7 @@ func TestDisplayAnalysisResults_SpeechDisplaySummaryIncludesZeroOmitted(t *testi
 	m.SpeechCandidates = makeRankedSpeechCandidates(4)
 	m.SpeechProfile = &m.SpeechCandidates[0]
 
-	config := processor.DefaultFilterConfig()
+	config := processor.DefaultEffectiveFilterConfig()
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
 	output := buf.String()

--- a/internal/logging/recording_tips.go
+++ b/internal/logging/recording_tips.go
@@ -22,7 +22,7 @@ const MaxRecordingTips = 5
 
 // GenerateRecordingTips analyses audio measurements and returns prioritised
 // recording improvement suggestions.
-func GenerateRecordingTips(m *processor.AudioMeasurements, config *processor.FilterChainConfig) []RecordingTip {
+func GenerateRecordingTips(m *processor.AudioMeasurements, config *processor.EffectiveFilterConfig) []RecordingTip {
 	if m == nil {
 		return nil
 	}
@@ -30,7 +30,7 @@ func GenerateRecordingTips(m *processor.AudioMeasurements, config *processor.Fil
 	var tips []RecordingTip
 	firedRules := make(map[string]bool)
 
-	rules := []func(*processor.AudioMeasurements, *processor.FilterChainConfig) *RecordingTip{
+	rules := []func(*processor.AudioMeasurements, *processor.EffectiveFilterConfig) *RecordingTip{
 		tipLevelTooHot,
 		tipLevelTooQuiet,
 		tipLevelQuiet,
@@ -124,7 +124,7 @@ func wrapText(text string, maxWidth int, indent string) string {
 // Uses SpeechProfile.RMSLevel when available (speech RMS < -42 dBFS),
 // falling back to InputI < -30 LUFS when no speech profile exists.
 // Gain target is -24 dBFS for speech RMS, -16 LUFS for InputI fallback.
-func tipLevelTooQuiet(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipLevelTooQuiet(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	var gainNeeded float64
 	if m.SpeechProfile != nil {
 		speechRMS := m.SpeechProfile.RMSLevel
@@ -165,7 +165,7 @@ func tipLevelTooQuiet(m *processor.AudioMeasurements, _ *processor.FilterChainCo
 // Uses SpeechProfile.RMSLevel when available (speech RMS between -42 and -36 dBFS),
 // falling back to InputI between -30 and -24 LUFS when no speech profile exists.
 // Gain target is -24 dBFS for speech RMS, -16 LUFS for InputI fallback.
-func tipLevelQuiet(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipLevelQuiet(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	var gainNeeded float64
 	if m.SpeechProfile != nil {
 		speechRMS := m.SpeechProfile.RMSLevel
@@ -204,7 +204,7 @@ func tipLevelQuiet(m *processor.AudioMeasurements, _ *processor.FilterChainConfi
 
 // tipLevelTooHot fires when true peak approaches or exceeds 0 dBTP.
 // InputTP > 0.0 means actual clipping; > -1.0 means dangerously close.
-func tipLevelTooHot(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipLevelTooHot(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	if m.InputTP <= -1.0 {
 		return nil
 	}
@@ -244,7 +244,7 @@ func tipLevelTooHot(m *processor.AudioMeasurements, _ *processor.FilterChainConf
 // tipBackgroundNoise fires when the noise floor is elevated.
 // Uses NoiseProfile.MeasuredNoiseFloor when available, falling back to AstatsNoiseFloor.
 // Thresholds align with adaptive.go: -45 dBFS (la2aNoiseFloorNoisy), -55 dBFS (midpoint).
-func tipBackgroundNoise(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipBackgroundNoise(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	noiseFloor := m.AstatsNoiseFloor
 	if m.NoiseProfile != nil {
 		noiseFloor = m.NoiseProfile.MeasuredNoiseFloor
@@ -270,7 +270,7 @@ func tipBackgroundNoise(m *processor.AudioMeasurements, _ *processor.FilterChain
 // tipMainsHum fires when silence regions show tonal noise characteristics.
 // Requires NoiseProfile with low entropy (< 0.30, matching silenceEntropyTonal in adaptive.go),
 // low flatness (< 0.3, confirming tonal character), and audible noise (> -65 dBFS).
-func tipMainsHum(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipMainsHum(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	if m.NoiseProfile == nil {
 		return nil
 	}
@@ -290,7 +290,7 @@ func tipMainsHum(m *processor.AudioMeasurements, _ *processor.FilterChainConfig)
 // Requires both SpeechProfile and NoiseProfile to be present.
 // Thresholds: NoiseReductionHeadroom < 15 dB (below minSNRMargin of 20 dB in analyzer.go)
 // AND SpeechProfile.RMSLevel < -30 dBFS.
-func tipTooFarFromMic(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipTooFarFromMic(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	if m.SpeechProfile == nil || m.NoiseProfile == nil {
 		return nil
 	}
@@ -309,7 +309,7 @@ func tipTooFarFromMic(m *processor.AudioMeasurements, _ *processor.FilterChainCo
 // Thresholds from adaptive.go: spectralDecreaseVeryWarm = -0.10,
 // spectralDecreaseWarm = -0.05. Skewness > 2.5 is tip-specific (stricter
 // than adaptive.go's spectralSkewnessLFEmphasis = 1.0).
-func tipProximityEffect(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipProximityEffect(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	decrease := m.SpectralDecrease
 	skewness := m.SpectralSkewness
 	if m.SpeechProfile != nil {
@@ -332,10 +332,10 @@ func tipProximityEffect(m *processor.AudioMeasurements, _ *processor.FilterChain
 
 // tipSibilance fires when the adaptive de-esser was set to high intensity,
 // confirmed by bright speech spectral characteristics.
-// Checks FilterChainConfig.DeessIntensity > 0.5 (deessIntensityNormal in adaptive.go),
+// Checks EffectiveFilterConfig.DeessIntensity > 0.5 (deessIntensityNormal in adaptive.go),
 // speech centroid > 4000 Hz (centroidBright), and speech rolloff > 10000 Hz.
 // Prefers SpeechProfile metrics when available, falling back to full-file metrics.
-func tipSibilance(m *processor.AudioMeasurements, config *processor.FilterChainConfig) *RecordingTip {
+func tipSibilance(m *processor.AudioMeasurements, config *processor.EffectiveFilterConfig) *RecordingTip {
 	if config == nil || config.DeessIntensity <= 0.5 {
 		return nil
 	}
@@ -363,7 +363,7 @@ func tipSibilance(m *processor.AudioMeasurements, config *processor.FilterChainC
 
 // tipDynamicRange fires when the loudness range is very wide (InputLRA > 18 LU),
 // indicating inconsistent speaking volume or microphone distance.
-func tipDynamicRange(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipDynamicRange(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	if m.InputLRA <= 18.0 {
 		return nil
 	}
@@ -378,7 +378,7 @@ func tipDynamicRange(m *processor.AudioMeasurements, _ *processor.FilterChainCon
 // indicating aggressive AGC or prior processing has damaged the audio.
 // Threshold: CrestFactor < 6 dB (brickwalled per Spectral-Metrics-Reference.md).
 // CrestFactor == 0 is treated as unmeasured and skipped.
-func tipOverCompressed(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipOverCompressed(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	crest := m.CrestFactor
 	if m.SpeechProfile != nil && m.SpeechProfile.CrestFactor > 0 {
 		crest = m.SpeechProfile.CrestFactor
@@ -397,7 +397,7 @@ func tipOverCompressed(m *processor.AudioMeasurements, _ *processor.FilterChainC
 // tipPoorSNR fires when the noise-to-speech gap is critically small.
 // Threshold: NoiseReductionHeadroom < 10 dB (half of minSNRMargin 20 dB).
 // NoiseReductionHeadroom == 0 is treated as unmeasured and skipped.
-func tipPoorSNR(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipPoorSNR(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	if m.NoiseReductionHeadroom >= 10.0 || m.NoiseReductionHeadroom == 0 {
 		return nil
 	}
@@ -413,7 +413,7 @@ func tipPoorSNR(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) 
 // Threshold: CrestFactor > 20 dB (well above spoken word optimal 9-14 dB).
 // CrestFactor == 0 is treated as unmeasured and skipped.
 // Prefers SpeechProfile.CrestFactor when available, falling back to full-file CrestFactor.
-func tipHighCrestFactor(m *processor.AudioMeasurements, _ *processor.FilterChainConfig) *RecordingTip {
+func tipHighCrestFactor(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
 	crest := m.CrestFactor
 	if m.SpeechProfile != nil && m.SpeechProfile.CrestFactor > 0 {
 		crest = m.SpeechProfile.CrestFactor

--- a/internal/logging/recording_tips_test.go
+++ b/internal/logging/recording_tips_test.go
@@ -585,7 +585,7 @@ func TestTipProximityEffect(t *testing.T) {
 func TestTipSibilance(t *testing.T) {
 	tests := []struct {
 		name          string
-		config        *processor.FilterChainConfig
+		config        *processor.EffectiveFilterConfig
 		centroid      float64
 		rolloff       float64
 		speechProfile *processor.SpeechCandidateMetrics
@@ -593,21 +593,21 @@ func TestTipSibilance(t *testing.T) {
 	}{
 		{
 			name:     "high de-esser bright speech",
-			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			wantTip:  true,
 		},
 		{
 			name:     "low de-esser",
-			config:   &processor.FilterChainConfig{DeessIntensity: 0.3},
+			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.3},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			wantTip:  false,
 		},
 		{
 			name:     "de-esser at boundary no tip",
-			config:   &processor.FilterChainConfig{DeessIntensity: 0.5},
+			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.5},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			wantTip:  false,
@@ -621,21 +621,21 @@ func TestTipSibilance(t *testing.T) {
 		},
 		{
 			name:     "dark voice no sibilance",
-			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
 			centroid: 3000.0,
 			rolloff:  11000.0,
 			wantTip:  false,
 		},
 		{
 			name:     "low rolloff no sibilance",
-			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
 			centroid: 4500.0,
 			rolloff:  9000.0,
 			wantTip:  false,
 		},
 		{
 			name:     "speech profile overrides full-file",
-			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
 			centroid: 3000.0,
 			rolloff:  9000.0,
 			speechProfile: &processor.SpeechCandidateMetrics{
@@ -645,7 +645,7 @@ func TestTipSibilance(t *testing.T) {
 		},
 		{
 			name:     "speech profile zero values use full-file",
-			config:   &processor.FilterChainConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			speechProfile: &processor.SpeechCandidateMetrics{
@@ -839,7 +839,7 @@ func TestGenerateRecordingTips(t *testing.T) {
 	tests := []struct {
 		name             string
 		measurements     *processor.AudioMeasurements
-		config           *processor.FilterChainConfig
+		config           *processor.EffectiveFilterConfig
 		wantRuleIDs      []string // these RuleIDs must be present
 		excludeRuleIDs   []string // these RuleIDs must NOT be present
 		checkFirstRuleID string   // if set, first tip must have this RuleID
@@ -917,6 +917,23 @@ func TestGenerateRecordingTips(t *testing.T) {
 				return m
 			}(),
 			wantEmpty: true,
+		},
+		{
+			name: "sibilance uses effective de-esser tuning",
+			measurements: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.InputI = -20.0
+				m.InputTP = -6.0
+				m.InputLRA = 8.0
+				m.AstatsNoiseFloor = -70.0
+				m.CrestFactor = 12.0
+				m.NoiseReductionHeadroom = 25.0
+				m.SpectralCentroid = 4500.0
+				m.SpectralRolloff = 11000.0
+				return m
+			}(),
+			config:      &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
+			wantRuleIDs: []string{"sibilance"},
 		},
 		{
 			name: "mutual exclusion clipping suppresses level_too_quiet",

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -446,17 +446,17 @@ func GenerateReport(data ReportData) error {
 
 	// Filter Chain Applied
 	if data.Result != nil && data.Result.Config != nil {
-		writeFilterChainApplied(f, &data.Result.Config.FilterChainConfig, data.Result.Measurements)
+		writeFilterChainApplied(f, data.Result.Config, data.Result.Diagnostics, data.Result.Measurements)
 	}
 
 	// Peak Limiter (Pass 4 pre-limiting before loudnorm)
 	if data.Result != nil && data.Result.NormResult != nil {
-		writeDiagnosticPeakLimiter(f, data.Result.NormResult, &data.Result.Config.FilterChainConfig)
+		writeDiagnosticPeakLimiter(f, data.Result.NormResult, data.Result.Config)
 	}
 
 	// Loudnorm (follows filter chain as it's the final processing stage)
 	if data.Result != nil && data.Result.Config != nil {
-		writeDiagnosticLoudnorm(f, data.Result.NormResult, &data.Result.Config.FilterChainConfig)
+		writeDiagnosticLoudnorm(f, data.Result.NormResult, data.Result.Config)
 	}
 
 	// Loudness Measurements Table (Input → Filtered → Final)
@@ -518,18 +518,18 @@ func channelName(channels int) string {
 // formatFilterChain generates the filter chain section of the report.
 // Iterates over filters in chain order, showing enabled/disabled status,
 // key parameters, and adaptive rationale for each filter.
-func formatFilterChain(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements) {
+func formatFilterChain(f *os.File, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements) {
 	fmt.Fprintln(f, "Filter Chain (in processing order)")
 	fmt.Fprintln(f, "------------------------------------")
 
 	for i, filterID := range cfg.FilterOrder {
 		prefix := fmt.Sprintf("%2d. ", i+1)
-		formatFilter(f, filterID, cfg, m, prefix)
+		formatFilter(f, filterID, cfg, diagnostics, m, prefix)
 	}
 }
 
 // formatFilter outputs details for a single filter
-func formatFilter(f *os.File, filterID processor.FilterID, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
+func formatFilter(f *os.File, filterID processor.FilterID, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements, prefix string) {
 	switch filterID {
 	case processor.FilterDownmix:
 		formatDownmixFilter(f, cfg, prefix)
@@ -540,13 +540,13 @@ func formatFilter(f *os.File, filterID processor.FilterID, cfg *processor.Filter
 	case processor.FilterDS201HighPass:
 		formatDS201HighpassFilter(f, cfg, m, prefix)
 	case processor.FilterDS201LowPass:
-		formatDS201LowPassFilter(f, cfg, m, prefix)
+		formatDS201LowPassFilter(f, cfg, diagnostics, m, prefix)
 	case processor.FilterNoiseRemove:
 		formatNoiseRemoveFilter(f, cfg, m, prefix)
 	case processor.FilterDS201Gate:
-		formatDS201GateFilter(f, cfg, m, prefix)
+		formatDS201GateFilter(f, cfg, diagnostics, m, prefix)
 	case processor.FilterLA2ACompressor:
-		formatLA2ACompressorFilter(f, cfg, m, prefix)
+		formatLA2ACompressorFilter(f, cfg, diagnostics, m, prefix)
 	case processor.FilterDeesser:
 		formatDeesserFilter(f, cfg, m, prefix)
 	default:
@@ -555,7 +555,7 @@ func formatFilter(f *os.File, filterID processor.FilterID, cfg *processor.Filter
 }
 
 // formatDS201HighpassFilter outputs DS201-inspired highpass filter details
-func formatDS201HighpassFilter(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
+func formatDS201HighpassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *processor.AudioMeasurements, prefix string) {
 	if !cfg.DS201HPEnabled {
 		fmt.Fprintf(f, "%sDS201 highpass: DISABLED\n", prefix)
 		return
@@ -619,11 +619,11 @@ func formatDS201HighpassFilter(f *os.File, cfg *processor.FilterChainConfig, m *
 }
 
 // formatDS201LowPassFilter outputs DS201-inspired low-pass filter details
-func formatDS201LowPassFilter(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
+func formatDS201LowPassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements, prefix string) {
 	if !cfg.DS201LPEnabled {
 		// Show reason for being disabled (pass-through mode)
-		if cfg.DS201LPReason != "" {
-			fmt.Fprintf(f, "%sDS201 lowpass: DISABLED (%s)\n", prefix, cfg.DS201LPReason)
+		if diagnostics != nil && diagnostics.DS201LPReason != "" {
+			fmt.Fprintf(f, "%sDS201 lowpass: DISABLED (%s)\n", prefix, diagnostics.DS201LPReason)
 		} else {
 			fmt.Fprintf(f, "%sDS201 lowpass: DISABLED\n", prefix)
 		}
@@ -660,20 +660,30 @@ func formatDS201LowPassFilter(f *os.File, cfg *processor.FilterChainConfig, m *p
 	fmt.Fprintln(f, header)
 
 	// Show rationale
-	if cfg.DS201LPReason != "" {
-		fmt.Fprintf(f, "        Rationale: %s\n", cfg.DS201LPReason)
+	if diagnostics != nil && diagnostics.DS201LPReason != "" {
+		fmt.Fprintf(f, "        Rationale: %s\n", diagnostics.DS201LPReason)
 	}
 
 	// Show content type detection metrics
 	if m != nil {
+		contentType := processor.ContentType(-1)
+		if diagnostics != nil {
+			contentType = diagnostics.DS201LPContentType
+		}
 		fmt.Fprintf(f, "        Content type: %s (kurtosis %.1f, flatness %.3f, flux %.4f)\n",
-			cfg.DS201LPContentType.String(), m.SpectralKurtosis, m.SpectralFlatness, m.SpectralFlux)
+			contentType.String(), m.SpectralKurtosis, m.SpectralFlatness, m.SpectralFlux)
 
 		// Show the triggering metric details
-		switch cfg.DS201LPReason {
+		lpReason := ""
+		rolloffRatio := 0.0
+		if diagnostics != nil {
+			lpReason = diagnostics.DS201LPReason
+			rolloffRatio = diagnostics.DS201LPRolloffRatio
+		}
+		switch lpReason {
 		case "rolloff/centroid gap":
 			fmt.Fprintf(f, "        Rolloff/centroid ratio: %.2f > 2.5 (rolloff %.0f Hz, centroid %.0f Hz)\n",
-				cfg.DS201LPRolloffRatio, m.SpectralRolloff, m.SpectralCentroid)
+				rolloffRatio, m.SpectralRolloff, m.SpectralCentroid)
 		case "flat spectral slope":
 			fmt.Fprintf(f, "        Spectral slope: %.2e > -1e-05 (unusual HF emphasis)\n", m.SpectralSlope)
 		case "high ZCR with low centroid":
@@ -685,7 +695,7 @@ func formatDS201LowPassFilter(f *os.File, cfg *processor.FilterChainConfig, m *p
 
 // formatNoiseRemoveFilter outputs NoiseRemove (anlmdn + compand) filter details
 // Uses Non-Local Means denoiser followed by compand for residual suppression
-func formatNoiseRemoveFilter(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
+func formatNoiseRemoveFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *processor.AudioMeasurements, prefix string) {
 	if !cfg.NoiseRemoveEnabled {
 		fmt.Fprintf(f, "%snoiseremove: DISABLED\n", prefix)
 		return
@@ -720,7 +730,7 @@ func formatNoiseRemoveFilter(f *os.File, cfg *processor.FilterChainConfig, m *pr
 }
 
 // formatDS201GateFilter outputs DS201-inspired gate filter details
-func formatDS201GateFilter(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
+func formatDS201GateFilter(f *os.File, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements, prefix string) {
 	if !cfg.DS201GateEnabled {
 		fmt.Fprintf(f, "%sDS201 gate: DISABLED\n", prefix)
 		return
@@ -736,7 +746,7 @@ func formatDS201GateFilter(f *os.File, cfg *processor.FilterChainConfig, m *proc
 
 	// Show mode indicator if gentle mode is active
 	modeNote := ""
-	if cfg.DS201GateGentleMode {
+	if diagnostics != nil && diagnostics.DS201GateGentleMode {
 		modeNote = " [gentle mode]"
 	}
 
@@ -796,7 +806,7 @@ func formatDS201GateFilter(f *os.File, cfg *processor.FilterChainConfig, m *proc
 		}
 
 		// Gentle mode rationale - for extreme LUFS gap + low LRA recordings
-		if cfg.DS201GateGentleMode {
+		if diagnostics != nil && diagnostics.DS201GateGentleMode {
 			rationale = append(rationale, "gentle mode (extreme LUFS gap + low LRA)")
 		}
 
@@ -805,23 +815,23 @@ func formatDS201GateFilter(f *os.File, cfg *processor.FilterChainConfig, m *proc
 		}
 
 		// Show aggression-based threshold calculation
-		if cfg.DS201GateAggression > 0 {
+		if diagnostics != nil && diagnostics.DS201GateAggression > 0 {
 			fmt.Fprintf(f, "        Aggression: %.2f (separation %.1f dB)\n",
-				cfg.DS201GateAggression, cfg.DS201GateSpeechSeparation)
+				diagnostics.DS201GateAggression, diagnostics.DS201GateSpeechSeparation)
 			fmt.Fprintf(f, "        Quiet speech: %.1f dB, Dynamic range: %.1f dB\n",
-				cfg.DS201GateQuietSpeechEstimate, cfg.DS201GateDynamicRange)
-			if cfg.DS201GateClampReason != "none" {
+				diagnostics.DS201GateQuietSpeechEstimate, diagnostics.DS201GateDynamicRange)
+			if diagnostics.DS201GateClampReason != "none" {
 				fmt.Fprintf(f, "        Clamped by: %s (unclamped: %.1f dB)\n",
-					cfg.DS201GateClampReason, cfg.DS201GateThresholdUnclamped)
+					diagnostics.DS201GateClampReason, diagnostics.DS201GateThresholdUnclamped)
 			}
 			fmt.Fprintf(f, "        Headroom above quiet speech: %.1f dB\n",
-				-cfg.DS201GateSpeechHeadroom) // Negative because threshold is above quiet speech
+				-diagnostics.DS201GateSpeechHeadroom) // Negative because threshold is above quiet speech
 		}
 	}
 }
 
 // formatLA2ACompressorFilter outputs LA-2A Compressor filter details
-func formatLA2ACompressorFilter(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
+func formatLA2ACompressorFilter(f *os.File, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements, prefix string) {
 	if !cfg.LA2AEnabled {
 		fmt.Fprintf(f, "%sLA-2A Compressor: DISABLED\n", prefix)
 		return
@@ -861,24 +871,28 @@ func formatLA2ACompressorFilter(f *os.File, cfg *processor.FilterChainConfig, m 
 	}
 
 	// High-crest override diagnostics
-	if cfg.LA2AHighCrestActive && m != nil {
+	if diagnostics != nil && diagnostics.LA2AHighCrestActive && m != nil {
 		fmt.Fprintf(f, "        High-crest override: ACTIVE (deficit %.1f dB, severity %.2f)\n",
-			cfg.LA2AHighCrestDeficit, cfg.LA2AHighCrestSeverity)
+			diagnostics.LA2AHighCrestDeficit, diagnostics.LA2AHighCrestSeverity)
 		gainRequired := processor.NormTargetLUFS - m.InputI
 		fmt.Fprintf(f, "        Projected TP: %.1f dBTP (gain %.1f dB applied to %.1f dBTP peaks)\n",
-			cfg.LA2AHighCrestProjectedTP, gainRequired, m.InputTP)
+			diagnostics.LA2AHighCrestProjectedTP, gainRequired, m.InputTP)
 		idealCeiling := cfg.LoudnormTargetTP - gainRequired - 1.5
 		fmt.Fprintf(f, "        Ideal ceiling: %.1f dBTP, alimiter minimum: -24.0 dBTP\n", idealCeiling)
 		fmt.Fprintf(f, "        Override targets: threshold <= %.0f dB, ratio >= %.1f:1\n",
 			cfg.LA2AThreshold, cfg.LA2ARatio)
 	} else {
+		highCrestDeficit := 0.0
+		if diagnostics != nil {
+			highCrestDeficit = diagnostics.LA2AHighCrestDeficit
+		}
 		fmt.Fprintf(f, "        High-crest override: not needed (deficit %.1f dB)\n",
-			cfg.LA2AHighCrestDeficit)
+			highCrestDeficit)
 	}
 }
 
 // formatDeesserFilter outputs deesser filter details
-func formatDeesserFilter(f *os.File, cfg *processor.FilterChainConfig, m *processor.AudioMeasurements, prefix string) {
+func formatDeesserFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *processor.AudioMeasurements, prefix string) {
 	if !cfg.DeessEnabled {
 		fmt.Fprintf(f, "%sdeesser: DISABLED\n", prefix)
 		return
@@ -926,7 +940,7 @@ func formatDeesserFilter(f *os.File, cfg *processor.FilterChainConfig, m *proces
 }
 
 // formatDownmixFilter outputs downmix filter details
-func formatDownmixFilter(f *os.File, cfg *processor.FilterChainConfig, prefix string) {
+func formatDownmixFilter(f *os.File, cfg *processor.EffectiveFilterConfig, prefix string) {
 	if !cfg.DownmixEnabled {
 		fmt.Fprintf(f, "%sdownmix: DISABLED\n", prefix)
 		return
@@ -935,7 +949,7 @@ func formatDownmixFilter(f *os.File, cfg *processor.FilterChainConfig, prefix st
 }
 
 // formatAnalysisFilter outputs analysis filter details
-func formatAnalysisFilter(f *os.File, cfg *processor.FilterChainConfig, prefix string) {
+func formatAnalysisFilter(f *os.File, cfg *processor.EffectiveFilterConfig, prefix string) {
 	if !cfg.AnalysisEnabled {
 		fmt.Fprintf(f, "%sanalysis: DISABLED\n", prefix)
 		return
@@ -944,7 +958,7 @@ func formatAnalysisFilter(f *os.File, cfg *processor.FilterChainConfig, prefix s
 }
 
 // formatResampleFilter outputs resample filter details
-func formatResampleFilter(f *os.File, cfg *processor.FilterChainConfig, prefix string) {
+func formatResampleFilter(f *os.File, cfg *processor.EffectiveFilterConfig, prefix string) {
 	if !cfg.ResampleEnabled {
 		fmt.Fprintf(f, "%sresample: DISABLED\n", prefix)
 		return
@@ -1008,8 +1022,8 @@ func writeProcessingSummary(f *os.File, data ReportData) {
 }
 
 // writeFilterChainApplied outputs the filter chain section.
-func writeFilterChainApplied(f *os.File, config *processor.FilterChainConfig, measurements *processor.AudioMeasurements) {
-	formatFilterChain(f, config, measurements)
+func writeFilterChainApplied(f *os.File, config *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, measurements *processor.AudioMeasurements) {
+	formatFilterChain(f, config, diagnostics, measurements)
 	fmt.Fprintln(f, "")
 }
 
@@ -1884,7 +1898,7 @@ func formatRejectionSummary(reasonCounts map[string]int, order []string) string 
 
 // writeDiagnosticPeakLimiter outputs the Pass 4 pre-limiting diagnostics.
 // The peak limiter creates headroom before loudnorm so it can apply full linear gain.
-func writeDiagnosticPeakLimiter(f *os.File, result *processor.NormalisationResult, config *processor.FilterChainConfig) {
+func writeDiagnosticPeakLimiter(f *os.File, result *processor.NormalisationResult, config *processor.EffectiveFilterConfig) {
 	if result == nil || result.Skipped {
 		return
 	}
@@ -1968,7 +1982,7 @@ func writeDiagnosticPeakLimiter(f *os.File, result *processor.NormalisationResul
 }
 
 // writeDiagnosticLoudnorm outputs detailed loudnorm normalisation diagnostics.
-func writeDiagnosticLoudnorm(f *os.File, result *processor.NormalisationResult, config *processor.FilterChainConfig) {
+func writeDiagnosticLoudnorm(f *os.File, result *processor.NormalisationResult, config *processor.EffectiveFilterConfig) {
 	if result == nil || !config.LoudnormEnabled {
 		return
 	}

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -446,17 +446,17 @@ func GenerateReport(data ReportData) error {
 
 	// Filter Chain Applied
 	if data.Result != nil && data.Result.Config != nil {
-		writeFilterChainApplied(f, data.Result.Config, data.Result.Measurements)
+		writeFilterChainApplied(f, &data.Result.Config.FilterChainConfig, data.Result.Measurements)
 	}
 
 	// Peak Limiter (Pass 4 pre-limiting before loudnorm)
 	if data.Result != nil && data.Result.NormResult != nil {
-		writeDiagnosticPeakLimiter(f, data.Result.NormResult, data.Result.Config)
+		writeDiagnosticPeakLimiter(f, data.Result.NormResult, &data.Result.Config.FilterChainConfig)
 	}
 
 	// Loudnorm (follows filter chain as it's the final processing stage)
 	if data.Result != nil && data.Result.Config != nil {
-		writeDiagnosticLoudnorm(f, data.Result.NormResult, data.Result.Config)
+		writeDiagnosticLoudnorm(f, data.Result.NormResult, &data.Result.Config.FilterChainConfig)
 	}
 
 	// Loudness Measurements Table (Input → Filtered → Final)

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -28,7 +28,7 @@ func makeReportData(t *testing.T) ReportData {
 		Result: &processor.ProcessingResult{
 			Measurements:         makeInputMeasurements(),
 			FilteredMeasurements: makeOutputMeasurements(-20.2, -2.1, 6.4, makeSilenceSample(-64.0), makeSpeechSample(-24.0)),
-			Config:               processor.DefaultFilterConfig(),
+			Config:               processor.DefaultEffectiveFilterConfig(),
 			NormResult: &processor.NormalisationResult{
 				InputLUFS:  -20.2,
 				OutputLUFS: -16.0,

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -29,7 +29,7 @@ func makeReportData(t *testing.T) ReportData {
 		Result: &processor.ProcessingResult{
 			Measurements:         makeInputMeasurements(),
 			FilteredMeasurements: makeOutputMeasurements(-20.2, -2.1, 6.4, makeSilenceSample(-64.0), makeSpeechSample(-24.0)),
-			Config:               &processor.EffectiveFilterConfig{FilterChainConfig: *config},
+			Config:               config,
 			NormResult: &processor.NormalisationResult{
 				InputLUFS:  -20.2,
 				OutputLUFS: -16.0,
@@ -229,6 +229,132 @@ func TestGenerateReport_AudioMetricTables(t *testing.T) {
 		"Speech Region Analysis",
 		"Spectral Centroid",
 		"2400",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}
+
+func TestGenerateReport_FilterChainUsesProcessingDiagnostics(t *testing.T) {
+	data := makeReportData(t)
+	data.Result.Diagnostics = &processor.AdaptiveDiagnostics{
+		DS201LPContentType:  processor.ContentSpeech,
+		DS201LPReason:       "rolloff/centroid gap",
+		DS201LPRolloffRatio: 3.10,
+
+		DS201GateAggression:          0.72,
+		DS201GateDynamicRange:        18.4,
+		DS201GateQuietSpeechEstimate: -38.2,
+		DS201GateSpeechSeparation:    17.1,
+		DS201GateSpeechHeadroom:      -4.5,
+		DS201GateThresholdUnclamped:  -42.8,
+		DS201GateClampReason:         "quiet speech ceiling",
+		DS201GateGentleMode:          true,
+
+		LA2AHighCrestActive:      true,
+		LA2AHighCrestDeficit:     5.6,
+		LA2AHighCrestSeverity:    0.78,
+		LA2AHighCrestProjectedTP: 3.4,
+	}
+
+	output := generateReportText(t, data)
+
+	for _, want := range []string{
+		"Rationale: rolloff/centroid gap",
+		"Content type: speech",
+		"Rolloff/centroid ratio: 3.10 > 2.5",
+		"DS201 gate: threshold",
+		"[gentle mode]",
+		"Aggression: 0.72 (separation 17.1 dB)",
+		"Quiet speech: -38.2 dB, Dynamic range: 18.4 dB",
+		"Clamped by: quiet speech ceiling (unclamped: -42.8 dB)",
+		"Headroom above quiet speech: 4.5 dB",
+		"High-crest override: ACTIVE (deficit 5.6 dB, severity 0.78)",
+		"Projected TP: 3.4 dBTP",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+
+	for _, stale := range []string{
+		"stale config lowpass reason",
+		"Content type: music",
+		"Rolloff/centroid ratio: 9.99",
+		"stale config clamp",
+		"High-crest override: not needed (deficit 0.1 dB)",
+	} {
+		if strings.Contains(output, stale) {
+			t.Errorf("report used stale config diagnostic %q", stale)
+		}
+	}
+}
+
+func TestGenerateReport_FilterChainReportsDeesser(t *testing.T) {
+	data := makeReportData(t)
+	data.Result.Config.DeessEnabled = true
+	data.Result.Config.DeessIntensity = 0.42
+	data.Result.Config.DeessAmount = 0.55
+	data.Result.Config.DeessFreq = 0.65
+
+	output := generateReportText(t, data)
+
+	for _, want := range []string{
+		"deesser: intensity 42%, amount 55%, freq 65%",
+		"Rationale: normal voice",
+		"spectral centroid: 2400 Hz (speech region)",
+		"spectral rolloff: 6200 Hz (speech region)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}
+
+func TestGenerateReport_LoudnormAndPeakLimiterSections(t *testing.T) {
+	data := makeReportData(t)
+	data.Result.NormResult = &processor.NormalisationResult{
+		InputLUFS:         -28.0,
+		InputTP:           -8.0,
+		OutputLUFS:        -16.1,
+		OutputTP:          -1.3,
+		GainApplied:       0.25,
+		WithinTarget:      true,
+		RequestedTargetI:  -16.0,
+		EffectiveTargetI:  -16.0,
+		LimiterEnabled:    true,
+		LimiterCeiling:    -12.0,
+		LimiterGain:       12.0,
+		Pass3FilterPrefix: "alimiter=level_in=1:level_out=1:limit=0.251188:attack=5:release=100:asc=1:asc_level=0.8", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+		LoudnormStats: &processor.LoudnormStats{
+			InputThresh:       "-38.00",
+			OutputThresh:      "-26.00",
+			NormalizationType: "linear",
+			TargetOffset:      "-0.05",
+		},
+		FinalMeasurements: makeOutputMeasurements(
+			-16.1,
+			-1.3,
+			5.8,
+			makeSilenceSample(-61.0),
+			makeSpeechSample(-19.8),
+		),
+	}
+
+	output := generateReportText(t, data)
+
+	for _, want := range []string{
+		"Diagnostic: Peak Limiter",
+		"Status: ACTIVE",
+		"Limiter Ceiling:   -12.0 dBTP",
+		"Pass 3 measurement:",
+		"Diagnostic: Loudnorm",
+		"Target I:   -16.0 LUFS",
+		"Mode:       Linear (target adjusted to prevent dynamic fallback)",
+		"FFmpeg diagnostics:",
+		"Norm Type:       linear",
+		"Result: ✓ Within target",
 	} {
 		if !strings.Contains(output, want) {
 			t.Errorf("report missing %q", want)

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -14,6 +14,7 @@ func makeReportData(t *testing.T) ReportData {
 	t.Helper()
 
 	start := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	config := processor.DefaultEffectiveFilterConfig()
 	return ReportData{
 		InputPath:  filepath.Join(t.TempDir(), "input.wav"),
 		OutputPath: filepath.Join(t.TempDir(), "input-LUFS-16-processed.flac"),
@@ -28,7 +29,7 @@ func makeReportData(t *testing.T) ReportData {
 		Result: &processor.ProcessingResult{
 			Measurements:         makeInputMeasurements(),
 			FilteredMeasurements: makeOutputMeasurements(-20.2, -2.1, 6.4, makeSilenceSample(-64.0), makeSpeechSample(-24.0)),
-			Config:               processor.DefaultEffectiveFilterConfig(),
+			Config:               &processor.EffectiveFilterConfig{FilterChainConfig: *config},
 			NormResult: &processor.NormalisationResult{
 				InputLUFS:  -20.2,
 				OutputLUFS: -16.0,

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -404,27 +404,23 @@ func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) (*Ef
 	if effectiveConfig == nil {
 		return nil, nil
 	}
-	filterConfig := &effectiveConfig.FilterChainConfig
 	diagnostics := &AdaptiveDiagnostics{}
-
-	// Store measurements reference
-	filterConfig.Measurements = measurements
 
 	// Tune each filter adaptively based on measurements
 	// Order matters: gate threshold calculated BEFORE denoise filters
-	tuneDS201HighPass(filterConfig, measurements)             // Composite: highpass + hum notch
-	tuneDS201LowPass(filterConfig, diagnostics, measurements) // Ultrasonic rejection (adaptive)
+	tuneDS201HighPass(effectiveConfig, measurements)             // Composite: highpass + hum notch
+	tuneDS201LowPass(effectiveConfig, diagnostics, measurements) // Ultrasonic rejection (adaptive)
 
 	// NoiseRemove: anlmdn + compand (primary noise reduction)
-	tuneNoiseRemove(filterConfig, measurements)
+	tuneNoiseRemove(effectiveConfig, measurements)
 
-	tuneDS201Gate(filterConfig, diagnostics, measurements) // DS201-style soft expander gate
-	tuneDeesser(filterConfig, measurements)
-	tuneLA2ACompressor(filterConfig, diagnostics, measurements)
+	tuneDS201Gate(effectiveConfig, diagnostics, measurements) // DS201-style soft expander gate
+	tuneDeesser(effectiveConfig, measurements)
+	tuneLA2ACompressor(effectiveConfig, diagnostics, measurements)
 	// tuneVolumaxLimiter removed - limiter moved to Pass 4, tuned from Pass 3 measurements
 
 	// Final safety checks
-	sanitizeConfig(filterConfig)
+	sanitizeConfig(effectiveConfig)
 
 	return effectiveConfig, diagnostics
 }
@@ -450,7 +446,7 @@ func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) (*Ef
 // - Low entropy (< 0.7) indicates periodic/tonal noise → enable hum removal
 // - High entropy indicates broadband noise → skip notch filter
 // - Voice-aware: reduces harmonics for warm voices to protect vocal fundamentals
-func tuneDS201HighPass(config *FilterChainConfig, measurements *AudioMeasurements) {
+func tuneDS201HighPass(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	config.DS201HPPoles = ds201HPDefaultPoles
 	config.DS201HPWidth = ds201HPDefaultWidth
 	config.DS201HPMix = ds201HPDefaultMix
@@ -576,7 +572,7 @@ func tuneDS201HighPass(config *FilterChainConfig, measurements *AudioMeasurement
 // The DS201's LP filter prevents false gate triggers from ultrasonic noise.
 // Since we filter the audio path (not true sidechain), we must be conservative
 // to avoid audible HF loss.
-func tuneDS201LowPass(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
+func tuneDS201LowPass(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
 	// Start disabled - only enable when we detect clear benefit
 	config.DS201LPEnabled = false
 	config.DS201LPFreq = ds201LPDefaultFreq
@@ -630,7 +626,7 @@ func tuneDS201LowPass(config *FilterChainConfig, diagnostics *AdaptiveDiagnostic
 // Constraints:
 //   - Never cut below 8kHz (sibilance lives at 4-8kHz, air/presence at 8-12kHz)
 //   - Conservative approach — preserves natural voice character
-func tuneDS201LowPassForSpeech(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
+func tuneDS201LowPassForSpeech(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
 	// Default: DISABLED per spec — only activate when measurements indicate benefit
 	config.DS201LPEnabled = false
 	config.DS201LPFreq = ds201LPDefaultFreq
@@ -697,7 +693,7 @@ func tuneDS201LowPassForSpeech(config *FilterChainConfig, diagnostics *AdaptiveD
 // - patch: 6ms (context window)
 // - research: production default (search window)
 // - smooth: 11 (weight smoothing)
-func tuneNoiseRemove(config *FilterChainConfig, m *AudioMeasurements) {
+func tuneNoiseRemove(config *EffectiveFilterConfig, m *AudioMeasurements) {
 	if !config.NoiseRemoveEnabled {
 		return
 	}
@@ -774,7 +770,7 @@ func scaleExpansion(noiseFloor float64) float64 {
 // - High centroid + high rolloff → likely sibilance, use more de-essing
 // - Low rolloff → limited HF content, skip or reduce de-essing
 // - Dark voice with no HF extension → disable de-esser entirely
-func tuneDeesser(config *FilterChainConfig, measurements *AudioMeasurements) {
+func tuneDeesser(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	// Require speech profile for reliable sibilance detection.
 	// Full-file spectral metrics are diluted by silence/noise regions
 	// and produce false positives for sibilance in speech-sparse recordings.
@@ -799,7 +795,7 @@ func tuneDeesser(config *FilterChainConfig, measurements *AudioMeasurements) {
 }
 
 // tuneDeesserFull uses both centroid and rolloff for precise de-esser tuning
-func tuneDeesserFull(config *FilterChainConfig, measurements *AudioMeasurements) {
+func tuneDeesserFull(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	// Prefer speech-specific measurements for sibilance detection
 	centroid := measurements.SpectralCentroid
 	rolloff := measurements.SpectralRolloff
@@ -843,7 +839,7 @@ func tuneDeesserFull(config *FilterChainConfig, measurements *AudioMeasurements)
 }
 
 // tuneDeesserCentroidOnly provides fallback when rolloff is unavailable
-func tuneDeesserCentroidOnly(config *FilterChainConfig, measurements *AudioMeasurements) {
+func tuneDeesserCentroidOnly(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	// Prefer speech-specific centroid when available.
 	// Full-file averages are diluted by silence in multi-track recordings.
 	centroid := measurements.SpectralCentroid
@@ -872,7 +868,7 @@ func tuneDeesserCentroidOnly(config *FilterChainConfig, measurements *AudioMeasu
 //   - Knee: based on spectral crest (dynamic content = soft knee)
 //   - Detection: RMS for tonal bleed/noisy silence, peak for clean recordings
 //   - Makeup: 1.0 (loudness normalisation handles level compensation)
-func tuneDS201Gate(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
+func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
 	if diagnostics != nil {
 		diagnostics.DS201GateGentleMode = false
 		diagnostics.DS201GateAggression = 0
@@ -1319,7 +1315,7 @@ func calculateDS201GateDetection(silenceEntropy, silenceCrestDB float64) string 
 //
 // This implementation uses spectral measurements to emulate program-dependent
 // behaviour that the optical T4 cell provides naturally.
-func tuneLA2ACompressor(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
+func tuneLA2ACompressor(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
 	overrides := applyHighCrestOverrides(config, diagnostics, measurements)
 	tuneLA2AAttack(config, measurements)
 	tuneLA2ARelease(config, measurements, overrides)
@@ -1338,7 +1334,7 @@ func tuneLA2ACompressor(config *FilterChainConfig, diagnostics *AdaptiveDiagnost
 //
 // Diagnostic fields are always populated (active or not) when diagnostics is non-nil.
 // Returns zero-value la2aOverrides when no overrides are needed (deficit <= 0).
-func applyHighCrestOverrides(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) la2aOverrides {
+func applyHighCrestOverrides(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) la2aOverrides {
 	if measurements.SpeechProfile == nil {
 		debugLog("high-crest: SpeechProfile is nil, using full-file InputI/InputTP for deficit calculation")
 	}
@@ -1377,7 +1373,7 @@ func applyHighCrestOverrides(config *FilterChainConfig, diagnostics *AdaptiveDia
 // tuneLA2AAttack sets attack time based on transient characteristics.
 // LA-2A has fixed 10ms attack - we allow slight variation for extreme cases.
 // MaxDifference indicates transient sharpness (% of full scale).
-func tuneLA2AAttack(config *FilterChainConfig, measurements *AudioMeasurements) {
+func tuneLA2AAttack(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	// Default to LA-2A's fixed 10ms attack
 	attack := la2aAttackBase
 
@@ -1408,7 +1404,7 @@ func tuneLA2AAttack(config *FilterChainConfig, measurements *AudioMeasurements) 
 // - Wide LRA + high flux = expressive speech, needs longer release
 // - Narrow LRA + low flux = compressed/monotone, faster release OK
 // - Warm voices (high skewness) get extra release to preserve body
-func tuneLA2ARelease(config *FilterChainConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
+func tuneLA2ARelease(config *EffectiveFilterConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
 	// Prefer speech-specific flux for timing decisions
 	flux := measurements.SpectralFlux
 	if measurements.SpeechProfile != nil {
@@ -1478,7 +1474,7 @@ func tuneLA2ARelease(config *FilterChainConfig, measurements *AudioMeasurements,
 //
 // Kurtosis reference: Gaussian distribution has kurtosis=3.
 // Speech typically ranges 5-10 (leptokurtic, clear harmonics).
-func tuneLA2ARatio(config *FilterChainConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
+func tuneLA2ARatio(config *EffectiveFilterConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
 	// Prefer speech-specific kurtosis for harmonic structure
 	kurtosis := measurements.SpectralKurtosis
 	if measurements.SpeechProfile != nil {
@@ -1531,7 +1527,7 @@ func tuneLA2ARatio(config *FilterChainConfig, measurements *AudioMeasurements, o
 // tuneLA2AThreshold sets threshold relative to RMS level.
 // LA-2A's Peak Reduction knob effectively sets threshold relative to signal.
 // We calculate threshold as peak level minus headroom, where headroom determines depth.
-func tuneLA2AThreshold(config *FilterChainConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
+func tuneLA2AThreshold(config *EffectiveFilterConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
 	// Fallback if no peak measurement
 	if measurements.PeakLevel == 0 {
 		config.LA2AThreshold = defaultLA2AThreshold
@@ -1583,7 +1579,7 @@ func tuneLA2AThreshold(config *FilterChainConfig, measurements *AudioMeasurement
 // tuneLA2AKnee sets knee softness to emulate T4 optical cell.
 // The T4 provides an inherently soft knee - one of LA-2A's defining characteristics.
 // We adapt based on voice character (spectral centroid and skewness).
-func tuneLA2AKnee(config *FilterChainConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
+func tuneLA2AKnee(config *EffectiveFilterConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
 	// Start with standard LA-2A soft knee
 	knee := la2aKneeNormal
 
@@ -1632,7 +1628,7 @@ func tuneLA2AKnee(config *FilterChainConfig, measurements *AudioMeasurements, ov
 // tuneLA2AMix sets wet/dry mix.
 // Real LA-2A is 100% wet (no parallel compression).
 // We allow slight dry signal for problematic recordings to mask artefacts.
-func tuneLA2AMix(config *FilterChainConfig, measurements *AudioMeasurements) {
+func tuneLA2AMix(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	// Default to true LA-2A behaviour (100% wet)
 	mix := la2aMixClean
 
@@ -1650,7 +1646,7 @@ func tuneLA2AMix(config *FilterChainConfig, measurements *AudioMeasurements) {
 }
 
 // sanitizeConfig ensures no NaN or Inf values remain after adaptive tuning
-func sanitizeConfig(config *FilterChainConfig) {
+func sanitizeConfig(config *EffectiveFilterConfig) {
 	// DS201-inspired highpass filter
 	config.DS201HPFreq = sanitizeFloat(config.DS201HPFreq, ds201DefaultHPFreq)
 	config.DS201HPWidth = sanitizeFloat(config.DS201HPWidth, 0.707) // Butterworth default

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -398,33 +398,35 @@ func detectContentType(m *AudioMeasurements) ContentType {
 
 // AdaptConfig tunes all filter parameters based on Pass 1 measurements.
 // This is the main entry point for adaptive configuration.
-// It returns a per-file effective config without mutating the caller's base seed.
-func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) *FilterChainConfig {
-	effectiveConfig := derivePerFileConfig(config)
+// It returns per-file effective config and diagnostics without mutating the caller's base seed.
+func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) (*EffectiveFilterConfig, *AdaptiveDiagnostics) {
+	effectiveConfig := deriveEffectiveFilterConfig(config)
 	if effectiveConfig == nil {
-		return nil
+		return nil, nil
 	}
+	filterConfig := &effectiveConfig.FilterChainConfig
+	diagnostics := &AdaptiveDiagnostics{}
 
 	// Store measurements reference
-	effectiveConfig.Measurements = measurements
+	filterConfig.Measurements = measurements
 
 	// Tune each filter adaptively based on measurements
 	// Order matters: gate threshold calculated BEFORE denoise filters
-	tuneDS201HighPass(effectiveConfig, measurements) // Composite: highpass + hum notch
-	tuneDS201LowPass(effectiveConfig, measurements)  // Ultrasonic rejection (adaptive)
+	tuneDS201HighPass(filterConfig, measurements)             // Composite: highpass + hum notch
+	tuneDS201LowPass(filterConfig, diagnostics, measurements) // Ultrasonic rejection (adaptive)
 
 	// NoiseRemove: anlmdn + compand (primary noise reduction)
-	tuneNoiseRemove(effectiveConfig, measurements)
+	tuneNoiseRemove(filterConfig, measurements)
 
-	tuneDS201Gate(effectiveConfig, measurements) // DS201-style soft expander gate
-	tuneDeesser(effectiveConfig, measurements)
-	tuneLA2ACompressor(effectiveConfig, measurements)
+	tuneDS201Gate(filterConfig, diagnostics, measurements) // DS201-style soft expander gate
+	tuneDeesser(filterConfig, measurements)
+	tuneLA2ACompressor(filterConfig, diagnostics, measurements)
 	// tuneVolumaxLimiter removed - limiter moved to Pass 4, tuned from Pass 3 measurements
 
 	// Final safety checks
-	sanitizeConfig(effectiveConfig)
+	sanitizeConfig(filterConfig)
 
-	return effectiveConfig
+	return effectiveConfig, diagnostics
 }
 
 // tuneDS201HighPass adapts DS201-inspired highpass composite filter based on:
@@ -574,14 +576,17 @@ func tuneDS201HighPass(config *FilterChainConfig, measurements *AudioMeasurement
 // The DS201's LP filter prevents false gate triggers from ultrasonic noise.
 // Since we filter the audio path (not true sidechain), we must be conservative
 // to avoid audible HF loss.
-func tuneDS201LowPass(config *FilterChainConfig, m *AudioMeasurements) {
+func tuneDS201LowPass(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
 	// Start disabled - only enable when we detect clear benefit
 	config.DS201LPEnabled = false
 	config.DS201LPFreq = ds201LPDefaultFreq
+	if diagnostics == nil {
+		diagnostics = &AdaptiveDiagnostics{}
+	}
 
 	// Detect content type
 	contentType := detectContentType(m)
-	config.DS201LPContentType = contentType
+	diagnostics.DS201LPContentType = contentType
 
 	// Calculate rolloff/centroid ratio for logging
 	rolloff := m.SpectralRolloff
@@ -591,23 +596,23 @@ func tuneDS201LowPass(config *FilterChainConfig, m *AudioMeasurements) {
 		centroid = preferSpeechMetric(centroid, m.SpeechProfile.Spectral.Centroid)
 	}
 	if centroid > 0 {
-		config.DS201LPRolloffRatio = rolloff / centroid
+		diagnostics.DS201LPRolloffRatio = rolloff / centroid
 	}
 
 	switch contentType {
 	case ContentMusic:
 		// Music: preserve full spectrum
-		config.DS201LPReason = "music content detected"
+		diagnostics.DS201LPReason = "music content detected"
 		return
 
 	case ContentMixed:
 		// Mixed content: disable to be safe
-		config.DS201LPReason = "mixed content, conservative"
+		diagnostics.DS201LPReason = "mixed content, conservative"
 		return
 
 	case ContentSpeech:
 		// Speech: check for HF noise indicators
-		tuneDS201LowPassForSpeech(config, m)
+		tuneDS201LowPassForSpeech(config, diagnostics, m)
 	}
 }
 
@@ -625,13 +630,13 @@ func tuneDS201LowPass(config *FilterChainConfig, m *AudioMeasurements) {
 // Constraints:
 //   - Never cut below 8kHz (sibilance lives at 4-8kHz, air/presence at 8-12kHz)
 //   - Conservative approach — preserves natural voice character
-func tuneDS201LowPassForSpeech(config *FilterChainConfig, m *AudioMeasurements) {
+func tuneDS201LowPassForSpeech(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
 	// Default: DISABLED per spec — only activate when measurements indicate benefit
 	config.DS201LPEnabled = false
 	config.DS201LPFreq = ds201LPDefaultFreq
 	config.DS201LPPoles = 1 // 6dB/oct - gentle
 	config.DS201LPMix = 1.0
-	config.DS201LPReason = "no HF issues detected"
+	diagnostics.DS201LPReason = "no HF issues detected"
 
 	// Prefer speech-specific spectral metrics when available.
 	// Full-file averages are diluted by silence in multi-track recordings.
@@ -645,7 +650,7 @@ func tuneDS201LowPassForSpeech(config *FilterChainConfig, m *AudioMeasurements) 
 	// Condition 1: Voice already dark (rolloff < 8kHz)
 	// No benefit from lowpass — would only remove wanted content
 	if rolloff < lpRolloffDarkVoice {
-		config.DS201LPReason = "voice already dark (rolloff < 8kHz)"
+		diagnostics.DS201LPReason = "voice already dark (rolloff < 8kHz)"
 		return
 	}
 
@@ -661,7 +666,7 @@ func tuneDS201LowPassForSpeech(config *FilterChainConfig, m *AudioMeasurements) 
 		config.DS201LPFreq = cutoff
 		config.DS201LPPoles = 1 // 6dB/oct - very gentle for ultrasonic cleanup
 		config.DS201LPMix = 1.0
-		config.DS201LPReason = "ultrasonic cleanup (rolloff > 14kHz)"
+		diagnostics.DS201LPReason = "ultrasonic cleanup (rolloff > 14kHz)"
 		return
 	}
 
@@ -672,7 +677,7 @@ func tuneDS201LowPassForSpeech(config *FilterChainConfig, m *AudioMeasurements) 
 		config.DS201LPFreq = lpZCRCutoff
 		config.DS201LPPoles = 1 // 6dB/oct - gentle
 		config.DS201LPMix = 0.8 // Blend with dry for transparency
-		config.DS201LPReason = "high ZCR with low centroid (HF noise)"
+		diagnostics.DS201LPReason = "high ZCR with low centroid (HF noise)"
 		return
 	}
 
@@ -867,15 +872,17 @@ func tuneDeesserCentroidOnly(config *FilterChainConfig, measurements *AudioMeasu
 //   - Knee: based on spectral crest (dynamic content = soft knee)
 //   - Detection: RMS for tonal bleed/noisy silence, peak for clean recordings
 //   - Makeup: 1.0 (loudness normalisation handles level compensation)
-func tuneDS201Gate(config *FilterChainConfig, measurements *AudioMeasurements) {
-	config.DS201GateGentleMode = false
-	config.DS201GateAggression = 0
-	config.DS201GateDynamicRange = 0
-	config.DS201GateQuietSpeechEstimate = 0
-	config.DS201GateSpeechSeparation = 0
-	config.DS201GateSpeechHeadroom = 0
-	config.DS201GateThresholdUnclamped = 0
-	config.DS201GateClampReason = ""
+func tuneDS201Gate(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
+	if diagnostics != nil {
+		diagnostics.DS201GateGentleMode = false
+		diagnostics.DS201GateAggression = 0
+		diagnostics.DS201GateDynamicRange = 0
+		diagnostics.DS201GateQuietSpeechEstimate = 0
+		diagnostics.DS201GateSpeechSeparation = 0
+		diagnostics.DS201GateSpeechHeadroom = 0
+		diagnostics.DS201GateThresholdUnclamped = 0
+		diagnostics.DS201GateClampReason = ""
+	}
 
 	// Extract silence sample characteristics for gate tuning
 	var silenceEntropy, silenceCrest, silencePeak float64
@@ -924,7 +931,7 @@ func tuneDS201Gate(config *FilterChainConfig, measurements *AudioMeasurements) {
 	)
 
 	// Track threshold calculation diagnostics
-	if measurements.SpeechProfile != nil {
+	if measurements.SpeechProfile != nil && diagnostics != nil {
 		quietSpeech := measurements.SpeechProfile.RMSLevel - measurements.SpeechProfile.CrestFactor
 		separation := quietSpeech - measurements.NoiseFloor
 
@@ -950,13 +957,13 @@ func tuneDS201Gate(config *FilterChainConfig, measurements *AudioMeasurements) {
 			clampReason = "none"
 		}
 
-		config.DS201GateAggression = aggression
-		config.DS201GateDynamicRange = dynamicRange
-		config.DS201GateQuietSpeechEstimate = quietSpeech
-		config.DS201GateSpeechSeparation = separation
-		config.DS201GateThresholdUnclamped = thresholdUnclamped
-		config.DS201GateClampReason = clampReason
-		config.DS201GateSpeechHeadroom = quietSpeech - actualThreshold
+		diagnostics.DS201GateAggression = aggression
+		diagnostics.DS201GateDynamicRange = dynamicRange
+		diagnostics.DS201GateQuietSpeechEstimate = quietSpeech
+		diagnostics.DS201GateSpeechSeparation = separation
+		diagnostics.DS201GateThresholdUnclamped = thresholdUnclamped
+		diagnostics.DS201GateClampReason = clampReason
+		diagnostics.DS201GateSpeechHeadroom = quietSpeech - actualThreshold
 	}
 
 	// 3. Attack: based on MaxDifference, SpectralFlux, and SpectralCrest
@@ -1000,7 +1007,9 @@ func tuneDS201Gate(config *FilterChainConfig, measurements *AudioMeasurements) {
 	if lufsGap >= lufsGapExtreme && measurements.InputLRA < ds201GateGentleLRAThreshold {
 		config.DS201GateRatio = ds201GateGentleRatio
 		config.DS201GateKnee = ds201GateGentleKnee
-		config.DS201GateGentleMode = true
+		if diagnostics != nil {
+			diagnostics.DS201GateGentleMode = true
+		}
 	}
 }
 
@@ -1310,8 +1319,8 @@ func calculateDS201GateDetection(silenceEntropy, silenceCrestDB float64) string 
 //
 // This implementation uses spectral measurements to emulate program-dependent
 // behaviour that the optical T4 cell provides naturally.
-func tuneLA2ACompressor(config *FilterChainConfig, measurements *AudioMeasurements) {
-	overrides := applyHighCrestOverrides(config, measurements)
+func tuneLA2ACompressor(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
+	overrides := applyHighCrestOverrides(config, diagnostics, measurements)
 	tuneLA2AAttack(config, measurements)
 	tuneLA2ARelease(config, measurements, overrides)
 	tuneLA2ARatio(config, measurements, overrides)
@@ -1327,9 +1336,9 @@ func tuneLA2ACompressor(config *FilterChainConfig, measurements *AudioMeasuremen
 // calculateLimiterCeiling() in normalise.go using Pass 1 measurements as a
 // forward estimate.
 //
-// Diagnostic fields on config are always populated (active or not).
+// Diagnostic fields are always populated (active or not) when diagnostics is non-nil.
 // Returns zero-value la2aOverrides when no overrides are needed (deficit <= 0).
-func applyHighCrestOverrides(config *FilterChainConfig, measurements *AudioMeasurements) la2aOverrides {
+func applyHighCrestOverrides(config *FilterChainConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) la2aOverrides {
 	if measurements.SpeechProfile == nil {
 		debugLog("high-crest: SpeechProfile is nil, using full-file InputI/InputTP for deficit calculation")
 	}
@@ -1340,19 +1349,22 @@ func applyHighCrestOverrides(config *FilterChainConfig, measurements *AudioMeasu
 	idealCeiling := config.LoudnormTargetTP - gainRequired - safetyMarginDB
 	deficit := minLimiterCeilingDB - idealCeiling
 
-	// Always populate diagnostic fields
-	config.LA2AHighCrestDeficit = deficit
-	config.LA2AHighCrestProjectedTP = projectedTP
+	if diagnostics != nil {
+		diagnostics.LA2AHighCrestActive = false
+		diagnostics.LA2AHighCrestDeficit = deficit
+		diagnostics.LA2AHighCrestSeverity = 0
+		diagnostics.LA2AHighCrestProjectedTP = projectedTP
+	}
 
 	if deficit <= 0 {
-		config.LA2AHighCrestActive = false
-		config.LA2AHighCrestSeverity = 0
 		return la2aOverrides{}
 	}
 
 	severity := clamp(deficit/la2aHighCrestMaxDeficit, 0.0, 1.0)
-	config.LA2AHighCrestActive = true
-	config.LA2AHighCrestSeverity = severity
+	if diagnostics != nil {
+		diagnostics.LA2AHighCrestActive = true
+		diagnostics.LA2AHighCrestSeverity = severity
+	}
 
 	return la2aOverrides{
 		ThresholdFloor: lerp(-18.0, -40.0, severity),

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -399,7 +399,7 @@ func detectContentType(m *AudioMeasurements) ContentType {
 // AdaptConfig tunes all filter parameters based on Pass 1 measurements.
 // This is the main entry point for adaptive configuration.
 // It returns a per-file effective config without mutating the caller's base seed.
-func AdaptConfig(config *FilterChainConfig, measurements *AudioMeasurements) *FilterChainConfig {
+func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) *FilterChainConfig {
 	effectiveConfig := derivePerFileConfig(config)
 	if effectiveConfig == nil {
 		return nil
@@ -869,7 +869,13 @@ func tuneDeesserCentroidOnly(config *FilterChainConfig, measurements *AudioMeasu
 //   - Makeup: 1.0 (loudness normalisation handles level compensation)
 func tuneDS201Gate(config *FilterChainConfig, measurements *AudioMeasurements) {
 	config.DS201GateGentleMode = false
-	resetDS201GateDiagnostics(config)
+	config.DS201GateAggression = 0
+	config.DS201GateDynamicRange = 0
+	config.DS201GateQuietSpeechEstimate = 0
+	config.DS201GateSpeechSeparation = 0
+	config.DS201GateSpeechHeadroom = 0
+	config.DS201GateThresholdUnclamped = 0
+	config.DS201GateClampReason = ""
 
 	// Extract silence sample characteristics for gate tuning
 	var silenceEntropy, silenceCrest, silencePeak float64

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -57,9 +57,6 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	if effective.Pass != 0 {
 		t.Errorf("effective Pass = %d, want cleared pass state", effective.Pass)
 	}
-	if effective.OutputAnalysisEnabled {
-		t.Fatal("effective OutputAnalysisEnabled = true, want cleared pass state")
-	}
 	if !reflect.DeepEqual(effective.FilterOrder, base.FilterOrder) {
 		t.Errorf("effective FilterOrder = %v, want copied base order %v", effective.FilterOrder, base.FilterOrder)
 	}

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -33,9 +33,12 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	base.DS201HPFreq = 95.0
 	base.TargetI = -18.0
 
-	effective := AdaptConfig(base, measurements)
+	effective, diagnostics := AdaptConfig(base, measurements)
 	if effective == nil {
 		t.Fatal("AdaptConfig returned nil")
+	}
+	if diagnostics == nil {
+		t.Fatal("AdaptConfig returned nil diagnostics")
 	}
 	if effective.Measurements != measurements {
 		t.Fatal("effective Measurements was not set to Pass 1 measurements")
@@ -67,6 +70,13 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	if effective.DS201HPFreq == 95.0 {
 		t.Fatal("effective DS201HPFreq did not adapt from base seed value")
 	}
+	if diagnostics.DS201LPContentType != ContentMusic {
+		t.Errorf("diagnostics DS201LPContentType = %v, want %v", diagnostics.DS201LPContentType, ContentMusic)
+	}
+	if diagnostics.DS201LPReason != "music content detected" {
+		t.Errorf("diagnostics DS201LPReason = %q, want music content detected", diagnostics.DS201LPReason)
+	}
+	assertCompatibilityDiagnosticsClear(t, &effective.FilterChainConfig)
 }
 
 func TestAdaptConfigOrderIndependence(t *testing.T) {
@@ -74,27 +84,34 @@ func TestAdaptConfigOrderIndependence(t *testing.T) {
 	fileA := orderIndependenceWarmNoProfileMeasurements()
 	fileB := orderIndependenceBrightSpeechMeasurements()
 
-	firstEffective := AdaptConfig(sharedSeed, fileA)
+	firstEffective, firstDiagnostics := AdaptConfig(sharedSeed, fileA)
 	if firstEffective == nil {
 		t.Fatal("AdaptConfig returned nil for file A")
 	}
-	if !firstEffective.DS201GateGentleMode {
+	if firstDiagnostics == nil {
+		t.Fatal("AdaptConfig returned nil diagnostics for file A")
+	}
+	if !firstDiagnostics.DS201GateGentleMode {
 		t.Fatal("file A setup failed: expected gentle gate mode")
 	}
 	if firstEffective.NoiseRemoveCompandEnabled {
 		t.Fatal("file A setup failed: expected compand disabled without a noise profile")
 	}
-	if !firstEffective.LA2AHighCrestActive {
+	if !firstDiagnostics.LA2AHighCrestActive {
 		t.Fatal("file A setup failed: expected high-crest diagnostics active")
 	}
 
-	afterA := AdaptConfig(sharedSeed, fileB)
-	alone := AdaptConfig(newOrderIndependenceSeed(), fileB)
+	afterA, afterADiagnostics := AdaptConfig(sharedSeed, fileB)
+	alone, aloneDiagnostics := AdaptConfig(newOrderIndependenceSeed(), fileB)
 	if afterA == nil || alone == nil {
 		t.Fatal("AdaptConfig returned nil for file B")
 	}
+	if afterADiagnostics == nil || aloneDiagnostics == nil {
+		t.Fatal("AdaptConfig returned nil diagnostics for file B")
+	}
 
 	assertOrderIndependentAdaptiveFields(t, afterA, alone)
+	assertOrderIndependentAdaptiveDiagnostics(t, afterADiagnostics, aloneDiagnostics)
 
 	if !sharedSeed.NoiseRemoveCompandEnabled {
 		t.Fatal("shared seed retained file A compand disabled state")
@@ -130,9 +147,12 @@ func TestAdaptConfigFilterSpecBehaviourBaseline(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := newOrderIndependenceSeed()
-			got := AdaptConfig(config, tt.measurements)
+			got, diagnostics := AdaptConfig(config, tt.measurements)
 			if got == nil {
 				t.Fatal("AdaptConfig returned nil")
+			}
+			if diagnostics == nil {
+				t.Fatal("AdaptConfig returned nil diagnostics")
 			}
 
 			spec := got.BuildFilterSpec()
@@ -224,7 +244,7 @@ func orderIndependenceBrightSpeechMeasurements() *AudioMeasurements {
 	}
 }
 
-func assertOrderIndependentAdaptiveFields(t *testing.T, got, want *FilterChainConfig) {
+func assertOrderIndependentAdaptiveFields(t *testing.T, got, want *EffectiveFilterConfig) {
 	t.Helper()
 
 	tests := []struct {
@@ -237,15 +257,43 @@ func assertOrderIndependentAdaptiveFields(t *testing.T, got, want *FilterChainCo
 		{"DS201HPWidth", got.DS201HPWidth, want.DS201HPWidth},
 		{"DS201HPMix", got.DS201HPMix, want.DS201HPMix},
 		{"DS201HPTransform", got.DS201HPTransform, want.DS201HPTransform},
-		{"DS201GateGentleMode", got.DS201GateGentleMode, want.DS201GateGentleMode},
 		{"NoiseRemoveCompandEnabled", got.NoiseRemoveCompandEnabled, want.NoiseRemoveCompandEnabled},
 		{"NoiseRemoveCompandThreshold", got.NoiseRemoveCompandThreshold, want.NoiseRemoveCompandThreshold},
 		{"NoiseRemoveCompandExpansion", got.NoiseRemoveCompandExpansion, want.NoiseRemoveCompandExpansion},
 		{"DS201LPEnabled", got.DS201LPEnabled, want.DS201LPEnabled},
 		{"DS201LPFreq", got.DS201LPFreq, want.DS201LPFreq},
+		{"LA2AThreshold", got.LA2AThreshold, want.LA2AThreshold},
+		{"LA2ARatio", got.LA2ARatio, want.LA2ARatio},
+		{"LA2ARelease", got.LA2ARelease, want.LA2ARelease},
+		{"LA2AKnee", got.LA2AKnee, want.LA2AKnee},
+	}
+
+	for _, tt := range tests {
+		if !reflect.DeepEqual(tt.got, tt.want) {
+			t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+		}
+	}
+}
+
+func assertOrderIndependentAdaptiveDiagnostics(t *testing.T, got, want *AdaptiveDiagnostics) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		got  any
+		want any
+	}{
 		{"DS201LPContentType", got.DS201LPContentType, want.DS201LPContentType},
 		{"DS201LPReason", got.DS201LPReason, want.DS201LPReason},
 		{"DS201LPRolloffRatio", got.DS201LPRolloffRatio, want.DS201LPRolloffRatio},
+		{"DS201GateGentleMode", got.DS201GateGentleMode, want.DS201GateGentleMode},
+		{"DS201GateAggression", got.DS201GateAggression, want.DS201GateAggression},
+		{"DS201GateDynamicRange", got.DS201GateDynamicRange, want.DS201GateDynamicRange},
+		{"DS201GateQuietSpeechEstimate", got.DS201GateQuietSpeechEstimate, want.DS201GateQuietSpeechEstimate},
+		{"DS201GateSpeechSeparation", got.DS201GateSpeechSeparation, want.DS201GateSpeechSeparation},
+		{"DS201GateSpeechHeadroom", got.DS201GateSpeechHeadroom, want.DS201GateSpeechHeadroom},
+		{"DS201GateThresholdUnclamped", got.DS201GateThresholdUnclamped, want.DS201GateThresholdUnclamped},
+		{"DS201GateClampReason", got.DS201GateClampReason, want.DS201GateClampReason},
 		{"LA2AHighCrestActive", got.LA2AHighCrestActive, want.LA2AHighCrestActive},
 		{"LA2AHighCrestDeficit", got.LA2AHighCrestDeficit, want.LA2AHighCrestDeficit},
 		{"LA2AHighCrestSeverity", got.LA2AHighCrestSeverity, want.LA2AHighCrestSeverity},
@@ -690,10 +738,10 @@ func TestTuneDS201LowPass(t *testing.T) {
 	// Constants from adaptive.go for reference:
 	// Content detection: speech needs kurtosis>6, flatness<0.45, flux<0.003, crest>30 (3+ matches)
 	// HF noise triggers (speech only):
-	//   - Rolloff/centroid > 2.5 → cutoff = rolloff - 1000
-	//   - Slope > -1e-05 → cutoff = 12000
-	//   - ZCR > 0.10 AND centroid < 4000 → cutoff = 10000
-	// Cutoff clamped to 8000-18000
+	//   - Rolloff > 14kHz → cutoff = rolloff + 2kHz
+	//   - Rolloff < 8kHz → disabled because the voice is already dark
+	//   - ZCR > 0.10 AND centroid < 4000 → cutoff = 12000
+	// Cutoff capped at 20000
 
 	tests := []struct {
 		name            string
@@ -857,6 +905,7 @@ func TestTuneDS201LowPass(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := newTestConfig()
+			diagnostics := &AdaptiveDiagnostics{}
 			m := &AudioMeasurements{
 				BaseMeasurements: BaseMeasurements{
 					SpectralKurtosis:  tt.kurtosis,
@@ -870,22 +919,24 @@ func TestTuneDS201LowPass(t *testing.T) {
 				},
 			}
 
-			tuneDS201LowPass(config, m)
+			tuneDS201LowPass(config, diagnostics, m)
 
 			if config.DS201LPEnabled != tt.wantEnabled {
 				t.Errorf("DS201LPEnabled = %v, want %v [%s]",
 					config.DS201LPEnabled, tt.wantEnabled, tt.desc)
 			}
 
-			if config.DS201LPContentType != tt.wantContentType {
+			if diagnostics.DS201LPContentType != tt.wantContentType {
 				t.Errorf("DS201LPContentType = %v, want %v [%s]",
-					config.DS201LPContentType, tt.wantContentType, tt.desc)
+					diagnostics.DS201LPContentType, tt.wantContentType, tt.desc)
 			}
 
-			if config.DS201LPReason != tt.wantReason {
+			if diagnostics.DS201LPReason != tt.wantReason {
 				t.Errorf("DS201LPReason = %q, want %q [%s]",
-					config.DS201LPReason, tt.wantReason, tt.desc)
+					diagnostics.DS201LPReason, tt.wantReason, tt.desc)
 			}
+
+			assertCompatibilityDiagnosticsClear(t, config)
 
 			if tt.wantEnabled && tt.wantFreqMin > 0 {
 				if config.DS201LPFreq < tt.wantFreqMin || config.DS201LPFreq > tt.wantFreqMax {
@@ -1230,7 +1281,7 @@ func TestTuneDS201Gate(t *testing.T) {
 					},
 				}
 
-				tuneDS201Gate(config, measurements)
+				tuneDS201GateForTest(config, measurements)
 
 				actualDB := linearToDB(config.DS201GateThreshold)
 				diff := actualDB - tt.wantThresholdDB
@@ -1267,7 +1318,7 @@ func TestTuneDS201Gate(t *testing.T) {
 					InputLRA:   tt.lra,
 				}
 
-				tuneDS201Gate(config, measurements)
+				tuneDS201GateForTest(config, measurements)
 
 				if config.DS201GateRatio != tt.wantRatio {
 					t.Errorf("DS201GateRatio = %.1f, want %.1f [%s]", config.DS201GateRatio, tt.wantRatio, tt.desc)
@@ -1304,7 +1355,7 @@ func TestTuneDS201Gate(t *testing.T) {
 					NoiseFloor: -55.0,
 				}
 
-				tuneDS201Gate(config, measurements)
+				tuneDS201GateForTest(config, measurements)
 
 				diff := config.DS201GateAttack - tt.wantAttackMS
 				if diff < 0 {
@@ -1347,7 +1398,7 @@ func TestTuneDS201Gate(t *testing.T) {
 					},
 				}
 
-				tuneDS201Gate(config, measurements)
+				tuneDS201GateForTest(config, measurements)
 
 				if config.DS201GateDetection != tt.wantDetection {
 					t.Errorf("DS201GateDetection = %q, want %q [%s]",
@@ -1385,7 +1436,7 @@ func TestTuneDS201Gate(t *testing.T) {
 					},
 				}
 
-				tuneDS201Gate(config, measurements)
+				tuneDS201GateForTest(config, measurements)
 
 				actualDB := linearToDB(config.DS201GateRange)
 				diff := actualDB - tt.wantRangeDB
@@ -1409,7 +1460,7 @@ func TestTuneDS201Gate(t *testing.T) {
 		}
 
 		// Should not panic
-		tuneDS201Gate(config, measurements)
+		tuneDS201GateForTest(config, measurements)
 
 		// Should still calculate threshold from noise floor
 		thresholdDB := linearToDB(config.DS201GateThreshold)
@@ -1499,7 +1550,7 @@ func TestTuneDS201Gate(t *testing.T) {
 					},
 				}
 
-				tuneDS201Gate(config, measurements)
+				tuneDS201GateForTest(config, measurements)
 
 				if config.DS201GateRelease < tt.wantReleaseMin || config.DS201GateRelease > tt.wantReleaseMax {
 					t.Errorf("DS201GateRelease = %.1f ms, want %.1f-%.1f ms [%s]",
@@ -1573,7 +1624,7 @@ func TestTuneDS201Gate(t *testing.T) {
 					},
 				}
 
-				tuneDS201Gate(config, measurements)
+				tuneDS201GateForTest(config, measurements)
 
 				if config.DS201GateRelease < tt.wantReleaseMin || config.DS201GateRelease > tt.wantReleaseMax {
 					t.Errorf("DS201GateRelease = %.1f ms (LRA=%.1f LU), want %.1f-%.1f ms [%s]",
@@ -1583,10 +1634,9 @@ func TestTuneDS201Gate(t *testing.T) {
 		}
 	})
 
-	t.Run("resets gentle mode and diagnostics without speech metrics", func(t *testing.T) {
+	t.Run("populates diagnostics with speech metrics", func(t *testing.T) {
 		config := newTestConfig()
-
-		tuneDS201Gate(config, &AudioMeasurements{
+		diagnostics := tuneDS201GateForTest(config, &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
 				SpectralFlux:  0.02,
 				SpectralCrest: 20.0,
@@ -1605,19 +1655,27 @@ func TestTuneDS201Gate(t *testing.T) {
 			},
 		})
 
-		if !config.DS201GateGentleMode {
+		if !diagnostics.DS201GateGentleMode {
 			t.Fatal("expected first tuning to enable gentle mode")
 		}
-		if config.DS201GateAggression == 0 ||
-			config.DS201GateDynamicRange == 0 ||
-			config.DS201GateQuietSpeechEstimate == 0 ||
-			config.DS201GateSpeechSeparation == 0 ||
-			config.DS201GateThresholdUnclamped == 0 ||
-			config.DS201GateClampReason == "" {
-			t.Fatalf("expected first tuning to populate gate diagnostics: %+v", config)
+		if diagnostics.DS201GateAggression == 0 ||
+			diagnostics.DS201GateDynamicRange == 0 ||
+			diagnostics.DS201GateQuietSpeechEstimate == 0 ||
+			diagnostics.DS201GateSpeechSeparation == 0 ||
+			diagnostics.DS201GateThresholdUnclamped == 0 ||
+			diagnostics.DS201GateClampReason == "" {
+			t.Fatalf("expected tuning to populate gate diagnostics: %+v", diagnostics)
 		}
+		if config.DS201GateRatio != ds201GateGentleRatio || config.DS201GateKnee != ds201GateGentleKnee {
+			t.Fatalf("expected gentle mode to tune builder values, ratio=%.1f knee=%.1f",
+				config.DS201GateRatio, config.DS201GateKnee)
+		}
+		assertCompatibilityDiagnosticsClear(t, config)
+	})
 
-		tuneDS201Gate(config, &AudioMeasurements{
+	t.Run("fresh diagnostics without speech metrics", func(t *testing.T) {
+		config := newTestConfig()
+		diagnostics := tuneDS201GateForTest(config, &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
 				SpectralFlux: 0.02,
 			},
@@ -1626,19 +1684,25 @@ func TestTuneDS201Gate(t *testing.T) {
 			NoiseFloor: -55.0,
 		})
 
-		if config.DS201GateGentleMode {
-			t.Error("DS201GateGentleMode = true, want false")
+		if diagnostics.DS201GateGentleMode {
+			t.Error("diagnostics DS201GateGentleMode = true, want false")
 		}
-		if config.DS201GateAggression != 0 ||
-			config.DS201GateDynamicRange != 0 ||
-			config.DS201GateQuietSpeechEstimate != 0 ||
-			config.DS201GateSpeechSeparation != 0 ||
-			config.DS201GateSpeechHeadroom != 0 ||
-			config.DS201GateThresholdUnclamped != 0 ||
-			config.DS201GateClampReason != "" {
-			t.Errorf("gate diagnostics retained without speech metrics: %+v", config)
+		if diagnostics.DS201GateAggression != 0 ||
+			diagnostics.DS201GateDynamicRange != 0 ||
+			diagnostics.DS201GateQuietSpeechEstimate != 0 ||
+			diagnostics.DS201GateSpeechSeparation != 0 ||
+			diagnostics.DS201GateSpeechHeadroom != 0 ||
+			diagnostics.DS201GateThresholdUnclamped != 0 ||
+			diagnostics.DS201GateClampReason != "" {
+			t.Errorf("fresh gate diagnostics populated without speech metrics: %+v", diagnostics)
 		}
 	})
+}
+
+func tuneDS201GateForTest(config *FilterChainConfig, measurements *AudioMeasurements) *AdaptiveDiagnostics {
+	diagnostics := &AdaptiveDiagnostics{}
+	tuneDS201Gate(config, diagnostics, measurements)
+	return diagnostics
 }
 
 // linearToDB converts linear amplitude to dB for test error messages
@@ -2610,20 +2674,22 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 				config := newTestConfig()
 				// Use DefaultFilterConfig target TP (-2.0) to match proposal calculations
 				config.LoudnormTargetTP = -2.0
+				diagnostics := &AdaptiveDiagnostics{}
 				measurements := &AudioMeasurements{
 					InputI:        tt.inputI,
 					InputTP:       tt.inputTP,
 					SpeechProfile: tt.speechProfile,
 				}
 
-				overrides := applyHighCrestOverrides(config, measurements)
+				overrides := applyHighCrestOverrides(config, diagnostics, measurements)
 
-				if config.LA2AHighCrestActive != tt.wantActive {
-					t.Errorf("LA2AHighCrestActive = %v, want %v", config.LA2AHighCrestActive, tt.wantActive)
+				if diagnostics.LA2AHighCrestActive != tt.wantActive {
+					t.Errorf("LA2AHighCrestActive = %v, want %v", diagnostics.LA2AHighCrestActive, tt.wantActive)
 				}
-				assertClose(t, "LA2AHighCrestDeficit", config.LA2AHighCrestDeficit, tt.wantDeficit, 0.01)
-				assertClose(t, "LA2AHighCrestSeverity", config.LA2AHighCrestSeverity, tt.wantSeverity, 0.001)
-				assertClose(t, "LA2AHighCrestProjectedTP", config.LA2AHighCrestProjectedTP, tt.wantProjectedTP, 0.01)
+				assertClose(t, "LA2AHighCrestDeficit", diagnostics.LA2AHighCrestDeficit, tt.wantDeficit, 0.01)
+				assertClose(t, "LA2AHighCrestSeverity", diagnostics.LA2AHighCrestSeverity, tt.wantSeverity, 0.001)
+				assertClose(t, "LA2AHighCrestProjectedTP", diagnostics.LA2AHighCrestProjectedTP, tt.wantProjectedTP, 0.01)
+				assertCompatibilityDiagnosticsClear(t, config)
 
 				// When inactive, overrides must be zero-valued
 				if !tt.wantActive {
@@ -2679,18 +2745,20 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
 				config.LoudnormTargetTP = -2.0
+				diagnostics := &AdaptiveDiagnostics{}
 				measurements := &AudioMeasurements{
 					InputI:        tt.inputI,
 					InputTP:       tt.inputTP,
 					SpeechProfile: &SpeechCandidateMetrics{},
 				}
 
-				overrides := applyHighCrestOverrides(config, measurements)
+				overrides := applyHighCrestOverrides(config, diagnostics, measurements)
 
 				assertClose(t, "ThresholdFloor", overrides.ThresholdFloor, tt.wantThresholdFloor, 0.01)
 				assertClose(t, "RatioFloor", overrides.RatioFloor, tt.wantRatioFloor, 0.01)
 				assertClose(t, "ReleaseFloor", overrides.ReleaseFloor, tt.wantReleaseFloor, 0.01)
 				assertClose(t, "KneeFloor", overrides.KneeFloor, tt.wantKneeFloor, 0.01)
+				assertCompatibilityDiagnosticsClear(t, config)
 			})
 		}
 	})
@@ -2717,16 +2785,18 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 		for _, tt := range deficits {
 			config := newTestConfig()
 			config.LoudnormTargetTP = -2.0
+			diagnostics := &AdaptiveDiagnostics{}
 			measurements := &AudioMeasurements{
 				InputI:        tt.inputI,
 				InputTP:       -5.0,
 				SpeechProfile: &SpeechCandidateMetrics{},
 			}
 
-			applyHighCrestOverrides(config, measurements)
+			applyHighCrestOverrides(config, diagnostics, measurements)
 
-			assertClose(t, "deficit", config.LA2AHighCrestDeficit, tt.wantDeficit, 0.01)
-			assertClose(t, "severity", config.LA2AHighCrestSeverity, tt.wantSeverity, 0.001)
+			assertClose(t, "deficit", diagnostics.LA2AHighCrestDeficit, tt.wantDeficit, 0.01)
+			assertClose(t, "severity", diagnostics.LA2AHighCrestSeverity, tt.wantSeverity, 0.001)
+			assertCompatibilityDiagnosticsClear(t, config)
 		}
 	})
 
@@ -2734,22 +2804,24 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 		// Acceptance criterion 6: fields populated even when inactive
 		config := newTestConfig()
 		config.LoudnormTargetTP = -2.0
+		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			InputI:        -20.2,
 			InputTP:       -2.5,
 			SpeechProfile: &SpeechCandidateMetrics{},
 		}
 
-		applyHighCrestOverrides(config, measurements)
+		applyHighCrestOverrides(config, diagnostics, measurements)
 
-		if config.LA2AHighCrestActive {
+		if diagnostics.LA2AHighCrestActive {
 			t.Error("expected LA2AHighCrestActive=false for Marius-like input")
 		}
-		if config.LA2AHighCrestDeficit == 0 && config.LA2AHighCrestProjectedTP == 0 {
+		if diagnostics.LA2AHighCrestDeficit == 0 && diagnostics.LA2AHighCrestProjectedTP == 0 {
 			t.Error("diagnostic fields should be populated even when inactive")
 		}
-		assertClose(t, "deficit", config.LA2AHighCrestDeficit, -16.3, 0.01)
-		assertClose(t, "projectedTP", config.LA2AHighCrestProjectedTP, 1.7, 0.01)
+		assertClose(t, "deficit", diagnostics.LA2AHighCrestDeficit, -16.3, 0.01)
+		assertClose(t, "projectedTP", diagnostics.LA2AHighCrestProjectedTP, 1.7, 0.01)
+		assertCompatibilityDiagnosticsClear(t, config)
 	})
 }
 
@@ -2779,6 +2851,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		// Acceptance criterion 1: ratio pushed toward ~3.87, threshold toward ~-27.5
 		config := newTestConfig()
 		config.LoudnormTargetTP = -2.0
+		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
 				DynamicRange:     86.3,
@@ -2795,14 +2868,15 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 			SpeechProfile: speechProfile,
 		}
 
-		tuneLA2ACompressor(config, measurements)
+		tuneLA2ACompressor(config, diagnostics, measurements)
 
 		// Diagnostic fields must be set
-		if !config.LA2AHighCrestActive {
+		if !diagnostics.LA2AHighCrestActive {
 			t.Fatal("expected LA2AHighCrestActive=true for Anna-like input")
 		}
-		assertClose(t, "deficit", config.LA2AHighCrestDeficit, 2.6, 0.1)
-		assertClose(t, "severity", config.LA2AHighCrestSeverity, 0.433, 0.01)
+		assertClose(t, "deficit", diagnostics.LA2AHighCrestDeficit, 2.6, 0.1)
+		assertClose(t, "severity", diagnostics.LA2AHighCrestSeverity, 0.433, 0.01)
+		assertCompatibilityDiagnosticsClear(t, config)
 
 		// Override floors: ratio >= 3.8, threshold <= -27.0
 		// Sub-tuners may push further, but not back above the floor.
@@ -2830,6 +2904,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		// Acceptance criterion 2: identical output to before high-crest logic
 		config := newTestConfig()
 		config.LoudnormTargetTP = -2.0
+		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
 				DynamicRange:     88.9,
@@ -2847,11 +2922,12 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		}
 
 		// Run once with the full tuner chain
-		tuneLA2ACompressor(config, measurements)
+		tuneLA2ACompressor(config, diagnostics, measurements)
 
-		if config.LA2AHighCrestActive {
+		if diagnostics.LA2AHighCrestActive {
 			t.Error("expected LA2AHighCrestActive=false for Marius-like input")
 		}
+		assertCompatibilityDiagnosticsClear(t, config)
 
 		// Capture the values
 		ratioWithOverrides := config.LA2ARatio
@@ -2863,7 +2939,9 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		// since overrides are zero-valued)
 		config2 := newTestConfig()
 		config2.LoudnormTargetTP = -2.0
-		tuneLA2ACompressor(config2, measurements)
+		diagnostics2 := &AdaptiveDiagnostics{}
+		tuneLA2ACompressor(config2, diagnostics2, measurements)
+		assertCompatibilityDiagnosticsClear(t, config2)
 
 		assertClose(t, "ratio", ratioWithOverrides, config2.LA2ARatio, 0.001)
 		assertClose(t, "threshold", thresholdWithOverrides, config2.LA2AThreshold, 0.001)
@@ -2890,6 +2968,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
 				config.LoudnormTargetTP = -2.0
+				diagnostics := &AdaptiveDiagnostics{}
 				measurements := &AudioMeasurements{
 					BaseMeasurements: BaseMeasurements{
 						DynamicRange:     60.0,
@@ -2906,12 +2985,13 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 					SpeechProfile: speechProfile,
 				}
 
-				tuneLA2ACompressor(config, measurements)
+				tuneLA2ACompressor(config, diagnostics, measurements)
 
-				if config.LA2AHighCrestActive {
+				if diagnostics.LA2AHighCrestActive {
 					t.Errorf("deficit > 0 (%.2f) with hot InputTP (%.1f dBTP) - invariant violated",
-						config.LA2AHighCrestDeficit, tt.inputTP)
+						diagnostics.LA2AHighCrestDeficit, tt.inputTP)
 				}
+				assertCompatibilityDiagnosticsClear(t, config)
 			})
 		}
 	})
@@ -2920,6 +3000,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		// Deficit >= 4.0 -> severity 1.0 -> maximum override floors
 		config := newTestConfig()
 		config.LoudnormTargetTP = -2.0
+		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
 				DynamicRange:     90.0,
@@ -2936,12 +3017,13 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 			SpeechProfile: speechProfile,
 		}
 
-		tuneLA2ACompressor(config, measurements)
+		tuneLA2ACompressor(config, diagnostics, measurements)
 
-		if !config.LA2AHighCrestActive {
+		if !diagnostics.LA2AHighCrestActive {
 			t.Fatal("expected LA2AHighCrestActive=true for maximum severity input")
 		}
-		assertClose(t, "severity", config.LA2AHighCrestSeverity, 1.0, 0.001)
+		assertClose(t, "severity", diagnostics.LA2AHighCrestSeverity, 1.0, 0.001)
+		assertCompatibilityDiagnosticsClear(t, config)
 
 		// At severity 1.0, floors are: threshold=-40, ratio=5.0, release=350, knee=6.0
 		// Sub-tuners may push further but not below the floor.

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -40,9 +40,7 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	if diagnostics == nil {
 		t.Fatal("AdaptConfig returned nil diagnostics")
 	}
-	if effective.Measurements != measurements {
-		t.Fatal("effective Measurements was not set to Pass 1 measurements")
-	}
+	assertNoStaleEffectiveConfigFields(t)
 
 	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) {
 		t.Errorf("base FilterOrder = %v, want unchanged custom order", base.FilterOrder)
@@ -54,9 +52,6 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 		t.Errorf("base TargetI = %.1f, want unchanged -18.0", base.TargetI)
 	}
 
-	if effective.Pass != 0 {
-		t.Errorf("effective Pass = %d, want cleared pass state", effective.Pass)
-	}
 	if !reflect.DeepEqual(effective.FilterOrder, base.FilterOrder) {
 		t.Errorf("effective FilterOrder = %v, want copied base order %v", effective.FilterOrder, base.FilterOrder)
 	}
@@ -73,7 +68,7 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	if diagnostics.DS201LPReason != "music content detected" {
 		t.Errorf("diagnostics DS201LPReason = %q, want music content detected", diagnostics.DS201LPReason)
 	}
-	assertCompatibilityDiagnosticsClear(t, &effective.FilterChainConfig)
+	assertNoStaleEffectiveConfigFields(t)
 }
 
 func TestAdaptConfigOrderIndependence(t *testing.T) {
@@ -933,7 +928,7 @@ func TestTuneDS201LowPass(t *testing.T) {
 					diagnostics.DS201LPReason, tt.wantReason, tt.desc)
 			}
 
-			assertCompatibilityDiagnosticsClear(t, config)
+			assertNoStaleEffectiveConfigFields(t)
 
 			if tt.wantEnabled && tt.wantFreqMin > 0 {
 				if config.DS201LPFreq < tt.wantFreqMin || config.DS201LPFreq > tt.wantFreqMax {
@@ -1667,7 +1662,7 @@ func TestTuneDS201Gate(t *testing.T) {
 			t.Fatalf("expected gentle mode to tune builder values, ratio=%.1f knee=%.1f",
 				config.DS201GateRatio, config.DS201GateKnee)
 		}
-		assertCompatibilityDiagnosticsClear(t, config)
+		assertNoStaleEffectiveConfigFields(t)
 	})
 
 	t.Run("fresh diagnostics without speech metrics", func(t *testing.T) {
@@ -1696,7 +1691,7 @@ func TestTuneDS201Gate(t *testing.T) {
 	})
 }
 
-func tuneDS201GateForTest(config *FilterChainConfig, measurements *AudioMeasurements) *AdaptiveDiagnostics {
+func tuneDS201GateForTest(config *EffectiveFilterConfig, measurements *AudioMeasurements) *AdaptiveDiagnostics {
 	diagnostics := &AdaptiveDiagnostics{}
 	tuneDS201Gate(config, diagnostics, measurements)
 	return diagnostics
@@ -1861,7 +1856,7 @@ func TestSanitizeFloat(t *testing.T) {
 }
 
 func TestSanitizeConfig(t *testing.T) {
-	// Tests for sanitizeConfig which sanitizes all tunable parameters in FilterChainConfig
+	// Tests for sanitizeConfig which sanitizes all tunable parameters in EffectiveFilterConfig
 	// Uses defaults from adaptive.go:
 	// defaultHighpassFreq   = 80.0
 	// defaultDeessIntensity = 0.0
@@ -1872,20 +1867,20 @@ func TestSanitizeConfig(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		config FilterChainConfig // input config
-		want   FilterChainConfig // expected after sanitization
+		config EffectiveFilterConfig // input config
+		want   EffectiveFilterConfig // expected after sanitization
 	}{
 		// Clean config should pass through unchanged
 		{
 			name: "valid config passes through unchanged",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: 0.02,
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
@@ -1897,14 +1892,14 @@ func TestSanitizeConfig(t *testing.T) {
 		// NaN in each field
 		{
 			name: "NaN HighpassFreq gets default",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        math.NaN(),
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: 0.02,
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        80.0, // defaultHighpassFreq
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
@@ -1914,14 +1909,14 @@ func TestSanitizeConfig(t *testing.T) {
 		},
 		{
 			name: "NaN DeessIntensity gets default",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     math.NaN(),
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: 0.02,
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.0, // defaultDeessIntensity
 				LA2ARatio:          3.0,
@@ -1931,14 +1926,14 @@ func TestSanitizeConfig(t *testing.T) {
 		},
 		{
 			name: "NaN LA2ARatio gets default",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          math.NaN(),
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: 0.02,
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0, // defaultLA2ARatio (LA-2A inspired)
@@ -1948,14 +1943,14 @@ func TestSanitizeConfig(t *testing.T) {
 		},
 		{
 			name: "NaN LA2AThreshold gets default",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
 				LA2AThreshold:      math.NaN(),
 				DS201GateThreshold: 0.02,
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
@@ -1965,14 +1960,14 @@ func TestSanitizeConfig(t *testing.T) {
 		},
 		{
 			name: "NaN GateThreshold gets default",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: math.NaN(),
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
@@ -1984,14 +1979,14 @@ func TestSanitizeConfig(t *testing.T) {
 		// Inf cases
 		{
 			name: "positive Inf values get defaults",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        math.Inf(1),
 				DeessIntensity:     math.Inf(1),
 				LA2ARatio:          math.Inf(1),
 				LA2AThreshold:      math.Inf(1),
 				DS201GateThreshold: math.Inf(1),
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        80.0,
 				DeessIntensity:     0.0,
 				LA2ARatio:          3.0,   // LA-2A inspired
@@ -2001,14 +1996,14 @@ func TestSanitizeConfig(t *testing.T) {
 		},
 		{
 			name: "negative Inf values get defaults",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        math.Inf(-1),
 				DeessIntensity:     math.Inf(-1),
 				LA2ARatio:          math.Inf(-1),
 				LA2AThreshold:      math.Inf(-1),
 				DS201GateThreshold: math.Inf(-1),
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        80.0,
 				DeessIntensity:     0.0,
 				LA2ARatio:          3.0,   // LA-2A inspired
@@ -2021,14 +2016,14 @@ func TestSanitizeConfig(t *testing.T) {
 		// (other fields allow zero/negative values)
 		{
 			name: "zero GateThreshold gets default",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.0, // zero is valid for DeessIntensity
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: 0.0, // zero is NOT valid for GateThreshold
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.0,
 				LA2ARatio:          3.0,
@@ -2038,14 +2033,14 @@ func TestSanitizeConfig(t *testing.T) {
 		},
 		{
 			name: "negative GateThreshold gets default",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: -0.5, // negative is NOT valid for GateThreshold
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
@@ -2058,14 +2053,14 @@ func TestSanitizeConfig(t *testing.T) {
 		// (sanitizeFloat doesn't treat zero specially)
 		{
 			name: "zero values for non-GateThreshold fields pass through",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        0.0, // passes through (edge case: probably invalid, but sanitize doesn't clamp)
 				DeessIntensity:     0.0, // valid: de-essing disabled
 				LA2ARatio:          0.0, // passes through (edge case: probably invalid)
 				LA2AThreshold:      0.0, // passes through (0 dB threshold)
 				DS201GateThreshold: 0.02,
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        0.0,
 				DeessIntensity:     0.0,
 				LA2ARatio:          0.0,
@@ -2077,14 +2072,14 @@ func TestSanitizeConfig(t *testing.T) {
 		// Negative values for fields that legitimately use them
 		{
 			name: "negative LA2AThreshold passes through (valid dB value)",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -40.0, // very aggressive threshold
 				DS201GateThreshold: 0.02,
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
@@ -2096,14 +2091,14 @@ func TestSanitizeConfig(t *testing.T) {
 		// All fields NaN - complete fallback to defaults
 		{
 			name: "all NaN values get all defaults",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        math.NaN(),
 				DeessIntensity:     math.NaN(),
 				LA2ARatio:          math.NaN(),
 				LA2AThreshold:      math.NaN(),
 				DS201GateThreshold: math.NaN(),
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        80.0,
 				DeessIntensity:     0.0,
 				LA2ARatio:          3.0,   // LA-2A inspired
@@ -2115,14 +2110,14 @@ func TestSanitizeConfig(t *testing.T) {
 		// Very small positive GateThreshold passes through
 		{
 			name: "very small positive GateThreshold passes through",
-			config: FilterChainConfig{
+			config: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
 				LA2AThreshold:      -24.0,
 				DS201GateThreshold: 1e-10, // very small but positive
 			},
-			want: FilterChainConfig{
+			want: EffectiveFilterConfig{
 				DS201HPFreq:        100.0,
 				DeessIntensity:     0.3,
 				LA2ARatio:          3.0,
@@ -2686,7 +2681,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 				assertClose(t, "LA2AHighCrestDeficit", diagnostics.LA2AHighCrestDeficit, tt.wantDeficit, 0.01)
 				assertClose(t, "LA2AHighCrestSeverity", diagnostics.LA2AHighCrestSeverity, tt.wantSeverity, 0.001)
 				assertClose(t, "LA2AHighCrestProjectedTP", diagnostics.LA2AHighCrestProjectedTP, tt.wantProjectedTP, 0.01)
-				assertCompatibilityDiagnosticsClear(t, config)
+				assertNoStaleEffectiveConfigFields(t)
 
 				// When inactive, overrides must be zero-valued
 				if !tt.wantActive {
@@ -2755,7 +2750,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 				assertClose(t, "RatioFloor", overrides.RatioFloor, tt.wantRatioFloor, 0.01)
 				assertClose(t, "ReleaseFloor", overrides.ReleaseFloor, tt.wantReleaseFloor, 0.01)
 				assertClose(t, "KneeFloor", overrides.KneeFloor, tt.wantKneeFloor, 0.01)
-				assertCompatibilityDiagnosticsClear(t, config)
+				assertNoStaleEffectiveConfigFields(t)
 			})
 		}
 	})
@@ -2793,7 +2788,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 
 			assertClose(t, "deficit", diagnostics.LA2AHighCrestDeficit, tt.wantDeficit, 0.01)
 			assertClose(t, "severity", diagnostics.LA2AHighCrestSeverity, tt.wantSeverity, 0.001)
-			assertCompatibilityDiagnosticsClear(t, config)
+			assertNoStaleEffectiveConfigFields(t)
 		}
 	})
 
@@ -2818,7 +2813,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 		}
 		assertClose(t, "deficit", diagnostics.LA2AHighCrestDeficit, -16.3, 0.01)
 		assertClose(t, "projectedTP", diagnostics.LA2AHighCrestProjectedTP, 1.7, 0.01)
-		assertCompatibilityDiagnosticsClear(t, config)
+		assertNoStaleEffectiveConfigFields(t)
 	})
 }
 
@@ -2873,7 +2868,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		}
 		assertClose(t, "deficit", diagnostics.LA2AHighCrestDeficit, 2.6, 0.1)
 		assertClose(t, "severity", diagnostics.LA2AHighCrestSeverity, 0.433, 0.01)
-		assertCompatibilityDiagnosticsClear(t, config)
+		assertNoStaleEffectiveConfigFields(t)
 
 		// Override floors: ratio >= 3.8, threshold <= -27.0
 		// Sub-tuners may push further, but not back above the floor.
@@ -2924,7 +2919,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		if diagnostics.LA2AHighCrestActive {
 			t.Error("expected LA2AHighCrestActive=false for Marius-like input")
 		}
-		assertCompatibilityDiagnosticsClear(t, config)
+		assertNoStaleEffectiveConfigFields(t)
 
 		// Capture the values
 		ratioWithOverrides := config.LA2ARatio
@@ -2938,7 +2933,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		config2.LoudnormTargetTP = -2.0
 		diagnostics2 := &AdaptiveDiagnostics{}
 		tuneLA2ACompressor(config2, diagnostics2, measurements)
-		assertCompatibilityDiagnosticsClear(t, config2)
+		assertNoStaleEffectiveConfigFields(t)
 
 		assertClose(t, "ratio", ratioWithOverrides, config2.LA2ARatio, 0.001)
 		assertClose(t, "threshold", thresholdWithOverrides, config2.LA2AThreshold, 0.001)
@@ -2988,7 +2983,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 					t.Errorf("deficit > 0 (%.2f) with hot InputTP (%.1f dBTP) - invariant violated",
 						diagnostics.LA2AHighCrestDeficit, tt.inputTP)
 				}
-				assertCompatibilityDiagnosticsClear(t, config)
+				assertNoStaleEffectiveConfigFields(t)
 			})
 		}
 	})
@@ -3020,7 +3015,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 			t.Fatal("expected LA2AHighCrestActive=true for maximum severity input")
 		}
 		assertClose(t, "severity", diagnostics.LA2AHighCrestSeverity, 1.0, 0.001)
-		assertCompatibilityDiagnosticsClear(t, config)
+		assertNoStaleEffectiveConfigFields(t)
 
 		// At severity 1.0, floors are: threshold=-40, ratio=5.0, release=350, knee=6.0
 		// Sub-tuners may push further but not below the floor.

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
-	staleMeasurements := &AudioMeasurements{InputI: -12.0}
 	measurements := &AudioMeasurements{
 		BaseMeasurements: BaseMeasurements{
 			SpectralCentroid: 5000,
@@ -28,11 +27,8 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 		},
 	}
 
-	base := newTestConfig()
-	base.Pass = PassProcessing
+	base := newTestBaseConfig()
 	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
-	base.Measurements = staleMeasurements
-	base.OutputAnalysisEnabled = true
 	base.DS201HPEnabled = true
 	base.DS201HPFreq = 95.0
 	base.TargetI = -18.0
@@ -41,24 +37,12 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	if effective == nil {
 		t.Fatal("AdaptConfig returned nil")
 	}
-	if effective == base {
-		t.Fatal("AdaptConfig returned the base pointer")
-	}
 	if effective.Measurements != measurements {
 		t.Fatal("effective Measurements was not set to Pass 1 measurements")
 	}
 
-	if base.Pass != PassProcessing {
-		t.Errorf("base Pass = %d, want %d", base.Pass, PassProcessing)
-	}
 	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) {
 		t.Errorf("base FilterOrder = %v, want unchanged custom order", base.FilterOrder)
-	}
-	if base.Measurements != staleMeasurements {
-		t.Fatal("base Measurements was mutated")
-	}
-	if !base.OutputAnalysisEnabled {
-		t.Fatal("base OutputAnalysisEnabled was mutated")
 	}
 	if base.DS201HPFreq != 95.0 {
 		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", base.DS201HPFreq)
@@ -110,28 +94,66 @@ func TestAdaptConfigOrderIndependence(t *testing.T) {
 		t.Fatal("AdaptConfig returned nil for file B")
 	}
 
-	if afterA == sharedSeed {
-		t.Fatal("AdaptConfig returned shared seed for file B after file A")
-	}
-	if alone == sharedSeed {
-		t.Fatal("AdaptConfig returned shared seed for file B alone")
-	}
-
 	assertOrderIndependentAdaptiveFields(t, afterA, alone)
 
-	if sharedSeed.DS201GateGentleMode {
-		t.Fatal("shared seed retained file A gentle gate state")
-	}
 	if !sharedSeed.NoiseRemoveCompandEnabled {
 		t.Fatal("shared seed retained file A compand disabled state")
 	}
-	if sharedSeed.LA2AHighCrestActive {
-		t.Fatal("shared seed retained file A high-crest state")
+}
+
+func TestAdaptConfigFilterSpecBehaviourBaseline(t *testing.T) {
+	tests := []struct {
+		name         string
+		measurements *AudioMeasurements
+		want         string
+	}{
+		{
+			name:         "warm voice without noise profile",
+			measurements: orderIndependenceWarmNoProfileMeasurements(),
+			want: "highpass=f=60:poles=1:width_type=q:width=0.500:normalize=1:a=tdii:m=0.80," +
+				"anlmdn=s=0.00001:p=0.0060:r=0.0058:m=11," +
+				"agate=threshold=0.012589:ratio=1.2:attack=17.00:release=400:range=0.0447:knee=2.0:detection=rms:makeup=1.0," +
+				"acompressor=threshold=0.011839:ratio=4.9:attack=10:release=340:makeup=1.00:knee=5.9:detection=rms:mix=0.93",
+		},
+		{
+			name:         "bright speech with noise profile",
+			measurements: orderIndependenceBrightSpeechMeasurements(),
+			want: "highpass=f=110:poles=2:width_type=q:width=0.707:normalize=1:a=tdii," +
+				"lowpass=f=17000:poles=1:width_type=q:width=0.707:normalize=1," +
+				"anlmdn=s=0.00001:p=0.0060:r=0.0058:m=11," +
+				"compand=attacks=0.005:decays=0.100:soft-knee=6.0:points=-90/-96|-75/-81|-55/-55|-30/-30|0/0," +
+				"agate=threshold=0.019953:ratio=2.0:attack=10.00:release=250:range=0.0447:knee=5.0:detection=rms:makeup=1.0," +
+				"acompressor=threshold=0.050119:ratio=3.0:attack=10:release=150:makeup=1.00:knee=4.0:detection=rms:mix=0.93",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := newOrderIndependenceSeed()
+			got := AdaptConfig(config, tt.measurements)
+			if got == nil {
+				t.Fatal("AdaptConfig returned nil")
+			}
+
+			spec := got.BuildFilterSpec()
+			if spec != tt.want {
+				t.Errorf("BuildFilterSpec() = %q, want %q", spec, tt.want)
+			}
+		})
 	}
 }
 
-func newOrderIndependenceSeed() *FilterChainConfig {
-	config := newTestConfig()
+func TestAdaptConfigSeedParameterOwnershipBoundary(t *testing.T) {
+	typ := reflect.TypeOf(AdaptConfig)
+	if typ.NumIn() != 2 {
+		t.Fatalf("AdaptConfig has %d parameters, want 2", typ.NumIn())
+	}
+
+	assertSeedConfigTypeCannotOwnPerFileState(t, typ.In(0))
+}
+
+func newOrderIndependenceSeed() *BaseFilterConfig {
+	config := newTestBaseConfig()
 	config.DS201HPEnabled = true
 	config.DS201LPEnabled = true
 	config.NoiseRemoveEnabled = true

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -682,9 +682,14 @@ func createAnalysisFilterGraph(
 	// Configure for Pass 1 analysis
 	// Uses unified BuildFilterSpec() with Pass1FilterOrder:
 	// Downmix → Analysis
-	analysisConfig := derivePerFileConfig(config)
+	analysisConfig := *config
+	if config.FilterOrder != nil {
+		analysisConfig.FilterOrder = append([]FilterID(nil), config.FilterOrder...)
+	}
+	analysisConfig.Measurements = nil
+	analysisConfig.OutputAnalysisEnabled = false
 	analysisConfig.Pass = PassAnalysis
 	analysisConfig.FilterOrder = Pass1FilterOrder
 
-	return setupFilterGraph(decCtx, analysisConfig.BuildFilterSpec())
+	return setupFilterGraph(decCtx, (&analysisConfig).BuildFilterSpec())
 }

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -691,8 +691,6 @@ func createAnalysisFilterGraph(
 
 	analysisConfig := deriveEffectiveFilterConfig(config)
 	analysisConfig.FilterOrder = cloneFilterOrder(Pass1FilterOrder)
-	analysisConfig.Measurements = context.Measurements
-	analysisConfig.Pass = context.Pass
 
 	return setupFilterGraph(decCtx, analysisConfig.BuildFilterSpec())
 }

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -276,11 +276,12 @@ type OutputMeasurements struct {
 //
 // The noise floor and silence threshold are computed from interval data AFTER the full pass,
 // eliminating the need for a separate pre-scan phase.
-func AnalyzeAudio(filename string, config *FilterChainConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*AudioMeasurements, error) {
+func AnalyzeAudio(filename string, config *BaseFilterConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*AudioMeasurements, error) {
 	// Default fallback threshold if interval analysis yields insufficient data
 	const defaultNoiseFloor = -50.0
 
-	collection, err := collectAnalysisFrames(filename, config, progressCallback)
+	analysisContext := &ProcessingFilterContext{Pass: PassAnalysis}
+	collection, err := collectAnalysisFrames(filename, config, analysisContext, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +372,7 @@ func selectSpeechProfile(measurements *AudioMeasurements, intervals []IntervalSa
 	}
 }
 
-func buildInputMeasurements(filename string, collection *analysisFrameCollection, config *FilterChainConfig, defaultNoiseFloor float64) (*AudioMeasurements, error) {
+func buildInputMeasurements(filename string, collection *analysisFrameCollection, config *BaseFilterConfig, defaultNoiseFloor float64) (*AudioMeasurements, error) {
 	acc := collection.accumulators
 
 	noiseFloorEstimate, silenceThreshold, ok := estimateNoiseFloorAndThreshold(collection.silenceIntervals, collection.silenceMedians)
@@ -496,7 +497,7 @@ type analysisFrameCollection struct {
 	silenceMedians   silenceMedians
 }
 
-func collectAnalysisFrames(filename string, config *FilterChainConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*analysisFrameCollection, error) {
+func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *ProcessingFilterContext, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*analysisFrameCollection, error) {
 	reader, metadata, err := audio.OpenAudioFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open audio file: %w", err)
@@ -511,6 +512,7 @@ func collectAnalysisFrames(filename string, config *FilterChainConfig, progressC
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := createAnalysisFilterGraph(
 		reader.GetDecoderContext(),
 		config,
+		context,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create filter graph: %w", err)
@@ -569,7 +571,7 @@ func collectAnalysisFrames(filename string, config *FilterChainConfig, progressC
 				if progress > 1.0 {
 					progress = 1.0
 				}
-				progressCallback(PassAnalysis, "Analyzing", progress, currentLevel, nil)
+				progressCallback(context.Pass, "Analyzing", progress, currentLevel, nil)
 			}
 			frameCount++
 		},
@@ -677,19 +679,20 @@ func calculateAdaptiveDS201GateThreshold(noiseFloor, rmsTrough float64) float64 
 // Silence detection is now performed in Go using 250ms interval sampling.
 func createAnalysisFilterGraph(
 	decCtx *ffmpeg.AVCodecContext,
-	config *FilterChainConfig,
+	config *BaseFilterConfig,
+	context *ProcessingFilterContext,
 ) (*ffmpeg.AVFilterGraph, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, error) {
-	// Configure for Pass 1 analysis
-	// Uses unified BuildFilterSpec() with Pass1FilterOrder:
-	// Downmix → Analysis
-	analysisConfig := *config
-	if config.FilterOrder != nil {
-		analysisConfig.FilterOrder = append([]FilterID(nil), config.FilterOrder...)
+	if context == nil {
+		context = &ProcessingFilterContext{Pass: PassAnalysis}
 	}
-	analysisConfig.Measurements = nil
-	analysisConfig.OutputAnalysisEnabled = false
-	analysisConfig.Pass = PassAnalysis
-	analysisConfig.FilterOrder = Pass1FilterOrder
+	if context.Pass == 0 {
+		context.Pass = PassAnalysis
+	}
 
-	return setupFilterGraph(decCtx, (&analysisConfig).BuildFilterSpec())
+	analysisConfig := deriveEffectiveFilterConfig(config)
+	analysisConfig.FilterOrder = cloneFilterOrder(Pass1FilterOrder)
+	analysisConfig.Measurements = context.Measurements
+	analysisConfig.Pass = context.Pass
+
+	return setupFilterGraph(decCtx, analysisConfig.BuildFilterSpec())
 }

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -29,7 +29,7 @@ func TestAnalyzeAudio(t *testing.T) {
 	defer cleanupTestAudio(t, testFile)
 
 	// Use test config with podcast standard targets
-	config := newTestConfig()
+	config := newTestBaseConfig()
 	config.AnalysisEnabled = true
 
 	t.Run("synthetic_tone_with_silence", func(t *testing.T) {
@@ -101,22 +101,17 @@ func TestAnalyzeAudioDoesNotMutateCallerConfig(t *testing.T) {
 	})
 	defer cleanupTestAudio(t, testFile)
 
-	seedMeasurements := &AudioMeasurements{InputI: -30.0}
-	config := DefaultEffectiveFilterConfig()
-	config.Pass = PassProcessing
+	config := DefaultFilterConfig()
 	config.FilterOrder = []FilterID{FilterNoiseRemove, FilterAnalysis}
-	config.Measurements = seedMeasurements
-	config.OutputAnalysisEnabled = true
+	config.SilenceScanDuration = 250 * time.Millisecond
 
 	originalOrder := append([]FilterID(nil), config.FilterOrder...)
+	originalSilenceScanDuration := config.SilenceScanDuration
 
 	if _, err := AnalyzeAudio(testFile, config, nil); err != nil {
 		t.Fatalf("AnalyzeAudio failed: %v", err)
 	}
 
-	if config.Pass != PassProcessing {
-		t.Errorf("Pass = %d, want %d", config.Pass, PassProcessing)
-	}
 	if len(config.FilterOrder) != len(originalOrder) {
 		t.Fatalf("FilterOrder length = %d, want %d", len(config.FilterOrder), len(originalOrder))
 	}
@@ -125,11 +120,8 @@ func TestAnalyzeAudioDoesNotMutateCallerConfig(t *testing.T) {
 			t.Errorf("FilterOrder[%d] = %q, want %q", i, config.FilterOrder[i], originalOrder[i])
 		}
 	}
-	if config.Measurements != seedMeasurements {
-		t.Errorf("Measurements = %p, want %p", config.Measurements, seedMeasurements)
-	}
-	if !config.OutputAnalysisEnabled {
-		t.Error("OutputAnalysisEnabled = false, want true")
+	if config.SilenceScanDuration != originalSilenceScanDuration {
+		t.Errorf("SilenceScanDuration = %v, want %v", config.SilenceScanDuration, originalSilenceScanDuration)
 	}
 }
 
@@ -2550,7 +2542,7 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 	// any non-determinism in floating-point reductions across runs.
 	const loudnessTolerance = 0.01
 
-	baselineConfig := newTestConfig()
+	baselineConfig := newTestBaseConfig()
 	baselineConfig.AnalysisEnabled = true
 
 	baseline, err := AnalyzeAudio(testFile, baselineConfig, nil)
@@ -2591,7 +2583,7 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 
 	t.Run("zero_matches_baseline", func(t *testing.T) {
 		// AC1 / AC5: explicit zero is identical to flag absent (no cap).
-		config := newTestConfig()
+		config := newTestBaseConfig()
 		config.AnalysisEnabled = true
 		config.SilenceScanDuration = 0
 
@@ -2620,7 +2612,7 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 		// AC6: with a cap of 2 s, the silence at 8-55 s falls outside the silence
 		// pipeline's view, so no candidates are formed and no profile is extracted.
 		// 2 s lands cleanly between the 1.75 s and 2.0 s interval start times.
-		config := newTestConfig()
+		config := newTestBaseConfig()
 		config.AnalysisEnabled = true
 		config.SilenceScanDuration = 2 * time.Second
 
@@ -2642,7 +2634,7 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 		// AC7: cap at 60 s comfortably covers the silence at 8-55 s, so the
 		// silence pipeline elects the same region as the uncapped run and
 		// produces the same NoiseProfile placement.
-		config := newTestConfig()
+		config := newTestBaseConfig()
 		config.AnalysisEnabled = true
 		config.SilenceScanDuration = 60 * time.Second
 
@@ -2670,7 +2662,7 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 		// elects the same region), whole-file measurements (loudness, true peak,
 		// LRA, speech regions, interval samples) match the uncapped run because
 		// only the silence pipeline reads the capped slice.
-		config := newTestConfig()
+		config := newTestBaseConfig()
 		config.AnalysisEnabled = true
 		config.SilenceScanDuration = 60 * time.Second
 

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -102,7 +102,7 @@ func TestAnalyzeAudioDoesNotMutateCallerConfig(t *testing.T) {
 	defer cleanupTestAudio(t, testFile)
 
 	seedMeasurements := &AudioMeasurements{InputI: -30.0}
-	config := DefaultFilterConfig()
+	config := DefaultEffectiveFilterConfig()
 	config.Pass = PassProcessing
 	config.FilterOrder = []FilterID{FilterNoiseRemove, FilterAnalysis}
 	config.Measurements = seedMeasurements

--- a/internal/processor/benchmark_test.go
+++ b/internal/processor/benchmark_test.go
@@ -15,7 +15,7 @@ func BenchmarkAnalyzeAudioSynthetic5m(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		config := newTestConfig()
+		config := newTestBaseConfig()
 		config.AnalysisEnabled = true
 		if _, err := AnalyzeAudio(inputPath, config, nil); err != nil {
 			b.Fatalf("AnalyzeAudio failed: %v", err)

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -29,7 +29,7 @@ type fullbenchPass2Seed struct {
 
 type fullbenchLoudnormSetup struct {
 	Measurement       *LoudnormMeasurement
-	EffectiveConfig   *FilterChainConfig
+	EffectiveConfig   *EffectiveFilterConfig
 	Pass3FilterPrefix string
 	PreGainDB         float64
 	LimiterCeiling    float64
@@ -52,7 +52,7 @@ type fullbenchFilterSpecRunResult struct {
 type fullbenchPass2AblationVariant struct {
 	Name                string
 	ExtractMeasurements bool
-	BuildSpec           func(*FilterChainConfig) string
+	BuildSpec           func(*EffectiveFilterConfig) string
 }
 
 type fullbenchPass4AblationVariant struct {
@@ -244,14 +244,14 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 		{
 			Name:                "full_chain",
 			ExtractMeasurements: true,
-			BuildSpec: func(config *FilterChainConfig) string {
+			BuildSpec: func(config *EffectiveFilterConfig) string {
 				return config.BuildFilterSpec()
 			},
 		},
 		{
 			Name:                "without_output_analysis",
 			ExtractMeasurements: false,
-			BuildSpec: func(config *FilterChainConfig) string {
+			BuildSpec: func(config *EffectiveFilterConfig) string {
 				ablated := *config
 				ablated.AnalysisEnabled = false
 				ablated.OutputAnalysisEnabled = false
@@ -266,7 +266,7 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 		{
 			Name:                "without_compand",
 			ExtractMeasurements: true,
-			BuildSpec: func(config *FilterChainConfig) string {
+			BuildSpec: func(config *EffectiveFilterConfig) string {
 				ablated := *config
 				ablated.NoiseRemoveCompandEnabled = false
 				return ablated.BuildFilterSpec()
@@ -275,7 +275,7 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 		{
 			Name:                "without_gate_compressor",
 			ExtractMeasurements: true,
-			BuildSpec: func(config *FilterChainConfig) string {
+			BuildSpec: func(config *EffectiveFilterConfig) string {
 				ablated := *config
 				ablated.DS201GateEnabled = false
 				ablated.LA2AEnabled = false
@@ -285,7 +285,7 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 	}
 }
 
-func buildFullbenchPass2WithoutAnlmdnSpec(config *FilterChainConfig) string {
+func buildFullbenchPass2WithoutAnlmdnSpec(config *EffectiveFilterConfig) string {
 	ablated := *config
 	order := ablated.FilterOrder
 	if len(order) == 0 {
@@ -361,14 +361,14 @@ func buildFullbenchPass4AblationSpec(loudnorm *fullbenchLoudnormSetup, includeLi
 	return strings.Join(filters, ",")
 }
 
-func buildFullbenchLoudnormClause(config *FilterChainConfig, measurement *LoudnormMeasurement) string {
+func buildFullbenchLoudnormClause(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	return extractFullbenchFilterClause(
 		buildFullbenchProductionPass4SpecWithoutAdeclick(config, measurement),
 		"loudnorm=",
 	)
 }
 
-func buildFullbenchPass4OutputAnalysisFilters(config *FilterChainConfig, measurement *LoudnormMeasurement) string {
+func buildFullbenchPass4OutputAnalysisFilters(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	clauses := strings.Split(buildFullbenchProductionPass4SpecWithoutAdeclick(config, measurement), ",")
 	analysisStart := -1
 	resampleStart := -1
@@ -387,16 +387,16 @@ func buildFullbenchPass4OutputAnalysisFilters(config *FilterChainConfig, measure
 	return strings.Join(clauses[analysisStart:resampleStart], ",")
 }
 
-func buildFullbenchPass4ResampleFilter(config *FilterChainConfig) string {
+func buildFullbenchPass4ResampleFilter(config *EffectiveFilterConfig) string {
 	resampleConfig := *config
 	resampleConfig.ResampleEnabled = true
 	return resampleConfig.buildResampleFilter()
 }
 
-func buildFullbenchProductionPass4SpecWithoutAdeclick(config *FilterChainConfig, measurement *LoudnormMeasurement) string {
+func buildFullbenchProductionPass4SpecWithoutAdeclick(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	pass4Config := *config
 	pass4Config.AdeclickEnabled = false
-	return buildLoudnormFilterSpec(&pass4Config, measurement, 0, 0, false)
+	return buildLoudnormFilterSpec(&pass4Config.FilterChainConfig, measurement, 0, 0, false)
 }
 
 func extractFullbenchFilterClause(spec, prefix string) string {
@@ -489,7 +489,7 @@ func TestFullbenchPass2AblationSpecs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variant := variantByName[tt.name]
-			spec := variant.BuildSpec(config)
+			spec := variant.BuildSpec(effectiveFromFilterChainConfig(config))
 			assertFullbenchSpecContains(t, spec, tt.wantPresent)
 			assertFullbenchSpecExcludes(t, spec, tt.wantAbsent)
 			if variant.ExtractMeasurements != tt.extractMeasurements {
@@ -514,7 +514,7 @@ func TestFullbenchPass2WithoutAnlmdnPreservesOrder(t *testing.T) {
 	config.ResampleEnabled = true
 	config.FilterOrder = Pass2FilterOrder
 
-	spec := buildFullbenchPass2WithoutAnlmdnSpec(config)
+	spec := buildFullbenchPass2WithoutAnlmdnSpec(effectiveFromFilterChainConfig(config))
 
 	assertFullbenchSpecExcludes(t, spec, []string{"anlmdn="})
 	assertFullbenchSpecContains(t, spec, []string{"compand="})
@@ -555,7 +555,7 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false),
 		"loudnorm=",
 	)
-	benchmarkClause := buildFullbenchLoudnormClause(config, measurement)
+	benchmarkClause := buildFullbenchLoudnormClause(effectiveFromFilterChainConfig(config), measurement)
 
 	if benchmarkClause != productionClause {
 		t.Fatalf("benchmark loudnorm clause drifted from production\nbenchmark:  %s\nproduction: %s", benchmarkClause, productionClause)
@@ -591,7 +591,7 @@ func TestFullbenchPass4AblationSpecs(t *testing.T) {
 	}
 	loudnorm := &fullbenchLoudnormSetup{
 		Measurement:       measurement,
-		EffectiveConfig:   config,
+		EffectiveConfig:   effectiveFromFilterChainConfig(config),
 		Pass3FilterPrefix: buildPreLimiterPrefix(0, -12.0, true),
 		LimiterNeeded:     true,
 		LimiterCeiling:    -12.0,
@@ -682,7 +682,7 @@ func TestFullbenchPass4LimiterVariantOmitsInactivePrefix(t *testing.T) {
 	}
 	loudnorm := &fullbenchLoudnormSetup{
 		Measurement:     measurement,
-		EffectiveConfig: config,
+		EffectiveConfig: effectiveFromFilterChainConfig(config),
 	}
 
 	for _, variant := range fullbenchPass4AblationVariants() {
@@ -798,7 +798,7 @@ func BenchmarkPass2FilterAblations(b *testing.B) {
 			config := *adapted.Config
 			config.Pass = PassProcessing
 			config.FilterOrder = Pass2FilterOrder
-			spec := variant.BuildSpec(&config)
+			spec := variant.BuildSpec(effectiveFromFilterChainConfig(&config))
 			if spec == "" {
 				b.Fatal("Pass 2 ablation filter spec must not be empty")
 			}
@@ -1008,7 +1008,7 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 
 	return &fullbenchLoudnormSetup{
 		Measurement:       measurement,
-		EffectiveConfig:   &effectiveConfig,
+		EffectiveConfig:   effectiveFromFilterChainConfig(&effectiveConfig),
 		Pass3FilterPrefix: filterPrefix,
 		PreGainDB:         preGainDB,
 		LimiterCeiling:    limiterCeiling,

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -15,13 +15,13 @@ import (
 const fullbenchFixtureEnv = "JIVETALKING_BENCH_FIXTURE"
 
 type fullbenchAdaptedSetup struct {
-	Config       *FilterChainConfig
+	Config       *EffectiveFilterConfig
 	Measurements *AudioMeasurements
 }
 
 type fullbenchPass2Seed struct {
 	OutputPath         string
-	Config             *FilterChainConfig
+	Config             *EffectiveFilterConfig
 	InputMeasurements  *AudioMeasurements
 	OutputMeasurements *OutputMeasurements
 	InputMetadata      InputMetadata
@@ -60,6 +60,10 @@ type fullbenchPass4AblationVariant struct {
 	RequiresLimiter     bool
 	ExtractMeasurements bool
 	BuildSpec           func(*fullbenchLoudnormSetup) string
+}
+
+func newFullbenchEffectiveTestConfig() *EffectiveFilterConfig {
+	return deriveEffectiveFilterConfig(newTestBaseConfig())
 }
 
 func resolveFullbenchFixture(tb testing.TB) string {
@@ -409,7 +413,7 @@ func extractFullbenchFilterClause(spec, prefix string) string {
 }
 
 func TestFullbenchPass2AblationSpecs(t *testing.T) {
-	config := newTestConfig()
+	config := newFullbenchEffectiveTestConfig()
 	config.DownmixEnabled = true
 	config.DS201HPEnabled = true
 	config.DS201LPEnabled = true
@@ -487,7 +491,7 @@ func TestFullbenchPass2AblationSpecs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variant := variantByName[tt.name]
-			spec := variant.BuildSpec(effectiveFromFilterChainConfig(config))
+			spec := variant.BuildSpec(config)
 			assertFullbenchSpecContains(t, spec, tt.wantPresent)
 			assertFullbenchSpecExcludes(t, spec, tt.wantAbsent)
 			if variant.ExtractMeasurements != tt.extractMeasurements {
@@ -498,7 +502,7 @@ func TestFullbenchPass2AblationSpecs(t *testing.T) {
 }
 
 func TestFullbenchPass2WithoutAnlmdnPreservesOrder(t *testing.T) {
-	config := newTestConfig()
+	config := newFullbenchEffectiveTestConfig()
 	config.DownmixEnabled = true
 	config.DS201HPEnabled = true
 	config.DS201LPEnabled = true
@@ -512,7 +516,7 @@ func TestFullbenchPass2WithoutAnlmdnPreservesOrder(t *testing.T) {
 	config.ResampleEnabled = true
 	config.FilterOrder = Pass2FilterOrder
 
-	spec := buildFullbenchPass2WithoutAnlmdnSpec(effectiveFromFilterChainConfig(config))
+	spec := buildFullbenchPass2WithoutAnlmdnSpec(config)
 
 	assertFullbenchSpecExcludes(t, spec, []string{"anlmdn="})
 	assertFullbenchSpecContains(t, spec, []string{"compand="})
@@ -533,7 +537,7 @@ func TestFullbenchPass2WithoutAnlmdnPreservesOrder(t *testing.T) {
 }
 
 func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
-	config := newTestConfig()
+	config := newFullbenchEffectiveTestConfig()
 	config.AdeclickEnabled = true
 	config.LoudnormTargetI = -17.25
 	config.LoudnormTargetTP = -2.25
@@ -550,10 +554,10 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 	productionConfig := *config
 	productionConfig.AdeclickEnabled = false
 	productionClause := extractFullbenchFilterClause(
-		buildLoudnormFilterSpec(effectiveFromFilterChainConfig(&productionConfig), measurement, 0, 0, false),
+		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false),
 		"loudnorm=",
 	)
-	benchmarkClause := buildFullbenchLoudnormClause(effectiveFromFilterChainConfig(config), measurement)
+	benchmarkClause := buildFullbenchLoudnormClause(config, measurement)
 
 	if benchmarkClause != productionClause {
 		t.Fatalf("benchmark loudnorm clause drifted from production\nbenchmark:  %s\nproduction: %s", benchmarkClause, productionClause)
@@ -577,7 +581,7 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 }
 
 func TestFullbenchPass4AblationSpecs(t *testing.T) {
-	config := newTestConfig()
+	config := newFullbenchEffectiveTestConfig()
 	config.AdeclickEnabled = true
 	config.ResampleEnabled = false
 	measurement := &LoudnormMeasurement{
@@ -589,7 +593,7 @@ func TestFullbenchPass4AblationSpecs(t *testing.T) {
 	}
 	loudnorm := &fullbenchLoudnormSetup{
 		Measurement:       measurement,
-		EffectiveConfig:   effectiveFromFilterChainConfig(config),
+		EffectiveConfig:   config,
 		Pass3FilterPrefix: buildPreLimiterPrefix(0, -12.0, true),
 		LimiterNeeded:     true,
 		LimiterCeiling:    -12.0,
@@ -670,7 +674,7 @@ func TestFullbenchPass4AblationSpecs(t *testing.T) {
 }
 
 func TestFullbenchPass4LimiterVariantOmitsInactivePrefix(t *testing.T) {
-	config := newTestConfig()
+	config := newFullbenchEffectiveTestConfig()
 	measurement := &LoudnormMeasurement{
 		InputI:       -20.0,
 		InputTP:      -8.0,
@@ -680,7 +684,7 @@ func TestFullbenchPass4LimiterVariantOmitsInactivePrefix(t *testing.T) {
 	}
 	loudnorm := &fullbenchLoudnormSetup{
 		Measurement:     measurement,
-		EffectiveConfig: effectiveFromFilterChainConfig(config),
+		EffectiveConfig: config,
 	}
 
 	for _, variant := range fullbenchPass4AblationVariants() {
@@ -746,7 +750,7 @@ func TestRunFullbenchFilterSpecSyntheticSmoke(t *testing.T) {
 	})
 	defer cleanupTestAudio(t, inputPath)
 
-	config := newTestConfig()
+	config := newFullbenchEffectiveTestConfig()
 	config.AnalysisEnabled = true
 	config.ResampleEnabled = true
 	config.FilterOrder = Pass2FilterOrder
@@ -794,9 +798,8 @@ func BenchmarkPass2FilterAblations(b *testing.B) {
 	for _, variant := range fullbenchPass2AblationVariants() {
 		b.Run(variant.Name, func(b *testing.B) {
 			config := *adapted.Config
-			config.Pass = PassProcessing
-			config.FilterOrder = Pass2FilterOrder
-			spec := variant.BuildSpec(effectiveFromFilterChainConfig(&config))
+			config.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
+			spec := variant.BuildSpec(&config)
 			if spec == "" {
 				b.Fatal("Pass 2 ablation filter spec must not be empty")
 			}
@@ -915,11 +918,10 @@ func setupFullbenchAdaptedConfig(tb testing.TB, inputPath string) *fullbenchAdap
 		tb.Fatal("fullbench adapted setup returned incomplete analysis result")
 	}
 
-	analysisResult.Config.Pass = PassProcessing
-	analysisResult.Config.FilterOrder = Pass2FilterOrder
+	analysisResult.Config.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
 
 	return &fullbenchAdaptedSetup{
-		Config:       &analysisResult.Config.FilterChainConfig,
+		Config:       analysisResult.Config,
 		Measurements: analysisResult.Measurements,
 	}
 }
@@ -932,8 +934,7 @@ func setupFullbenchPass2Seed(tb testing.TB, inputPath string, adapted *fullbench
 	}
 
 	config := *adapted.Config
-	config.Pass = PassProcessing
-	config.FilterOrder = Pass2FilterOrder
+	config.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
 	config.AnalysisEnabled = true
 
 	outputPath := filepath.Join(tb.TempDir(), "fullbench-pass2-seed.flac")
@@ -981,7 +982,7 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 	}
 
 	filterPrefix := buildPreLimiterPrefix(preGainDB, limiterCeiling, limiterNeeded)
-	measurement, err := measureWithLoudnorm(seed.OutputPath, effectiveFromFilterChainConfig(&config), filterPrefix, nil)
+	measurement, err := measureWithLoudnorm(seed.OutputPath, &config, filterPrefix, nil)
 	if err != nil {
 		tb.Fatalf("failed to prepare fullbench loudnorm measurement: %v", err)
 	}
@@ -1004,7 +1005,7 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 
 	return &fullbenchLoudnormSetup{
 		Measurement:       measurement,
-		EffectiveConfig:   effectiveFromFilterChainConfig(&effectiveConfig),
+		EffectiveConfig:   &effectiveConfig,
 		Pass3FilterPrefix: filterPrefix,
 		PreGainDB:         preGainDB,
 		LimiterCeiling:    limiterCeiling,
@@ -1045,12 +1046,7 @@ func TestFullbenchSetupHelpersSyntheticSmoke(t *testing.T) {
 	if adapted.Measurements == nil {
 		t.Fatal("expected Pass 1 measurements")
 	}
-	if adapted.Config.Measurements != adapted.Measurements {
-		t.Fatal("adapted config does not reference Pass 1 measurements")
-	}
-	if adapted.Config.Pass != PassProcessing {
-		t.Fatalf("adapted config pass mismatch: got %d, want %d", adapted.Config.Pass, PassProcessing)
-	}
+	assertNoStaleEffectiveConfigFields(t)
 
 	pass2Seed := setupFullbenchPass2Seed(t, inputPath, adapted)
 	if pass2Seed.OutputMeasurements == nil {

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -254,7 +254,6 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 			BuildSpec: func(config *EffectiveFilterConfig) string {
 				ablated := *config
 				ablated.AnalysisEnabled = false
-				ablated.OutputAnalysisEnabled = false
 				return ablated.BuildFilterSpec()
 			},
 		},
@@ -396,7 +395,7 @@ func buildFullbenchPass4ResampleFilter(config *EffectiveFilterConfig) string {
 func buildFullbenchProductionPass4SpecWithoutAdeclick(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	pass4Config := *config
 	pass4Config.AdeclickEnabled = false
-	return buildLoudnormFilterSpec(&pass4Config.FilterChainConfig, measurement, 0, 0, false)
+	return buildLoudnormFilterSpec(&pass4Config, measurement, 0, 0, false)
 }
 
 func extractFullbenchFilterClause(spec, prefix string) string {
@@ -421,7 +420,6 @@ func TestFullbenchPass2AblationSpecs(t *testing.T) {
 	config.DeessEnabled = true
 	config.DeessIntensity = 0.5
 	config.AnalysisEnabled = true
-	config.OutputAnalysisEnabled = true
 	config.ResampleEnabled = true
 	config.FilterOrder = Pass2FilterOrder
 
@@ -552,7 +550,7 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 	productionConfig := *config
 	productionConfig.AdeclickEnabled = false
 	productionClause := extractFullbenchFilterClause(
-		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false),
+		buildLoudnormFilterSpec(effectiveFromFilterChainConfig(&productionConfig), measurement, 0, 0, false),
 		"loudnorm=",
 	)
 	benchmarkClause := buildFullbenchLoudnormClause(effectiveFromFilterChainConfig(config), measurement)
@@ -919,10 +917,9 @@ func setupFullbenchAdaptedConfig(tb testing.TB, inputPath string) *fullbenchAdap
 
 	analysisResult.Config.Pass = PassProcessing
 	analysisResult.Config.FilterOrder = Pass2FilterOrder
-	analysisResult.Config.OutputAnalysisEnabled = true
 
 	return &fullbenchAdaptedSetup{
-		Config:       analysisResult.Config,
+		Config:       &analysisResult.Config.FilterChainConfig,
 		Measurements: analysisResult.Measurements,
 	}
 }
@@ -938,7 +935,6 @@ func setupFullbenchPass2Seed(tb testing.TB, inputPath string, adapted *fullbench
 	config.Pass = PassProcessing
 	config.FilterOrder = Pass2FilterOrder
 	config.AnalysisEnabled = true
-	config.OutputAnalysisEnabled = true
 
 	outputPath := filepath.Join(tb.TempDir(), "fullbench-pass2-seed.flac")
 	inputMetadata, outputMeasurements := runFullbenchFilterSpec(
@@ -985,7 +981,7 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 	}
 
 	filterPrefix := buildPreLimiterPrefix(preGainDB, limiterCeiling, limiterNeeded)
-	measurement, err := measureWithLoudnorm(seed.OutputPath, &config, filterPrefix, nil)
+	measurement, err := measureWithLoudnorm(seed.OutputPath, effectiveFromFilterChainConfig(&config), filterPrefix, nil)
 	if err != nil {
 		tb.Fatalf("failed to prepare fullbench loudnorm measurement: %v", err)
 	}

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -4,7 +4,6 @@ package processor
 import (
 	"fmt"
 	"math"
-	"reflect"
 	"strings"
 	"time"
 
@@ -288,142 +287,9 @@ const (
 	PassNormalising PassNumber = 4
 )
 
-// FilterChainConfig holds configuration for the audio processing filter chain
-type FilterChainConfig struct {
-	// Pass indicates which processing pass is being executed (1 = analysis, 2 = processing)
-	// Used by filters that need pass-specific behaviour
-	Pass PassNumber
-
-	// Downmix (pan) - stereo to mono conversion
-	// Applied first to ensure all downstream filters work with mono
-	DownmixEnabled bool
-
-	// Analysis (ebur128 + astats + aspectralstats) - audio measurement collection
-	// Captures loudness, dynamics, spectral characteristics
-	AnalysisEnabled bool
-
-	// SilenceScanDuration caps how much of the input is examined when collecting
-	// silence candidates for room-tone election. Zero is the sentinel meaning
-	// "scan whole file" (current behaviour); a positive value restricts silence
-	// candidate collection to intervals before this input time. Loudness, true
-	// peak, LRA, spectral statistics, and speech detection always remain
-	// whole-file regardless of this cap.
-	SilenceScanDuration time.Duration
-
-	// Resample (aformat) - output format standardisation
-	// Pass 2 only - ensures consistent output format
-	ResampleEnabled    bool
-	ResampleSampleRate int    // Output sample rate (default: 44100)
-	ResampleFormat     string // Output sample format (default: s16)
-	ResampleFrameSize  int    // Samples per frame (default: 4096)
-
-	// DS201-Inspired High-Pass Filter (highpass) - removes subsonic rumble
-	// Part of the DS201 side-chain composite: removes rumble before gate detection
-	DS201HPEnabled   bool    // Enable DS201 high-pass filter
-	DS201HPFreq      float64 // Hz, cutoff frequency (removes frequencies below this)
-	DS201HPPoles     int     // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
-	DS201HPWidth     float64 // Q factor: 0.707=Butterworth (default), lower=gentler rolloff
-	DS201HPMix       float64 // Wet/dry mix (0-1, 1=full filter, 0.7=subtle for warm voices)
-	DS201HPTransform string  // Filter transform: "tdii" (best accuracy), "zdf", etc.
-
-	// DS201-Inspired Low-Pass Filter (lowpass) - removes ultrasonic noise
-	// Part of the DS201 side-chain composite: prevents HF noise from triggering gate
-	// Enabled adaptively based on content type and HF noise indicators
-	DS201LPEnabled   bool    // Enable DS201 low-pass filter
-	DS201LPFreq      float64 // Hz, cutoff frequency (removes frequencies above this)
-	DS201LPPoles     int     // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
-	DS201LPWidth     float64 // Q factor: 0.707=Butterworth (default)
-	DS201LPMix       float64 // Wet/dry mix (0-1, 1=full filter)
-	DS201LPTransform string  // Filter transform: "tdii" (best accuracy), "zdf", etc.
-
-	// NoiseRemove - anlmdn + compand noise reduction
-	// Non-Local Means denoiser (anlmdn) with a compand for residual suppression.
-	// Production runs anlmdn at the source sample rate with r=0.0020 and m=3,
-	// validated by the matrix spike at .bench/anlmdn-matrix-spike.
-	NoiseRemoveEnabled          bool    // Enable anlmdn+compand noise reduction
-	NoiseRemoveCompandEnabled   bool    // Enable compand residual suppression (false = anlmdn-only)
-	NoiseRemoveStrength         float64 // anlmdn strength (0.00001 = minimum, kept constant)
-	NoiseRemovePatchSec         float64 // Patch size in seconds (context window for similarity)
-	NoiseRemoveResearchSec      float64 // Research radius in seconds (search window for matching)
-	NoiseRemoveSmooth           float64 // Smoothing factor for weights (1-1000)
-	NoiseRemoveCompandThreshold float64 // Expansion threshold (dB) - set to measured noise floor
-	NoiseRemoveCompandExpansion float64 // Expansion depth (dB) - gap between input floor and target floor
-	NoiseRemoveCompandAttack    float64 // Attack time (seconds) - fixed at 5ms for speech
-	NoiseRemoveCompandDecay     float64 // Decay time (seconds) - fixed at 100ms for speech
-	NoiseRemoveCompandKnee      float64 // Soft knee (dB) - fixed at 6dB for transparency
-
-	// DS201-Inspired Gate (agate) - Drawmer DS201 style soft expander
-	// Uses gentle ratio (2:1-4:1) rather than DS201's hard gate for natural speech transitions.
-	// Minimum 10ms attack prevents click artifacts from rapid gain changes.
-	DS201GateEnabled   bool    // Enable DS201-style gate
-	DS201GateThreshold float64 // Activation threshold (0.0-1.0, linear)
-	DS201GateRatio     float64 // Reduction ratio - soft expander (2:1-4:1), not hard gate
-	DS201GateAttack    float64 // Attack time (ms) - minimum 10ms to avoid click artifacts
-	DS201GateRelease   float64 // Release time (ms) - includes +50ms to compensate for no Hold param
-	DS201GateRange     float64 // Level of gain reduction below threshold (0.0-1.0)
-	DS201GateKnee      float64 // Knee curve softness (1.0-8.0) - soft knee for natural transitions
-	DS201GateMakeup    float64 // Makeup gain after gating (1.0-64.0)
-	DS201GateDetection string  // Level detection mode: "rms" (default, smoother) or "peak" (tighter)
-
-	// LA-2A Compressor - Teletronix LA-2A style optical compression
-	// The LA-2A is legendary for its gentle, program-dependent character from the T4 optical cell.
-	LA2AEnabled   bool    // Enable LA-2A compressor
-	LA2AThreshold float64 // dB, compression threshold (stored in dB, converted to linear)
-	LA2ARatio     float64 // Compression ratio (1.0-20.0)
-	LA2AAttack    float64 // Attack time (ms) - LA-2A has fixed ~10ms attack
-	LA2ARelease   float64 // Release time (ms) - LA-2A has program-dependent two-stage release
-	LA2AMakeup    float64 // dB, makeup gain (stored in dB, converted to linear)
-	LA2AKnee      float64 // Knee curve softness (1.0-8.0) - T4 cell provides inherent soft knee
-	LA2AMix       float64 // Wet/dry mix (0.0-1.0, 1.0 = 100% compressed)
-
-	// De-esser (deesser) - removes harsh sibilance automatically
-	DeessEnabled   bool    // Enable deesser filter
-	DeessIntensity float64 // 0.0-1.0, intensity for triggering de-essing (0=off, 1=max)
-	DeessAmount    float64 // 0.0-1.0, amount of ducking on treble (how much to reduce)
-	DeessFreq      float64 // 0.0-1.0, how much original frequency content to keep
-
-	// Target values (for reference only)
-	TargetI   float64 // LUFS target reference (podcast standard: -16)
-	TargetTP  float64 // dBTP, true peak ceiling reference
-	TargetLRA float64 // LU, loudness range reference
-
-	// Filter chain order - controls the sequence of filters in the processing chain
-	// Use Pass2FilterOrder or customise for experimentation
-	FilterOrder []FilterID
-
-	// Pass 1 measurements (nil for first pass)
-	Measurements *AudioMeasurements
-
-	// Temporary compatibility for report consumers until diagnostics are routed
-	// explicitly through ProcessingResult.
-	AdaptiveDiagnostics
-
-	// Adeclick - Click/pop repair filter (Pass 4)
-	// Detects and repairs waveform discontinuities through interpolation
-	// Applied after loudnorm to catch clicks from limiter and gain changes
-	AdeclickEnabled   bool    // Enable adeclick filter (default: true in Pass 4)
-	AdeclickThreshold float64 // Detection sensitivity (0.1-8.0, lower=more sensitive)
-	AdeclickWindow    float64 // Analysis window in ms (10-100)
-	AdeclickOverlap   float64 // Window overlap percentage (50-95)
-	AdeclickMethod    string  // Interpolation method ("" = default "a" = average; "s" = spline)
-
-	// Loudnorm (Pass 3) - EBU R128 dynamic loudness normalisation
-	// Replaces simple volume gain + limiting with integrated dynamic normalisation
-	// Uses two-pass mode with measurements from Pass 2 for optimal transparency
-	LoudnormEnabled   bool    // Enable loudnorm in Pass 3 (default: true)
-	LoudnormTargetI   float64 // Target integrated loudness (LUFS), default: -16.0
-	LoudnormTargetTP  float64 // Target true peak (dBTP), default: -1.5
-	LoudnormTargetLRA float64 // Target loudness range (LU), default: 11.0
-	LoudnormDualMono  bool    // Treat mono as dual-mono (CRITICAL for mono files)
-	LoudnormLinear    bool    // Prefer linear mode (falls back to dynamic if needed)
-}
-
-// EffectiveFilterConfig is the per-file filter-builder input. During the
-// compatibility phase it embeds FilterChainConfig, but assembly helpers populate
-// only caller defaults and adaptive filter values.
-type EffectiveFilterConfig struct {
-	FilterChainConfig
-}
+// EffectiveFilterConfig is the per-file filter-builder input.
+// It excludes diagnostics and pass execution state.
+type EffectiveFilterConfig filterConfigDefaults
 
 // DefaultFilterConfig returns the scientifically-tuned caller-owned defaults for
 // podcast spoken word audio processing.
@@ -530,29 +396,12 @@ func DefaultFilterConfig() *BaseFilterConfig {
 	}}
 }
 
-func DefaultEffectiveFilterConfig() *FilterChainConfig {
-	return derivePerFileConfig(DefaultFilterConfig())
-}
-
-func derivePerFileConfig(base *BaseFilterConfig) *FilterChainConfig {
-	effective := deriveEffectiveFilterConfig(base)
-	if effective == nil {
-		return nil
-	}
-	return &effective.FilterChainConfig
+func DefaultEffectiveFilterConfig() *EffectiveFilterConfig {
+	return deriveEffectiveFilterConfig(DefaultFilterConfig())
 }
 
 func deriveEffectiveFilterConfig(base *BaseFilterConfig) *EffectiveFilterConfig {
 	return assembleEffectiveFilterConfig(base, deriveAdaptiveFilterResult(base))
-}
-
-func effectiveFromFilterChainConfig(config *FilterChainConfig) *EffectiveFilterConfig {
-	if config == nil {
-		return nil
-	}
-	effective := &EffectiveFilterConfig{FilterChainConfig: *config}
-	effective.FilterOrder = cloneFilterOrder(config.FilterOrder)
-	return effective
 }
 
 func deriveAdaptiveFilterResult(base *BaseFilterConfig) *AdaptiveFilterResult {
@@ -570,9 +419,9 @@ func assembleEffectiveFilterConfig(base *BaseFilterConfig, adaptive *AdaptiveFil
 	}
 
 	effective := &EffectiveFilterConfig{}
-	copyFilterDefaults(&effective.FilterChainConfig, &base.filterConfigDefaults)
+	copyFilterDefaults(effective, &base.filterConfigDefaults)
 	if adaptive != nil {
-		copyFilterDefaults(&effective.FilterChainConfig, &adaptive.filterConfigDefaults)
+		copyFilterDefaults(effective, &adaptive.filterConfigDefaults)
 	}
 	effective.FilterOrder = cloneFilterOrder(base.FilterOrder)
 
@@ -595,18 +444,8 @@ func cloneFilterOrder(order []FilterID) []FilterID {
 	return append([]FilterID(nil), order...)
 }
 
-func copyFilterDefaults(dst *FilterChainConfig, src *filterConfigDefaults) {
-	dstValue := reflect.ValueOf(dst).Elem()
-	srcValue := reflect.ValueOf(src).Elem()
-	srcType := srcValue.Type()
-
-	for i := 0; i < srcValue.NumField(); i++ {
-		name := srcType.Field(i).Name
-		field := dstValue.FieldByName(name)
-		if field.IsValid() && field.CanSet() {
-			field.Set(srcValue.Field(i))
-		}
-	}
+func copyFilterDefaults(dst *EffectiveFilterConfig, src *filterConfigDefaults) {
+	*dst = EffectiveFilterConfig(cloneFilterDefaults(src))
 }
 
 // DbToLinear converts decibel value to linear amplitude.
@@ -976,54 +815,6 @@ func (cfg *EffectiveFilterConfig) BuildFilterSpec() string {
 	}
 
 	return strings.Join(filters, ",")
-}
-
-func (cfg *FilterChainConfig) buildDownmixFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildDownmixFilter()
-}
-
-func (cfg *FilterChainConfig) buildAnalysisFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildAnalysisFilter()
-}
-
-func (cfg *FilterChainConfig) buildResampleFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildResampleFilter()
-}
-
-func (cfg *FilterChainConfig) buildRequiredOutputFormatFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildRequiredOutputFormatFilter()
-}
-
-func (cfg *FilterChainConfig) buildDS201HighpassFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildDS201HighpassFilter()
-}
-
-func (cfg *FilterChainConfig) buildDS201LowPassFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildDS201LowPassFilter()
-}
-
-func (cfg *FilterChainConfig) buildNoiseRemoveFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildNoiseRemoveFilter()
-}
-
-func (cfg *FilterChainConfig) buildDS201GateFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildDS201GateFilter()
-}
-
-func (cfg *FilterChainConfig) buildLA2ACompressorFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildLA2ACompressorFilter()
-}
-
-func (cfg *FilterChainConfig) buildDeesserFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildDeesserFilter()
-}
-
-func (cfg *FilterChainConfig) buildAdeclickFilter() string {
-	return effectiveFromFilterChainConfig(cfg).buildAdeclickFilter()
-}
-
-func (cfg *FilterChainConfig) BuildFilterSpec() string {
-	return effectiveFromFilterChainConfig(cfg).BuildFilterSpec()
 }
 
 func (cfg *BaseFilterConfig) BuildFilterSpec() string {

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -235,6 +235,23 @@ type AdaptiveFilterResult struct {
 
 // AdaptiveDiagnostics holds report-only adaptation explanations.
 type AdaptiveDiagnostics struct {
+	DS201LPContentType  ContentType
+	DS201LPReason       string
+	DS201LPRolloffRatio float64
+
+	DS201GateAggression          float64
+	DS201GateDynamicRange        float64
+	DS201GateQuietSpeechEstimate float64
+	DS201GateSpeechSeparation    float64
+	DS201GateSpeechHeadroom      float64
+	DS201GateThresholdUnclamped  float64
+	DS201GateClampReason         string
+	DS201GateGentleMode          bool
+
+	LA2AHighCrestActive      bool
+	LA2AHighCrestDeficit     float64
+	LA2AHighCrestSeverity    float64
+	LA2AHighCrestProjectedTP float64
 }
 
 // ProcessingFilterContext holds pass execution state outside caller-owned defaults.
@@ -244,22 +261,22 @@ type ProcessingFilterContext struct {
 	OutputAnalysisEnabled bool
 }
 
-// filterBuilderFunc is a function that builds a filter spec from config.
+// filterBuilderFunc is a function that builds a filter spec from effective config.
 // Returns the FFmpeg filter specification string, or empty string if disabled.
-type filterBuilderFunc func(*FilterChainConfig) string
+type filterBuilderFunc func(*EffectiveFilterConfig) string
 
 // filterBuilders maps FilterID to its builder function.
 // This registry centralises filter spec generation and avoids per-call map allocation.
 var filterBuilders = map[FilterID]filterBuilderFunc{
-	FilterDownmix:        (*FilterChainConfig).buildDownmixFilter,
-	FilterAnalysis:       (*FilterChainConfig).buildAnalysisFilter,
-	FilterResample:       (*FilterChainConfig).buildResampleFilter,
-	FilterDS201HighPass:  (*FilterChainConfig).buildDS201HighpassFilter,
-	FilterDS201LowPass:   (*FilterChainConfig).buildDS201LowPassFilter,
-	FilterNoiseRemove:    (*FilterChainConfig).buildNoiseRemoveFilter,
-	FilterDS201Gate:      (*FilterChainConfig).buildDS201GateFilter,
-	FilterLA2ACompressor: (*FilterChainConfig).buildLA2ACompressorFilter,
-	FilterDeesser:        (*FilterChainConfig).buildDeesserFilter,
+	FilterDownmix:        (*EffectiveFilterConfig).buildDownmixFilter,
+	FilterAnalysis:       (*EffectiveFilterConfig).buildAnalysisFilter,
+	FilterResample:       (*EffectiveFilterConfig).buildResampleFilter,
+	FilterDS201HighPass:  (*EffectiveFilterConfig).buildDS201HighpassFilter,
+	FilterDS201LowPass:   (*EffectiveFilterConfig).buildDS201LowPassFilter,
+	FilterNoiseRemove:    (*EffectiveFilterConfig).buildNoiseRemoveFilter,
+	FilterDS201Gate:      (*EffectiveFilterConfig).buildDS201GateFilter,
+	FilterLA2ACompressor: (*EffectiveFilterConfig).buildLA2ACompressorFilter,
+	FilterDeesser:        (*EffectiveFilterConfig).buildDeesserFilter,
 }
 
 // PassNumber identifies which processing pass is being executed.
@@ -313,15 +330,12 @@ type FilterChainConfig struct {
 	// DS201-Inspired Low-Pass Filter (lowpass) - removes ultrasonic noise
 	// Part of the DS201 side-chain composite: prevents HF noise from triggering gate
 	// Enabled adaptively based on content type and HF noise indicators
-	DS201LPEnabled      bool        // Enable DS201 low-pass filter
-	DS201LPFreq         float64     // Hz, cutoff frequency (removes frequencies above this)
-	DS201LPPoles        int         // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
-	DS201LPWidth        float64     // Q factor: 0.707=Butterworth (default)
-	DS201LPMix          float64     // Wet/dry mix (0-1, 1=full filter)
-	DS201LPTransform    string      // Filter transform: "tdii" (best accuracy), "zdf", etc.
-	DS201LPContentType  ContentType // Detected content type (speech/music/mixed)
-	DS201LPReason       string      // Why enabled/disabled (for logging)
-	DS201LPRolloffRatio float64     // Actual rolloff/centroid ratio (for logging)
+	DS201LPEnabled   bool    // Enable DS201 low-pass filter
+	DS201LPFreq      float64 // Hz, cutoff frequency (removes frequencies above this)
+	DS201LPPoles     int     // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
+	DS201LPWidth     float64 // Q factor: 0.707=Butterworth (default)
+	DS201LPMix       float64 // Wet/dry mix (0-1, 1=full filter)
+	DS201LPTransform string  // Filter transform: "tdii" (best accuracy), "zdf", etc.
 
 	// NoiseRemove - anlmdn + compand noise reduction
 	// Non-Local Means denoiser (anlmdn) with a compand for residual suppression.
@@ -342,25 +356,15 @@ type FilterChainConfig struct {
 	// DS201-Inspired Gate (agate) - Drawmer DS201 style soft expander
 	// Uses gentle ratio (2:1-4:1) rather than DS201's hard gate for natural speech transitions.
 	// Minimum 10ms attack prevents click artifacts from rapid gain changes.
-	DS201GateEnabled    bool    // Enable DS201-style gate
-	DS201GateThreshold  float64 // Activation threshold (0.0-1.0, linear)
-	DS201GateRatio      float64 // Reduction ratio - soft expander (2:1-4:1), not hard gate
-	DS201GateAttack     float64 // Attack time (ms) - minimum 10ms to avoid click artifacts
-	DS201GateRelease    float64 // Release time (ms) - includes +50ms to compensate for no Hold param
-	DS201GateRange      float64 // Level of gain reduction below threshold (0.0-1.0)
-	DS201GateKnee       float64 // Knee curve softness (1.0-8.0) - soft knee for natural transitions
-	DS201GateMakeup     float64 // Makeup gain after gating (1.0-64.0)
-	DS201GateDetection  string  // Level detection mode: "rms" (default, smoother) or "peak" (tighter)
-	DS201GateGentleMode bool    // Gentle mode active - for extreme LUFS gap + low LRA recordings
-
-	// Diagnostic: aggression-based threshold calculation
-	DS201GateAggression          float64 // Final aggression factor (0.25-0.60)
-	DS201GateDynamicRange        float64 // Speech crest factor used (dB)
-	DS201GateQuietSpeechEstimate float64 // speechRMS - speechCrest (dB)
-	DS201GateSpeechSeparation    float64 // Noise-to-speech gap used for aggression calc (dB)
-	DS201GateSpeechHeadroom      float64 // Gap between quiet speech and threshold (dB)
-	DS201GateThresholdUnclamped  float64 // Threshold before safety clamps (dB)
-	DS201GateClampReason         string  // "none", "noise_floor", "speech_rms"
+	DS201GateEnabled   bool    // Enable DS201-style gate
+	DS201GateThreshold float64 // Activation threshold (0.0-1.0, linear)
+	DS201GateRatio     float64 // Reduction ratio - soft expander (2:1-4:1), not hard gate
+	DS201GateAttack    float64 // Attack time (ms) - minimum 10ms to avoid click artifacts
+	DS201GateRelease   float64 // Release time (ms) - includes +50ms to compensate for no Hold param
+	DS201GateRange     float64 // Level of gain reduction below threshold (0.0-1.0)
+	DS201GateKnee      float64 // Knee curve softness (1.0-8.0) - soft knee for natural transitions
+	DS201GateMakeup    float64 // Makeup gain after gating (1.0-64.0)
+	DS201GateDetection string  // Level detection mode: "rms" (default, smoother) or "peak" (tighter)
 
 	// LA-2A Compressor - Teletronix LA-2A style optical compression
 	// The LA-2A is legendary for its gentle, program-dependent character from the T4 optical cell.
@@ -372,12 +376,6 @@ type FilterChainConfig struct {
 	LA2AMakeup    float64 // dB, makeup gain (stored in dB, converted to linear)
 	LA2AKnee      float64 // Knee curve softness (1.0-8.0) - T4 cell provides inherent soft knee
 	LA2AMix       float64 // Wet/dry mix (0.0-1.0, 1.0 = 100% compressed)
-
-	// Diagnostic: high-crest override (deficit-based detection)
-	LA2AHighCrestActive      bool    // Whether high-crest overrides were applied (deficit > 0)
-	LA2AHighCrestDeficit     float64 // Predicted ceiling deficit in dB (0.0 when inactive)
-	LA2AHighCrestSeverity    float64 // 0.0-1.0 scaling factor (clamp(deficit / 6.0, 0.0, 1.0))
-	LA2AHighCrestProjectedTP float64 // Projected true peak before compression (dBTP)
 
 	// De-esser (deesser) - removes harsh sibilance automatically
 	DeessEnabled   bool    // Enable deesser filter
@@ -400,6 +398,10 @@ type FilterChainConfig struct {
 	// Output Analysis - enables astats/ebur128/aspectralstats at end of Pass 2 filter chain
 	// When enabled, measurements are extracted from processed audio for comparison with Pass 1
 	OutputAnalysisEnabled bool
+
+	// Temporary compatibility for report consumers until diagnostics are routed
+	// explicitly through ProcessingResult.
+	AdaptiveDiagnostics
 
 	// Adeclick - Click/pop repair filter (Pass 4)
 	// Detects and repairs waveform discontinuities through interpolation
@@ -549,6 +551,15 @@ func deriveEffectiveFilterConfig(base *BaseFilterConfig) *EffectiveFilterConfig 
 	return assembleEffectiveFilterConfig(base, deriveAdaptiveFilterResult(base))
 }
 
+func effectiveFromFilterChainConfig(config *FilterChainConfig) *EffectiveFilterConfig {
+	if config == nil {
+		return nil
+	}
+	effective := &EffectiveFilterConfig{FilterChainConfig: *config}
+	effective.FilterOrder = cloneFilterOrder(config.FilterOrder)
+	return effective
+}
+
 func deriveAdaptiveFilterResult(base *BaseFilterConfig) *AdaptiveFilterResult {
 	if base == nil {
 		return nil
@@ -621,7 +632,7 @@ func LinearToDb(linear float64) float64 {
 // buildDownmixFilter builds the stereo-to-mono downmix filter specification.
 // Uses FFmpeg's built-in channel layout conversion which handles various input
 // configurations (stereo, mono, single-channel recordings) correctly.
-func (cfg *FilterChainConfig) buildDownmixFilter() string {
+func (cfg *EffectiveFilterConfig) buildDownmixFilter() string {
 	if !cfg.DownmixEnabled {
 		return ""
 	}
@@ -644,7 +655,7 @@ func (cfg *FilterChainConfig) buildDownmixFilter() string {
 // it always processes/normalizes audio. Loudnorm measurement for Pass 3 is done
 // separately via measureWithLoudnorm() which reads the processed file without
 // encoding output.
-func (cfg *FilterChainConfig) buildAnalysisFilter() string {
+func (cfg *EffectiveFilterConfig) buildAnalysisFilter() string {
 	if !cfg.AnalysisEnabled {
 		return ""
 	}
@@ -691,7 +702,7 @@ func (cfg *FilterChainConfig) buildAnalysisFilter() string {
 // buildResampleFilter builds the output format standardisation filter.
 // Ensures consistent output: 44.1kHz, 16-bit, mono, fixed frame size.
 // Pass 2 only - applied after all processing and analysis.
-func (cfg *FilterChainConfig) buildResampleFilter() string {
+func (cfg *EffectiveFilterConfig) buildResampleFilter() string {
 	if !cfg.ResampleEnabled {
 		return ""
 	}
@@ -701,7 +712,7 @@ func (cfg *FilterChainConfig) buildResampleFilter() string {
 // buildRequiredOutputFormatFilter builds the mandatory output format filter.
 // Use this when a pass must restore encoder-compatible audio regardless of
 // ResampleEnabled.
-func (cfg *FilterChainConfig) buildRequiredOutputFormatFilter() string {
+func (cfg *EffectiveFilterConfig) buildRequiredOutputFormatFilter() string {
 	return fmt.Sprintf("aformat=sample_rates=%d:channel_layouts=mono:sample_fmts=%s,asetnsamples=n=%d",
 		cfg.ResampleSampleRate, cfg.ResampleFormat, cfg.ResampleFrameSize)
 }
@@ -719,7 +730,7 @@ func (cfg *FilterChainConfig) buildRequiredOutputFormatFilter() string {
 // - width: Q factor (0.707=Butterworth, lower=gentler for warm voices)
 // - transform: filter algorithm (tdii=best floating-point accuracy)
 // - mix: wet/dry blend (1.0=full filter, 0.7=subtle for warm voices)
-func (cfg *FilterChainConfig) buildDS201HighpassFilter() string {
+func (cfg *EffectiveFilterConfig) buildDS201HighpassFilter() string {
 	if !cfg.DS201HPEnabled {
 		return ""
 	}
@@ -765,7 +776,7 @@ func (cfg *FilterChainConfig) buildDS201HighpassFilter() string {
 // - mix: wet/dry blend (1.0=full filter)
 //
 // Returns empty string if DS201LPEnabled is false.
-func (cfg *FilterChainConfig) buildDS201LowPassFilter() string {
+func (cfg *EffectiveFilterConfig) buildDS201LowPassFilter() string {
 	if !cfg.DS201LPEnabled {
 		return ""
 	}
@@ -813,7 +824,7 @@ func (cfg *FilterChainConfig) buildDS201LowPassFilter() string {
 // - attack: 5ms (fixed, empirically validated for speech)
 // - decay: 100ms (fixed, empirically validated for speech)
 // - soft-knee: 6dB (fixed, transparent)
-func (cfg *FilterChainConfig) buildNoiseRemoveFilter() string {
+func (cfg *EffectiveFilterConfig) buildNoiseRemoveFilter() string {
 	if !cfg.NoiseRemoveEnabled {
 		return ""
 	}
@@ -836,7 +847,7 @@ func (cfg *FilterChainConfig) buildNoiseRemoveFilter() string {
 // buildNoiseRemoveCompandFilter builds the compand filter for residual noise suppression.
 // Compand uses FLAT reduction curve with uniform expansion below threshold.
 // Parameters are derived from Pass 1 measurements in tuneNoiseRemove (adaptive.go).
-func (cfg *FilterChainConfig) buildNoiseRemoveCompandFilter() string {
+func (cfg *EffectiveFilterConfig) buildNoiseRemoveCompandFilter() string {
 	// Build FLAT reduction curve
 	// Every point below threshold gets the same expansion (reduction)
 	// Points: -90 → (-90 - exp), -75 → (-75 - exp), threshold → threshold, -30 → -30, 0 → 0
@@ -862,7 +873,7 @@ func (cfg *FilterChainConfig) buildNoiseRemoveCompandFilter() string {
 // Uses soft expander approach (2:1-4:1 ratio) rather than hard gate for natural speech.
 // Minimum 10ms attack prevents click artifacts from rapid gain changes.
 // Detection mode is adaptive: RMS for tonal bleed, peak for clean recordings.
-func (cfg *FilterChainConfig) buildDS201GateFilter() string {
+func (cfg *EffectiveFilterConfig) buildDS201GateFilter() string {
 	if !cfg.DS201GateEnabled {
 		return ""
 	}
@@ -889,7 +900,7 @@ func (cfg *FilterChainConfig) buildDS201GateFilter() string {
 // Uses FFmpeg's acompressor with settings tuned to emulate the Teletronix LA-2A
 // optical compressor's gentle, program-dependent character.
 // Converts dB values to linear for FFmpeg's format.
-func (cfg *FilterChainConfig) buildLA2ACompressorFilter() string {
+func (cfg *EffectiveFilterConfig) buildLA2ACompressorFilter() string {
 	if !cfg.LA2AEnabled {
 		return ""
 	}
@@ -909,7 +920,7 @@ func (cfg *FilterChainConfig) buildLA2ACompressorFilter() string {
 // buildDeesserFilter builds the deesser filter specification.
 // Automatically detects and reduces harsh sibilance ("s" sounds).
 // Returns empty string if disabled or intensity is 0.
-func (cfg *FilterChainConfig) buildDeesserFilter() string {
+func (cfg *EffectiveFilterConfig) buildDeesserFilter() string {
 	if !cfg.DeessEnabled || cfg.DeessIntensity <= 0 {
 		return ""
 	}
@@ -929,7 +940,7 @@ func (cfg *FilterChainConfig) buildDeesserFilter() string {
 // - t (threshold): Detection sensitivity (0.1-8.0, lower=more sensitive)
 // - w (window): Analysis window in ms (10-100, default 55)
 // - o (overlap): Window overlap percentage (50-95, default 75)
-func (cfg *FilterChainConfig) buildAdeclickFilter() string {
+func (cfg *EffectiveFilterConfig) buildAdeclickFilter() string {
 	if !cfg.AdeclickEnabled {
 		return ""
 	}
@@ -949,7 +960,10 @@ func (cfg *FilterChainConfig) buildAdeclickFilter() string {
 // Filter order is determined by cfg.FilterOrder (or Pass2FilterOrder if empty).
 // Each filter checks its Enabled flag and returns empty string if disabled.
 // Uses the package-level filterBuilders registry for filter spec generation.
-func (cfg *FilterChainConfig) BuildFilterSpec() string {
+func (cfg *EffectiveFilterConfig) BuildFilterSpec() string {
+	if cfg == nil {
+		return ""
+	}
 	// Use configured order or default
 	order := cfg.FilterOrder
 	if len(order) == 0 {
@@ -969,15 +983,63 @@ func (cfg *FilterChainConfig) BuildFilterSpec() string {
 	return strings.Join(filters, ",")
 }
 
+func (cfg *FilterChainConfig) buildDownmixFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildDownmixFilter()
+}
+
+func (cfg *FilterChainConfig) buildAnalysisFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildAnalysisFilter()
+}
+
+func (cfg *FilterChainConfig) buildResampleFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildResampleFilter()
+}
+
+func (cfg *FilterChainConfig) buildRequiredOutputFormatFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildRequiredOutputFormatFilter()
+}
+
+func (cfg *FilterChainConfig) buildDS201HighpassFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildDS201HighpassFilter()
+}
+
+func (cfg *FilterChainConfig) buildDS201LowPassFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildDS201LowPassFilter()
+}
+
+func (cfg *FilterChainConfig) buildNoiseRemoveFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildNoiseRemoveFilter()
+}
+
+func (cfg *FilterChainConfig) buildDS201GateFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildDS201GateFilter()
+}
+
+func (cfg *FilterChainConfig) buildLA2ACompressorFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildLA2ACompressorFilter()
+}
+
+func (cfg *FilterChainConfig) buildDeesserFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildDeesserFilter()
+}
+
+func (cfg *FilterChainConfig) buildAdeclickFilter() string {
+	return effectiveFromFilterChainConfig(cfg).buildAdeclickFilter()
+}
+
+func (cfg *FilterChainConfig) BuildFilterSpec() string {
+	return effectiveFromFilterChainConfig(cfg).BuildFilterSpec()
+}
+
 func (cfg *BaseFilterConfig) BuildFilterSpec() string {
-	return derivePerFileConfig(cfg).BuildFilterSpec()
+	return deriveEffectiveFilterConfig(cfg).BuildFilterSpec()
 }
 
 // CreateProcessingFilterGraph creates an AVFilterGraph for complete audio processing
 // This is used in Pass 2 to apply the full filter chain.
 func CreateProcessingFilterGraph(
 	decCtx *ffmpeg.AVCodecContext,
-	config *FilterChainConfig,
+	config *EffectiveFilterConfig,
 ) (*ffmpeg.AVFilterGraph, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, error) {
 	return setupFilterGraph(decCtx, config.BuildFilterSpec())
 }

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -4,6 +4,7 @@ package processor
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"time"
 
@@ -102,6 +103,146 @@ const (
 	ds201HPDefaultMix       = 1.0
 	ds201HPDefaultTransform = "tdii"
 )
+
+type filterConfigDefaults struct {
+	// Downmix (pan) - stereo to mono conversion
+	// Applied first to ensure all downstream filters work with mono
+	DownmixEnabled bool
+
+	// Analysis (ebur128 + astats + aspectralstats) - audio measurement collection
+	// Captures loudness, dynamics, spectral characteristics
+	AnalysisEnabled bool
+
+	// SilenceScanDuration caps how much of the input is examined when collecting
+	// silence candidates for room-tone election. Zero is the sentinel meaning
+	// "scan whole file" (current behaviour); a positive value restricts silence
+	// candidate collection to intervals before this input time. Loudness, true
+	// peak, LRA, spectral statistics, and speech detection always remain
+	// whole-file regardless of this cap.
+	SilenceScanDuration time.Duration
+
+	// Resample (aformat) - output format standardisation
+	// Pass 2 only - ensures consistent output format
+	ResampleEnabled    bool
+	ResampleSampleRate int    // Output sample rate (default: 44100)
+	ResampleFormat     string // Output sample format (default: s16)
+	ResampleFrameSize  int    // Samples per frame (default: 4096)
+
+	// DS201-Inspired High-Pass Filter (highpass) - removes subsonic rumble
+	// Part of the DS201 side-chain composite: removes rumble before gate detection
+	DS201HPEnabled   bool    // Enable DS201 high-pass filter
+	DS201HPFreq      float64 // Hz, cutoff frequency (removes frequencies below this)
+	DS201HPPoles     int     // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
+	DS201HPWidth     float64 // Q factor: 0.707=Butterworth (default), lower=gentler rolloff
+	DS201HPMix       float64 // Wet/dry mix (0-1, 1=full filter, 0.7=subtle for warm voices)
+	DS201HPTransform string  // Filter transform: "tdii" (best accuracy), "zdf", etc.
+
+	// DS201-Inspired Low-Pass Filter (lowpass) - removes ultrasonic noise
+	// Part of the DS201 side-chain composite: prevents HF noise from triggering gate
+	// Enabled adaptively based on content type and HF noise indicators
+	DS201LPEnabled   bool    // Enable DS201 low-pass filter
+	DS201LPFreq      float64 // Hz, cutoff frequency (removes frequencies above this)
+	DS201LPPoles     int     // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
+	DS201LPWidth     float64 // Q factor: 0.707=Butterworth (default)
+	DS201LPMix       float64 // Wet/dry mix (0-1, 1=full filter)
+	DS201LPTransform string  // Filter transform: "tdii" (best accuracy), "zdf", etc.
+
+	// NoiseRemove - anlmdn + compand noise reduction
+	// Non-Local Means denoiser (anlmdn) with a compand for residual suppression.
+	// Production runs anlmdn at the source sample rate with r=0.0020 and m=3,
+	// validated by the matrix spike at .bench/anlmdn-matrix-spike.
+	NoiseRemoveEnabled          bool    // Enable anlmdn+compand noise reduction
+	NoiseRemoveCompandEnabled   bool    // Enable compand residual suppression (false = anlmdn-only)
+	NoiseRemoveStrength         float64 // anlmdn strength (0.00001 = minimum, kept constant)
+	NoiseRemovePatchSec         float64 // Patch size in seconds (context window for similarity)
+	NoiseRemoveResearchSec      float64 // Research radius in seconds (search window for matching)
+	NoiseRemoveSmooth           float64 // Smoothing factor for weights (1-1000)
+	NoiseRemoveCompandThreshold float64 // Expansion threshold (dB) - set to measured noise floor
+	NoiseRemoveCompandExpansion float64 // Expansion depth (dB) - gap between input floor and target floor
+	NoiseRemoveCompandAttack    float64 // Attack time (seconds) - fixed at 5ms for speech
+	NoiseRemoveCompandDecay     float64 // Decay time (seconds) - fixed at 100ms for speech
+	NoiseRemoveCompandKnee      float64 // Soft knee (dB) - fixed at 6dB for transparency
+
+	// DS201-Inspired Gate (agate) - Drawmer DS201 style soft expander
+	// Uses gentle ratio (2:1-4:1) rather than DS201's hard gate for natural speech transitions.
+	// Minimum 10ms attack prevents click artifacts from rapid gain changes.
+	DS201GateEnabled   bool    // Enable DS201-style gate
+	DS201GateThreshold float64 // Activation threshold (0.0-1.0, linear)
+	DS201GateRatio     float64 // Reduction ratio - soft expander (2:1-4:1), not hard gate
+	DS201GateAttack    float64 // Attack time (ms) - minimum 10ms to avoid click artifacts
+	DS201GateRelease   float64 // Release time (ms) - includes +50ms to compensate for no Hold param
+	DS201GateRange     float64 // Level of gain reduction below threshold (0.0-1.0)
+	DS201GateKnee      float64 // Knee curve softness (1.0-8.0) - soft knee for natural transitions
+	DS201GateMakeup    float64 // Makeup gain after gating (1.0-64.0)
+	DS201GateDetection string  // Level detection mode: "rms" (default, smoother) or "peak" (tighter)
+
+	// LA-2A Compressor - Teletronix LA-2A style optical compression
+	// The LA-2A is legendary for its gentle, program-dependent character from the T4 optical cell.
+	LA2AEnabled   bool    // Enable LA-2A compressor
+	LA2AThreshold float64 // dB, compression threshold (stored in dB, converted to linear)
+	LA2ARatio     float64 // Compression ratio (1.0-20.0)
+	LA2AAttack    float64 // Attack time (ms) - LA-2A has fixed ~10ms attack
+	LA2ARelease   float64 // Release time (ms) - LA-2A has program-dependent two-stage release
+	LA2AMakeup    float64 // dB, makeup gain (stored in dB, converted to linear)
+	LA2AKnee      float64 // Knee curve softness (1.0-8.0) - T4 cell provides inherent soft knee
+	LA2AMix       float64 // Wet/dry mix (0.0-1.0, 1.0 = 100% compressed)
+
+	// De-esser (deesser) - removes harsh sibilance automatically
+	DeessEnabled   bool    // Enable deesser filter
+	DeessIntensity float64 // 0.0-1.0, intensity for triggering de-essing (0=off, 1=max)
+	DeessAmount    float64 // 0.0-1.0, amount of ducking on treble (how much to reduce)
+	DeessFreq      float64 // 0.0-1.0, how much original frequency content to keep
+
+	// Target values (for reference only)
+	TargetI   float64 // LUFS target reference (podcast standard: -16)
+	TargetTP  float64 // dBTP, true peak ceiling reference
+	TargetLRA float64 // LU, loudness range reference
+
+	// Filter chain order - controls the sequence of filters in the processing chain
+	// Use Pass2FilterOrder or customise for experimentation
+	FilterOrder []FilterID
+
+	// Adeclick - Click/pop repair filter (Pass 4)
+	// Detects and repairs waveform discontinuities through interpolation
+	// Applied after loudnorm to catch clicks from limiter and gain changes
+	AdeclickEnabled   bool    // Enable adeclick filter (default: true in Pass 4)
+	AdeclickThreshold float64 // Detection sensitivity (0.1-8.0, lower=more sensitive)
+	AdeclickWindow    float64 // Analysis window in ms (10-100)
+	AdeclickOverlap   float64 // Window overlap percentage (50-95)
+	AdeclickMethod    string  // Interpolation method ("" = default "a" = average; "s" = spline)
+
+	// Loudnorm (Pass 3) - EBU R128 dynamic loudness normalisation
+	// Replaces simple volume gain + limiting with integrated dynamic normalisation
+	// Uses two-pass mode with measurements from Pass 2 for optimal transparency
+	LoudnormEnabled   bool    // Enable loudnorm in Pass 3 (default: true)
+	LoudnormTargetI   float64 // Target integrated loudness (LUFS), default: -16.0
+	LoudnormTargetTP  float64 // Target true peak (dBTP), default: -1.5
+	LoudnormTargetLRA float64 // Target loudness range (LU), default: 11.0
+	LoudnormDualMono  bool    // Treat mono as dual-mono (CRITICAL for mono files)
+	LoudnormLinear    bool    // Prefer linear mode (falls back to dynamic if needed)
+}
+
+// BaseFilterConfig holds caller-owned defaults and user-facing options only.
+type BaseFilterConfig struct {
+	filterConfigDefaults
+}
+
+// AdaptiveFilterResult holds a complete per-file set of tunable filter values.
+// It excludes diagnostics and pass execution state.
+type AdaptiveFilterResult struct {
+	filterConfigDefaults
+}
+
+// AdaptiveDiagnostics holds report-only adaptation explanations.
+type AdaptiveDiagnostics struct {
+}
+
+// ProcessingFilterContext holds pass execution state outside caller-owned defaults.
+type ProcessingFilterContext struct {
+	Pass                  PassNumber
+	Measurements          *AudioMeasurements
+	OutputAnalysisEnabled bool
+}
 
 // filterBuilderFunc is a function that builds a filter spec from config.
 // Returns the FFmpeg filter specification string, or empty string if disabled.
@@ -280,13 +421,17 @@ type FilterChainConfig struct {
 	LoudnormLinear    bool    // Prefer linear mode (falls back to dynamic if needed)
 }
 
-// DefaultFilterConfig returns the scientifically-tuned default filter configuration
-// for podcast spoken word audio processing.
-func DefaultFilterConfig() *FilterChainConfig {
-	return &FilterChainConfig{
-		// Pass (set by caller, defaults to 0 meaning unset)
-		Pass: 0,
+// EffectiveFilterConfig is the per-file filter-builder input. During the
+// compatibility phase it embeds FilterChainConfig, but assembly helpers populate
+// only caller defaults and adaptive filter values.
+type EffectiveFilterConfig struct {
+	FilterChainConfig
+}
 
+// DefaultFilterConfig returns the scientifically-tuned caller-owned defaults for
+// podcast spoken word audio processing.
+func DefaultFilterConfig() *BaseFilterConfig {
+	return &BaseFilterConfig{filterConfigDefaults: filterConfigDefaults{
 		// Downmix - always enabled to ensure mono processing
 		DownmixEnabled: true,
 
@@ -378,8 +523,6 @@ func DefaultFilterConfig() *FilterChainConfig {
 		// Filter chain order - use default order
 		FilterOrder: Pass2FilterOrder,
 
-		Measurements: nil, // Will be set after Pass 1
-
 		// Loudnorm - enabled by default with podcast-optimised settings
 		LoudnormEnabled:   true,
 		LoudnormTargetI:   -16.0, // Podcast standard (-16 LUFS)
@@ -387,49 +530,77 @@ func DefaultFilterConfig() *FilterChainConfig {
 		LoudnormTargetLRA: 20.0,  // High value to prevent dynamic mode fallback (must be >= source LRA)
 		LoudnormDualMono:  true,  // CRITICAL for mono recordings
 		LoudnormLinear:    true,  // Prefer linear (transparent) mode
-	}
+	}}
 }
 
-func derivePerFileConfig(base *FilterChainConfig) *FilterChainConfig {
+func DefaultEffectiveFilterConfig() *FilterChainConfig {
+	return derivePerFileConfig(DefaultFilterConfig())
+}
+
+func derivePerFileConfig(base *BaseFilterConfig) *FilterChainConfig {
+	effective := deriveEffectiveFilterConfig(base)
+	if effective == nil {
+		return nil
+	}
+	return &effective.FilterChainConfig
+}
+
+func deriveEffectiveFilterConfig(base *BaseFilterConfig) *EffectiveFilterConfig {
+	return assembleEffectiveFilterConfig(base, deriveAdaptiveFilterResult(base))
+}
+
+func deriveAdaptiveFilterResult(base *BaseFilterConfig) *AdaptiveFilterResult {
 	if base == nil {
 		return nil
 	}
 
-	derived := *base
-	if base.FilterOrder != nil {
-		derived.FilterOrder = append([]FilterID(nil), base.FilterOrder...)
+	defaults := cloneFilterDefaults(&base.filterConfigDefaults)
+	return &AdaptiveFilterResult{filterConfigDefaults: defaults}
+}
+
+func assembleEffectiveFilterConfig(base *BaseFilterConfig, adaptive *AdaptiveFilterResult) *EffectiveFilterConfig {
+	if base == nil {
+		return nil
 	}
 
-	derived.Pass = 0
-	derived.Measurements = nil
-	derived.OutputAnalysisEnabled = false
-	resetAdaptiveDiagnostics(&derived)
+	effective := &EffectiveFilterConfig{}
+	copyFilterDefaults(&effective.FilterChainConfig, &base.filterConfigDefaults)
+	if adaptive != nil {
+		copyFilterDefaults(&effective.FilterChainConfig, &adaptive.filterConfigDefaults)
+	}
+	effective.FilterOrder = cloneFilterOrder(base.FilterOrder)
 
-	return &derived
+	return effective
 }
 
-func resetAdaptiveDiagnostics(config *FilterChainConfig) {
-	config.DS201LPContentType = 0
-	config.DS201LPReason = ""
-	config.DS201LPRolloffRatio = 0
-
-	config.DS201GateGentleMode = false
-	resetDS201GateDiagnostics(config)
-
-	config.LA2AHighCrestActive = false
-	config.LA2AHighCrestDeficit = 0
-	config.LA2AHighCrestSeverity = 0
-	config.LA2AHighCrestProjectedTP = 0
+func cloneFilterDefaults(src *filterConfigDefaults) filterConfigDefaults {
+	if src == nil {
+		return filterConfigDefaults{}
+	}
+	dst := *src
+	dst.FilterOrder = cloneFilterOrder(src.FilterOrder)
+	return dst
 }
 
-func resetDS201GateDiagnostics(config *FilterChainConfig) {
-	config.DS201GateAggression = 0
-	config.DS201GateDynamicRange = 0
-	config.DS201GateQuietSpeechEstimate = 0
-	config.DS201GateSpeechSeparation = 0
-	config.DS201GateSpeechHeadroom = 0
-	config.DS201GateThresholdUnclamped = 0
-	config.DS201GateClampReason = ""
+func cloneFilterOrder(order []FilterID) []FilterID {
+	if order == nil {
+		return nil
+	}
+	return append([]FilterID(nil), order...)
+}
+
+func copyFilterDefaults(dst *FilterChainConfig, src *filterConfigDefaults) {
+	dstValue := reflect.ValueOf(dst).Elem()
+	srcValue := reflect.ValueOf(src).Elem()
+	srcType := srcValue.Type()
+
+	for i := 0; i < srcValue.NumField(); i++ {
+		name := srcType.Field(i).Name
+		field := dstValue.FieldByName(name)
+		if field.IsValid() && field.CanSet() {
+			field.Set(srcValue.Field(i))
+		}
+	}
 }
 
 // DbToLinear converts decibel value to linear amplitude.
@@ -796,6 +967,10 @@ func (cfg *FilterChainConfig) BuildFilterSpec() string {
 	}
 
 	return strings.Join(filters, ",")
+}
+
+func (cfg *BaseFilterConfig) BuildFilterSpec() string {
+	return derivePerFileConfig(cfg).BuildFilterSpec()
 }
 
 // CreateProcessingFilterGraph creates an AVFilterGraph for complete audio processing

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -256,9 +256,8 @@ type AdaptiveDiagnostics struct {
 
 // ProcessingFilterContext holds pass execution state outside caller-owned defaults.
 type ProcessingFilterContext struct {
-	Pass                  PassNumber
-	Measurements          *AudioMeasurements
-	OutputAnalysisEnabled bool
+	Pass         PassNumber
+	Measurements *AudioMeasurements
 }
 
 // filterBuilderFunc is a function that builds a filter spec from effective config.
@@ -394,10 +393,6 @@ type FilterChainConfig struct {
 
 	// Pass 1 measurements (nil for first pass)
 	Measurements *AudioMeasurements
-
-	// Output Analysis - enables astats/ebur128/aspectralstats at end of Pass 2 filter chain
-	// When enabled, measurements are extracted from processed audio for comparison with Pass 1
-	OutputAnalysisEnabled bool
 
 	// Temporary compatibility for report consumers until diagnostics are routed
 	// explicitly through ProcessingResult.

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 )
 
-// newTestConfig creates a minimal FilterChainConfig for testing.
+// newTestBaseConfig creates a minimal BaseFilterConfig for testing.
 // All filters are disabled by default - enable only what you need for each test.
 // This isolates tests from application default configuration changes.
-func newTestConfig() *FilterChainConfig {
-	return &FilterChainConfig{
+func newTestBaseConfig() *BaseFilterConfig {
+	return &BaseFilterConfig{filterConfigDefaults: filterConfigDefaults{
 		// Infrastructure filters (disabled by default for isolated tests)
 		DownmixEnabled:     false,
 		AnalysisEnabled:    false,
@@ -84,7 +84,13 @@ func newTestConfig() *FilterChainConfig {
 		AdeclickMethod:    "s",
 
 		FilterOrder: Pass2FilterOrder,
-	}
+	}}
+}
+
+// newTestConfig creates a minimal effective FilterChainConfig for builder and
+// tuner tests that operate after seed assembly.
+func newTestConfig() *FilterChainConfig {
+	return derivePerFileConfig(newTestBaseConfig())
 }
 
 func TestBuildFilterSpec(t *testing.T) {
@@ -260,6 +266,196 @@ func TestBuildFilterSpec(t *testing.T) {
 			t.Errorf("asetnsamples must appear AFTER aformat\nSpec: %s", spec)
 		}
 	})
+}
+
+func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *FilterChainConfig
+		want   string
+	}{
+		{
+			name:   "default pass 2 chain",
+			config: DefaultEffectiveFilterConfig(),
+			want: "aformat=channel_layouts=mono," +
+				"highpass=f=80:poles=2:width_type=q:width=0.707:normalize=1:a=tdii," +
+				"lowpass=f=16000:poles=2:width_type=q:width=0.707:normalize=1:a=tdii," +
+				"anlmdn=s=0.00001:p=0.0060:r=0.0020:m=3," +
+				"compand=attacks=0.005:decays=0.100:soft-knee=6.0:points=-90/-96|-75/-81|-55/-55|-30/-30|0/0," +
+				"agate=threshold=0.010000:ratio=2.0:attack=12.00:release=350:range=0.0625:knee=3.0:detection=rms:makeup=1.0," +
+				"acompressor=threshold=0.125893:ratio=3.0:attack=10:release=200:makeup=1.00:knee=4.0:detection=rms:mix=1.00," +
+				"astats=metadata=1:measure_perchannel=all," +
+				"aspectralstats=win_size=2048:win_func=hann:measure=all," +
+				"ebur128=metadata=1:peak=sample+true:dualmono=true:target=-16," +
+				"aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096",
+		},
+		{
+			name: "low-pass disabled",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.DS201LPEnabled = false
+				config.FilterOrder = []FilterID{FilterDS201LowPass}
+				return config
+			}(),
+			want: "",
+		},
+		{
+			name: "low-pass enabled",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.DS201LPEnabled = true
+				config.DS201LPFreq = 14500.0
+				config.DS201LPPoles = 1
+				config.DS201LPWidth = 0.5
+				config.DS201LPMix = 0.75
+				config.DS201LPTransform = "zdf"
+				config.FilterOrder = []FilterID{FilterDS201LowPass}
+				return config
+			}(),
+			want: "lowpass=f=14500:poles=1:width_type=q:width=0.500:normalize=1:a=zdf:m=0.75",
+		},
+		{
+			name: "gate tuned",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.DS201GateEnabled = true
+				config.DS201GateThreshold = 0.003162
+				config.DS201GateRatio = 3.5
+				config.DS201GateAttack = 10.5
+				config.DS201GateRelease = 425
+				config.DS201GateRange = 0.0316
+				config.DS201GateKnee = 4.5
+				config.DS201GateDetection = "peak"
+				config.DS201GateMakeup = 1.2
+				config.FilterOrder = []FilterID{FilterDS201Gate}
+				return config
+			}(),
+			want: "agate=threshold=0.003162:ratio=3.5:attack=10.50:release=425:range=0.0316:knee=4.5:detection=peak:makeup=1.2",
+		},
+		{
+			name: "LA-2A high-crest tuned values",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.LA2AEnabled = true
+				config.LA2AThreshold = -30.0
+				config.LA2ARatio = 4.0
+				config.LA2AAttack = 10
+				config.LA2ARelease = 60
+				config.LA2AMakeup = 0
+				config.LA2AKnee = 6.0
+				config.LA2AMix = 0.85
+				config.LA2AHighCrestActive = true
+				config.LA2AHighCrestDeficit = 2.6
+				config.LA2AHighCrestSeverity = 0.433
+				config.LA2AHighCrestProjectedTP = 0.6
+				config.FilterOrder = []FilterID{FilterLA2ACompressor}
+				return config
+			}(),
+			want: "acompressor=threshold=0.031623:ratio=4.0:attack=10:release=60:makeup=1.00:knee=6.0:detection=rms:mix=0.85",
+		},
+		{
+			name: "noise-remove compand disabled",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.NoiseRemoveEnabled = true
+				config.NoiseRemoveCompandEnabled = false
+				config.FilterOrder = []FilterID{FilterNoiseRemove}
+				return config
+			}(),
+			want: "anlmdn=s=0.00001:p=0.0060:r=0.0058:m=11",
+		},
+		{
+			name: "noise-remove compand enabled",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.NoiseRemoveEnabled = true
+				config.NoiseRemoveCompandEnabled = true
+				config.NoiseRemoveCompandThreshold = -48.0
+				config.NoiseRemoveCompandExpansion = 12.0
+				config.FilterOrder = []FilterID{FilterNoiseRemove}
+				return config
+			}(),
+			want: "anlmdn=s=0.00001:p=0.0060:r=0.0058:m=11," +
+				"compand=attacks=0.005:decays=0.100:soft-knee=6.0:points=-90/-102|-75/-87|-48/-48|-30/-30|0/0",
+		},
+		{
+			name: "de-esser disabled",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.DeessEnabled = true
+				config.DeessIntensity = 0
+				config.FilterOrder = []FilterID{FilterDeesser}
+				return config
+			}(),
+			want: "",
+		},
+		{
+			name: "de-esser enabled",
+			config: func() *FilterChainConfig {
+				config := newTestConfig()
+				config.DeessEnabled = true
+				config.DeessIntensity = 0.6
+				config.DeessAmount = 0.4
+				config.DeessFreq = 0.7
+				config.FilterOrder = []FilterID{FilterDeesser}
+				return config
+			}(),
+			want: "deesser=i=0.60:m=0.40:f=0.70",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.BuildFilterSpec()
+			if got != tt.want {
+				t.Errorf("BuildFilterSpec() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultFilterConfigSeedOwnershipBoundary(t *testing.T) {
+	assertSeedConfigTypeCannotOwnPerFileState(t, reflect.TypeOf(DefaultFilterConfig()))
+}
+
+func assertSeedConfigTypeCannotOwnPerFileState(t *testing.T, typ reflect.Type) {
+	t.Helper()
+
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		t.Fatalf("seed config type = %s, want struct or pointer to struct", typ)
+	}
+
+	for _, name := range perFileStateFieldNames() {
+		if field, ok := typ.FieldByName(name); ok {
+			t.Errorf("seed config type %s owns per-file state field %s of type %s", typ.Name(), name, field.Type)
+		}
+	}
+}
+
+func perFileStateFieldNames() []string {
+	return []string{
+		"Pass",
+		"Measurements",
+		"OutputAnalysisEnabled",
+		"DS201LPContentType",
+		"DS201LPReason",
+		"DS201LPRolloffRatio",
+		"DS201GateGentleMode",
+		"DS201GateAggression",
+		"DS201GateDynamicRange",
+		"DS201GateQuietSpeechEstimate",
+		"DS201GateSpeechSeparation",
+		"DS201GateSpeechHeadroom",
+		"DS201GateThresholdUnclamped",
+		"DS201GateClampReason",
+		"LA2AHighCrestActive",
+		"LA2AHighCrestDeficit",
+		"LA2AHighCrestSeverity",
+		"LA2AHighCrestProjectedTP",
+	}
 }
 
 func TestBuildDS201HighpassFilter(t *testing.T) {
@@ -688,7 +884,7 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 
 func TestBuildAdeclickFilter(t *testing.T) {
 	t.Run("default config emits production clause", func(t *testing.T) {
-		config := DefaultFilterConfig()
+		config := DefaultEffectiveFilterConfig()
 
 		spec := config.buildAdeclickFilter()
 
@@ -782,41 +978,110 @@ func TestFilterOrderRespected(t *testing.T) {
 	}
 }
 
-func TestDerivePerFileConfig(t *testing.T) {
-	measurements := &AudioMeasurements{InputI: -24.0}
+func TestDeriveAdaptiveFilterResultDeepCopiesFilterOrder(t *testing.T) {
 	base := DefaultFilterConfig()
-	base.Pass = PassProcessing
 	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
-	base.Measurements = measurements
-	base.OutputAnalysisEnabled = true
+
+	adaptive := deriveAdaptiveFilterResult(base)
+	if adaptive == nil {
+		t.Fatal("deriveAdaptiveFilterResult returned nil")
+	}
+	if !reflect.DeepEqual(adaptive.FilterOrder, base.FilterOrder) {
+		t.Errorf("FilterOrder = %v, want %v", adaptive.FilterOrder, base.FilterOrder)
+	}
+
+	adaptive.FilterOrder[0] = FilterDownmix
+	if base.FilterOrder[0] == FilterDownmix {
+		t.Fatal("adaptive FilterOrder mutation changed base FilterOrder")
+	}
+}
+
+func TestAssembleEffectiveFilterConfig(t *testing.T) {
+	base := DefaultFilterConfig()
+	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
+	base.TargetI = -18.0
+	base.SilenceScanDuration = 2 * time.Second
+
+	adaptive := deriveAdaptiveFilterResult(base)
+	adaptive.DS201HPFreq = 65.0
+	adaptive.NoiseRemoveCompandEnabled = false
+	adaptive.FilterOrder = []FilterID{FilterDownmix}
+
+	effective := assembleEffectiveFilterConfig(base, adaptive)
+	if effective == nil {
+		t.Fatal("assembleEffectiveFilterConfig returned nil")
+	}
+	if effective.DS201HPFreq != adaptive.DS201HPFreq {
+		t.Errorf("DS201HPFreq = %.1f, want adaptive %.1f", effective.DS201HPFreq, adaptive.DS201HPFreq)
+	}
+	if effective.NoiseRemoveCompandEnabled {
+		t.Error("NoiseRemoveCompandEnabled = true, want adaptive false")
+	}
+	if effective.TargetI != base.TargetI {
+		t.Errorf("TargetI = %.1f, want base %.1f", effective.TargetI, base.TargetI)
+	}
+	if effective.SilenceScanDuration != base.SilenceScanDuration {
+		t.Errorf("SilenceScanDuration = %s, want base %s",
+			effective.SilenceScanDuration, base.SilenceScanDuration)
+	}
+	if !reflect.DeepEqual(effective.FilterOrder, base.FilterOrder) {
+		t.Errorf("FilterOrder = %v, want base order %v", effective.FilterOrder, base.FilterOrder)
+	}
+
+	effective.FilterOrder[0] = FilterDownmix
+	if base.FilterOrder[0] == FilterDownmix {
+		t.Fatal("effective FilterOrder mutation changed base FilterOrder")
+	}
+	if adaptive.FilterOrder[0] != FilterDownmix {
+		t.Fatal("effective FilterOrder mutation changed adaptive FilterOrder")
+	}
+
+	if effective.Pass != 0 {
+		t.Errorf("Pass = %d, want 0", effective.Pass)
+	}
+	if effective.Measurements != nil {
+		t.Errorf("Measurements = %p, want nil", effective.Measurements)
+	}
+	if effective.OutputAnalysisEnabled {
+		t.Error("OutputAnalysisEnabled = true, want false")
+	}
+	if effective.DS201LPContentType != 0 || effective.DS201LPReason != "" || effective.DS201LPRolloffRatio != 0 {
+		t.Errorf("low-pass diagnostics copied into effective config: type=%v reason=%q ratio=%.2f",
+			effective.DS201LPContentType, effective.DS201LPReason, effective.DS201LPRolloffRatio)
+	}
+	if effective.DS201GateGentleMode ||
+		effective.DS201GateAggression != 0 ||
+		effective.DS201GateDynamicRange != 0 ||
+		effective.DS201GateQuietSpeechEstimate != 0 ||
+		effective.DS201GateSpeechSeparation != 0 ||
+		effective.DS201GateSpeechHeadroom != 0 ||
+		effective.DS201GateThresholdUnclamped != 0 ||
+		effective.DS201GateClampReason != "" {
+		t.Errorf("gate diagnostics copied into effective config: %+v", effective)
+	}
+	if effective.LA2AHighCrestActive ||
+		effective.LA2AHighCrestDeficit != 0 ||
+		effective.LA2AHighCrestSeverity != 0 ||
+		effective.LA2AHighCrestProjectedTP != 0 {
+		t.Errorf("LA-2A diagnostics copied into effective config: active=%v deficit=%.2f severity=%.2f projected=%.2f",
+			effective.LA2AHighCrestActive,
+			effective.LA2AHighCrestDeficit,
+			effective.LA2AHighCrestSeverity,
+			effective.LA2AHighCrestProjectedTP)
+	}
+}
+
+func TestDerivePerFileConfig(t *testing.T) {
+	base := DefaultFilterConfig()
+	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
 	base.TargetI = -18.0
 	base.SilenceScanDuration = 2 * time.Second
 	base.NoiseRemoveCompandThreshold = -48.0
-
-	base.DS201LPContentType = ContentMusic
-	base.DS201LPReason = "stale lowpass reason"
-	base.DS201LPRolloffRatio = 3.5
-	base.DS201GateGentleMode = true
-	base.DS201GateAggression = 0.45
-	base.DS201GateDynamicRange = 12.0
-	base.DS201GateQuietSpeechEstimate = -42.0
-	base.DS201GateSpeechSeparation = 18.0
-	base.DS201GateSpeechHeadroom = 7.0
-	base.DS201GateThresholdUnclamped = -35.0
-	base.DS201GateClampReason = "speech_rms"
-	base.LA2AHighCrestActive = true
-	base.LA2AHighCrestDeficit = 2.5
-	base.LA2AHighCrestSeverity = 0.4
-	base.LA2AHighCrestProjectedTP = 1.2
 
 	derived := derivePerFileConfig(base)
 	if derived == nil {
 		t.Fatal("derivePerFileConfig returned nil")
 	}
-	if derived == base {
-		t.Fatal("derivePerFileConfig returned the base pointer")
-	}
-
 	if derived.Pass != 0 {
 		t.Errorf("Pass = %d, want 0", derived.Pass)
 	}
@@ -871,12 +1136,11 @@ func TestDerivePerFileConfig(t *testing.T) {
 			derived.LA2AHighCrestProjectedTP)
 	}
 
-	if base.Pass != PassProcessing ||
-		base.Measurements != measurements ||
-		!base.OutputAnalysisEnabled ||
-		base.DS201GateClampReason != "speech_rms" ||
-		!base.LA2AHighCrestActive {
-		t.Error("derivePerFileConfig mutated the base config")
+	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) ||
+		base.TargetI != -18.0 ||
+		base.SilenceScanDuration != 2*time.Second ||
+		base.NoiseRemoveCompandThreshold != -48.0 {
+		t.Error("derivePerFileConfig mutated caller-owned defaults")
 	}
 }
 

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -87,10 +87,10 @@ func newTestBaseConfig() *BaseFilterConfig {
 	}}
 }
 
-// newTestConfig creates a minimal effective FilterChainConfig for builder and
-// tuner tests that operate after seed assembly.
-func newTestConfig() *FilterChainConfig {
-	return derivePerFileConfig(newTestBaseConfig())
+// newTestConfig creates a minimal effective config for builder and tuner tests
+// that operate after seed assembly.
+func newTestConfig() *EffectiveFilterConfig {
+	return deriveEffectiveFilterConfig(newTestBaseConfig())
 }
 
 func TestBuildFilterSpec(t *testing.T) {
@@ -271,7 +271,7 @@ func TestBuildFilterSpec(t *testing.T) {
 func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 	tests := []struct {
 		name   string
-		config *FilterChainConfig
+		config *EffectiveFilterConfig
 		want   string
 	}{
 		{
@@ -291,7 +291,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "low-pass disabled",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.DS201LPEnabled = false
 				config.FilterOrder = []FilterID{FilterDS201LowPass}
@@ -301,7 +301,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "low-pass enabled",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.DS201LPEnabled = true
 				config.DS201LPFreq = 14500.0
@@ -316,7 +316,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "gate tuned",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.DS201GateEnabled = true
 				config.DS201GateThreshold = 0.003162
@@ -334,7 +334,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "LA-2A high-crest tuned values",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.LA2AEnabled = true
 				config.LA2AThreshold = -30.0
@@ -351,7 +351,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "noise-remove compand disabled",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.NoiseRemoveEnabled = true
 				config.NoiseRemoveCompandEnabled = false
@@ -362,7 +362,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "noise-remove compand enabled",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.NoiseRemoveEnabled = true
 				config.NoiseRemoveCompandEnabled = true
@@ -376,7 +376,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "de-esser disabled",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.DeessEnabled = true
 				config.DeessIntensity = 0
@@ -387,7 +387,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 		},
 		{
 			name: "de-esser enabled",
-			config: func() *FilterChainConfig {
+			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
 				config.DeessEnabled = true
 				config.DeessIntensity = 0.6
@@ -1032,32 +1032,21 @@ func TestAssembleEffectiveFilterConfig(t *testing.T) {
 		t.Fatal("effective FilterOrder mutation changed adaptive FilterOrder")
 	}
 
-	if effective.Pass != 0 {
-		t.Errorf("Pass = %d, want 0", effective.Pass)
-	}
-	if effective.Measurements != nil {
-		t.Errorf("Measurements = %p, want nil", effective.Measurements)
-	}
-	assertCompatibilityDiagnosticsClear(t, &effective.FilterChainConfig)
+	assertNoStaleEffectiveConfigFields(t)
 }
 
-func TestDerivePerFileConfig(t *testing.T) {
+func TestDeriveEffectiveFilterConfig(t *testing.T) {
 	base := DefaultFilterConfig()
 	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
 	base.TargetI = -18.0
 	base.SilenceScanDuration = 2 * time.Second
 	base.NoiseRemoveCompandThreshold = -48.0
 
-	derived := derivePerFileConfig(base)
+	derived := deriveEffectiveFilterConfig(base)
 	if derived == nil {
-		t.Fatal("derivePerFileConfig returned nil")
+		t.Fatal("deriveEffectiveFilterConfig returned nil")
 	}
-	if derived.Pass != 0 {
-		t.Errorf("Pass = %d, want 0", derived.Pass)
-	}
-	if derived.Measurements != nil {
-		t.Errorf("Measurements = %p, want nil", derived.Measurements)
-	}
+	assertNoStaleEffectiveConfigFields(t)
 	if !reflect.DeepEqual(derived.FilterOrder, base.FilterOrder) {
 		t.Errorf("FilterOrder = %v, want %v", derived.FilterOrder, base.FilterOrder)
 	}
@@ -1077,21 +1066,32 @@ func TestDerivePerFileConfig(t *testing.T) {
 			derived.NoiseRemoveCompandThreshold, base.NoiseRemoveCompandThreshold)
 	}
 
-	assertCompatibilityDiagnosticsClear(t, derived)
-
 	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) ||
 		base.TargetI != -18.0 ||
 		base.SilenceScanDuration != 2*time.Second ||
 		base.NoiseRemoveCompandThreshold != -48.0 {
-		t.Error("derivePerFileConfig mutated caller-owned defaults")
+		t.Error("deriveEffectiveFilterConfig mutated caller-owned defaults")
 	}
 }
 
-func assertCompatibilityDiagnosticsClear(t *testing.T, config *FilterChainConfig) {
+func assertNoStaleEffectiveConfigFields(t *testing.T) {
 	t.Helper()
 
-	if config.AdaptiveDiagnostics != (AdaptiveDiagnostics{}) {
-		t.Errorf("compatibility diagnostics populated on filter config: %+v", config.AdaptiveDiagnostics)
+	configType := reflect.TypeFor[EffectiveFilterConfig]()
+	for _, field := range []string{
+		"Pass",
+		"Measurements",
+		"OutputAnalysisEnabled",
+		"DS201LPReason",
+		"DS201GateClampReason",
+		"LA2AHighCrestActive",
+		"LA2AHighCrestDeficit",
+		"LA2AHighCrestSeverity",
+		"LA2AHighCrestProjectedTP",
+	} {
+		if _, ok := configType.FieldByName(field); ok {
+			t.Errorf("EffectiveFilterConfig contains stale field %s", field)
+		}
 	}
 }
 

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -1038,9 +1038,6 @@ func TestAssembleEffectiveFilterConfig(t *testing.T) {
 	if effective.Measurements != nil {
 		t.Errorf("Measurements = %p, want nil", effective.Measurements)
 	}
-	if effective.OutputAnalysisEnabled {
-		t.Error("OutputAnalysisEnabled = true, want false")
-	}
 	assertCompatibilityDiagnosticsClear(t, &effective.FilterChainConfig)
 }
 
@@ -1061,10 +1058,6 @@ func TestDerivePerFileConfig(t *testing.T) {
 	if derived.Measurements != nil {
 		t.Errorf("Measurements = %p, want nil", derived.Measurements)
 	}
-	if derived.OutputAnalysisEnabled {
-		t.Error("OutputAnalysisEnabled = true, want false")
-	}
-
 	if !reflect.DeepEqual(derived.FilterOrder, base.FilterOrder) {
 		t.Errorf("FilterOrder = %v, want %v", derived.FilterOrder, base.FilterOrder)
 	}

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -344,10 +344,6 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 				config.LA2AMakeup = 0
 				config.LA2AKnee = 6.0
 				config.LA2AMix = 0.85
-				config.LA2AHighCrestActive = true
-				config.LA2AHighCrestDeficit = 2.6
-				config.LA2AHighCrestSeverity = 0.433
-				config.LA2AHighCrestProjectedTP = 0.6
 				config.FilterOrder = []FilterID{FilterLA2ACompressor}
 				return config
 			}(),
@@ -1045,30 +1041,7 @@ func TestAssembleEffectiveFilterConfig(t *testing.T) {
 	if effective.OutputAnalysisEnabled {
 		t.Error("OutputAnalysisEnabled = true, want false")
 	}
-	if effective.DS201LPContentType != 0 || effective.DS201LPReason != "" || effective.DS201LPRolloffRatio != 0 {
-		t.Errorf("low-pass diagnostics copied into effective config: type=%v reason=%q ratio=%.2f",
-			effective.DS201LPContentType, effective.DS201LPReason, effective.DS201LPRolloffRatio)
-	}
-	if effective.DS201GateGentleMode ||
-		effective.DS201GateAggression != 0 ||
-		effective.DS201GateDynamicRange != 0 ||
-		effective.DS201GateQuietSpeechEstimate != 0 ||
-		effective.DS201GateSpeechSeparation != 0 ||
-		effective.DS201GateSpeechHeadroom != 0 ||
-		effective.DS201GateThresholdUnclamped != 0 ||
-		effective.DS201GateClampReason != "" {
-		t.Errorf("gate diagnostics copied into effective config: %+v", effective)
-	}
-	if effective.LA2AHighCrestActive ||
-		effective.LA2AHighCrestDeficit != 0 ||
-		effective.LA2AHighCrestSeverity != 0 ||
-		effective.LA2AHighCrestProjectedTP != 0 {
-		t.Errorf("LA-2A diagnostics copied into effective config: active=%v deficit=%.2f severity=%.2f projected=%.2f",
-			effective.LA2AHighCrestActive,
-			effective.LA2AHighCrestDeficit,
-			effective.LA2AHighCrestSeverity,
-			effective.LA2AHighCrestProjectedTP)
-	}
+	assertCompatibilityDiagnosticsClear(t, &effective.FilterChainConfig)
 }
 
 func TestDerivePerFileConfig(t *testing.T) {
@@ -1111,36 +1084,21 @@ func TestDerivePerFileConfig(t *testing.T) {
 			derived.NoiseRemoveCompandThreshold, base.NoiseRemoveCompandThreshold)
 	}
 
-	if derived.DS201LPContentType != 0 || derived.DS201LPReason != "" || derived.DS201LPRolloffRatio != 0 {
-		t.Errorf("low-pass diagnostics not reset: type=%v reason=%q ratio=%.2f",
-			derived.DS201LPContentType, derived.DS201LPReason, derived.DS201LPRolloffRatio)
-	}
-	if derived.DS201GateGentleMode ||
-		derived.DS201GateAggression != 0 ||
-		derived.DS201GateDynamicRange != 0 ||
-		derived.DS201GateQuietSpeechEstimate != 0 ||
-		derived.DS201GateSpeechSeparation != 0 ||
-		derived.DS201GateSpeechHeadroom != 0 ||
-		derived.DS201GateThresholdUnclamped != 0 ||
-		derived.DS201GateClampReason != "" {
-		t.Errorf("gate diagnostics not reset: %+v", derived)
-	}
-	if derived.LA2AHighCrestActive ||
-		derived.LA2AHighCrestDeficit != 0 ||
-		derived.LA2AHighCrestSeverity != 0 ||
-		derived.LA2AHighCrestProjectedTP != 0 {
-		t.Errorf("LA-2A diagnostics not reset: active=%v deficit=%.2f severity=%.2f projected=%.2f",
-			derived.LA2AHighCrestActive,
-			derived.LA2AHighCrestDeficit,
-			derived.LA2AHighCrestSeverity,
-			derived.LA2AHighCrestProjectedTP)
-	}
+	assertCompatibilityDiagnosticsClear(t, derived)
 
 	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) ||
 		base.TargetI != -18.0 ||
 		base.SilenceScanDuration != 2*time.Second ||
 		base.NoiseRemoveCompandThreshold != -48.0 {
 		t.Error("derivePerFileConfig mutated caller-owned defaults")
+	}
+}
+
+func assertCompatibilityDiagnosticsClear(t *testing.T, config *FilterChainConfig) {
+	t.Helper()
+
+	if config.AdaptiveDiagnostics != (AdaptiveDiagnostics{}) {
+		t.Errorf("compatibility diagnostics populated on filter config: %+v", config.AdaptiveDiagnostics)
 	}
 }
 

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -191,7 +191,7 @@ type LoudnormMeasurement struct {
 // Returns:
 //   - measurement: Loudnorm measurements for second pass
 //   - err: Error if measurement failed
-func measureWithLoudnorm(inputPath string, config *FilterChainConfig, filterPrefix string, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*LoudnormMeasurement, error) {
+func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filterPrefix string, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*LoudnormMeasurement, error) {
 	// Start capturing loudnorm log output
 	capture := beginLoudnormCapture()
 	defer capture.StopDiscard()
@@ -506,7 +506,7 @@ type NormalisationResult struct {
 //   - err: Error if normalisation failed
 func ApplyNormalisation(
 	inputPath string,
-	config *FilterChainConfig,
+	config *EffectiveFilterConfig,
 	outputMeasurements *OutputMeasurements,
 	inputMeasurements *AudioMeasurements,
 	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
@@ -627,7 +627,7 @@ func ApplyNormalisation(
 // and loudnorm diagnostic stats.
 func applyLoudnormAndMeasure(
 	inputPath string,
-	config *FilterChainConfig,
+	config *EffectiveFilterConfig,
 	measurement *LoudnormMeasurement,
 	inputMeasurements *AudioMeasurements,
 	preGainDB float64,
@@ -788,7 +788,7 @@ func applyLoudnormAndMeasure(
 //
 // Per ffmpeg-loudnorm-helper: the offset parameter MUST come from loudnorm's own
 // first pass measurement, not from external calculations.
-func buildLoudnormFilterSpec(config *FilterChainConfig, measurement *LoudnormMeasurement, preGainDB float64, ceiling float64, needsLimiting bool) string {
+func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, preGainDB float64, ceiling float64, needsLimiting bool) string {
 	var filters []string
 
 	// 1. Build pre-limiter prefix (volume + alimiter) from pre-computed values

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -238,7 +238,7 @@ func TestMeasureWithLoudnormStopsCaptureOnOpenError(t *testing.T) {
 		},
 	)
 
-	_, err := measureWithLoudnorm("/does/not/exist.wav", DefaultFilterConfig(), "", nil)
+	_, err := measureWithLoudnorm("/does/not/exist.wav", DefaultEffectiveFilterConfig(), "", nil)
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want open error")
 	}
@@ -300,7 +300,7 @@ func TestMeasureWithLoudnormLoopErrorFreesGraphBeforeStoppingCapture(t *testing.
 		loudnormRunFilterGraph = oldRun
 	})
 
-	_, err := measureWithLoudnorm(testFile, DefaultFilterConfig(), "", nil)
+	_, err := measureWithLoudnorm(testFile, DefaultEffectiveFilterConfig(), "", nil)
 	if !errors.Is(err, runErr) {
 		t.Fatalf("measureWithLoudnorm() error = %v, want wrapped run error", err)
 	}
@@ -481,7 +481,7 @@ func (e *loudnormTestEncoder) Close() error {
 }
 
 func loudnormApplicationTestConfig() *FilterChainConfig {
-	config := DefaultFilterConfig()
+	config := DefaultEffectiveFilterConfig()
 	config.AdeclickEnabled = false
 	return config
 }
@@ -1200,7 +1200,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := DefaultFilterConfig()
+			config := DefaultEffectiveFilterConfig()
 			measurement := &LoudnormMeasurement{
 				InputI:       tt.inputI,
 				InputTP:      tt.inputTP,
@@ -1282,7 +1282,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 }
 
 func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
-	config := DefaultFilterConfig()
+	config := DefaultEffectiveFilterConfig()
 	config.ResampleEnabled = false
 	config.ResampleSampleRate = 48000
 	config.ResampleFormat = "s32"
@@ -1318,7 +1318,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	}
 
 	t.Run("uses Pass 4 adeclick helper", func(t *testing.T) {
-		config := DefaultFilterConfig()
+		config := DefaultEffectiveFilterConfig()
 
 		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
 
@@ -1329,7 +1329,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	})
 
 	t.Run("omits disabled adeclick", func(t *testing.T) {
-		config := DefaultFilterConfig()
+		config := DefaultEffectiveFilterConfig()
 		config.AdeclickEnabled = false
 
 		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
@@ -1518,7 +1518,7 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 			}
 
 			// Step 4: verify buildLoudnormFilterSpec receives the full target
-			config := DefaultFilterConfig()
+			config := DefaultEffectiveFilterConfig()
 			config.LoudnormTargetI = effectiveTargetI
 			measurement := &LoudnormMeasurement{
 				InputI:       tt.measuredI,

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -238,7 +238,7 @@ func TestMeasureWithLoudnormStopsCaptureOnOpenError(t *testing.T) {
 		},
 	)
 
-	_, err := measureWithLoudnorm("/does/not/exist.wav", DefaultEffectiveFilterConfig(), "", nil)
+	_, err := measureWithLoudnorm("/does/not/exist.wav", defaultNormalisationTestConfig(), "", nil)
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want open error")
 	}
@@ -300,7 +300,7 @@ func TestMeasureWithLoudnormLoopErrorFreesGraphBeforeStoppingCapture(t *testing.
 		loudnormRunFilterGraph = oldRun
 	})
 
-	_, err := measureWithLoudnorm(testFile, DefaultEffectiveFilterConfig(), "", nil)
+	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
 	if !errors.Is(err, runErr) {
 		t.Fatalf("measureWithLoudnorm() error = %v, want wrapped run error", err)
 	}
@@ -480,8 +480,12 @@ func (e *loudnormTestEncoder) Close() error {
 	return e.closeErr
 }
 
-func loudnormApplicationTestConfig() *FilterChainConfig {
-	config := DefaultEffectiveFilterConfig()
+func defaultNormalisationTestConfig() *EffectiveFilterConfig {
+	return effectiveFromFilterChainConfig(DefaultEffectiveFilterConfig())
+}
+
+func loudnormApplicationTestConfig() *EffectiveFilterConfig {
+	config := defaultNormalisationTestConfig()
 	config.AdeclickEnabled = false
 	return config
 }
@@ -1200,7 +1204,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := DefaultEffectiveFilterConfig()
+			config := defaultNormalisationTestConfig()
 			measurement := &LoudnormMeasurement{
 				InputI:       tt.inputI,
 				InputTP:      tt.inputTP,
@@ -1282,7 +1286,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 }
 
 func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
-	config := DefaultEffectiveFilterConfig()
+	config := defaultNormalisationTestConfig()
 	config.ResampleEnabled = false
 	config.ResampleSampleRate = 48000
 	config.ResampleFormat = "s32"
@@ -1318,7 +1322,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	}
 
 	t.Run("uses Pass 4 adeclick helper", func(t *testing.T) {
-		config := DefaultEffectiveFilterConfig()
+		config := defaultNormalisationTestConfig()
 
 		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
 
@@ -1329,7 +1333,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	})
 
 	t.Run("omits disabled adeclick", func(t *testing.T) {
-		config := DefaultEffectiveFilterConfig()
+		config := defaultNormalisationTestConfig()
 		config.AdeclickEnabled = false
 
 		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
@@ -1338,6 +1342,40 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 			t.Errorf("buildLoudnormFilterSpec() emitted disabled adeclick\nfilterSpec: %s", filterSpec)
 		}
 	})
+}
+
+func TestBuildLoudnormFilterSpecIgnoresPassStateAndDiagnostics(t *testing.T) {
+	measurement := &LoudnormMeasurement{
+		InputI:       -24.0,
+		InputTP:      -5.0,
+		InputLRA:     6.0,
+		InputThresh:  -34.0,
+		TargetOffset: -0.5,
+	}
+
+	base := defaultNormalisationTestConfig()
+	controlSpec := buildLoudnormFilterSpec(base, measurement, 0, -1.0, false)
+
+	withPassState := *base
+	withPassState.Pass = PassAnalysis
+	withPassState.Measurements = &AudioMeasurements{InputI: -99.0}
+	withPassState.AdaptiveDiagnostics = AdaptiveDiagnostics{
+		DS201LPReason:            "diagnostic-only low-pass reason",
+		DS201GateClampReason:     "diagnostic-only gate reason",
+		LA2AHighCrestActive:      true,
+		LA2AHighCrestDeficit:     12.0,
+		LA2AHighCrestSeverity:    0.8,
+		LA2AHighCrestProjectedTP: -0.5,
+	}
+	withPassState.FilterOrder = []FilterID{FilterAnalysis}
+	withPassState.DS201LPFreq = 12000
+	withPassState.DS201GateRatio = 4.0
+	withPassState.LA2AThreshold = -30.0
+
+	gotSpec := buildLoudnormFilterSpec(&withPassState, measurement, 0, -1.0, false)
+	if gotSpec != controlSpec {
+		t.Fatalf("buildLoudnormFilterSpec() changed when pass state or diagnostics changed\ncontrol: %s\ngot:     %s", controlSpec, gotSpec)
+	}
 }
 
 func TestPreGainCeilingRederivation(t *testing.T) {
@@ -1518,7 +1556,7 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 			}
 
 			// Step 4: verify buildLoudnormFilterSpec receives the full target
-			config := DefaultEffectiveFilterConfig()
+			config := defaultNormalisationTestConfig()
 			config.LoudnormTargetI = effectiveTargetI
 			measurement := &LoudnormMeasurement{
 				InputI:       tt.measuredI,

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -481,7 +481,7 @@ func (e *loudnormTestEncoder) Close() error {
 }
 
 func defaultNormalisationTestConfig() *EffectiveFilterConfig {
-	return effectiveFromFilterChainConfig(DefaultEffectiveFilterConfig())
+	return DefaultEffectiveFilterConfig()
 }
 
 func loudnormApplicationTestConfig() *EffectiveFilterConfig {
@@ -1344,7 +1344,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	})
 }
 
-func TestBuildLoudnormFilterSpecIgnoresPassStateAndDiagnostics(t *testing.T) {
+func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 	measurement := &LoudnormMeasurement{
 		InputI:       -24.0,
 		InputTP:      -5.0,
@@ -1354,27 +1354,18 @@ func TestBuildLoudnormFilterSpecIgnoresPassStateAndDiagnostics(t *testing.T) {
 	}
 
 	base := defaultNormalisationTestConfig()
+	assertNoStaleEffectiveConfigFields(t)
 	controlSpec := buildLoudnormFilterSpec(base, measurement, 0, -1.0, false)
 
-	withPassState := *base
-	withPassState.Pass = PassAnalysis
-	withPassState.Measurements = &AudioMeasurements{InputI: -99.0}
-	withPassState.AdaptiveDiagnostics = AdaptiveDiagnostics{
-		DS201LPReason:            "diagnostic-only low-pass reason",
-		DS201GateClampReason:     "diagnostic-only gate reason",
-		LA2AHighCrestActive:      true,
-		LA2AHighCrestDeficit:     12.0,
-		LA2AHighCrestSeverity:    0.8,
-		LA2AHighCrestProjectedTP: -0.5,
-	}
-	withPassState.FilterOrder = []FilterID{FilterAnalysis}
-	withPassState.DS201LPFreq = 12000
-	withPassState.DS201GateRatio = 4.0
-	withPassState.LA2AThreshold = -30.0
+	withUnrelatedFilterFields := *base
+	withUnrelatedFilterFields.FilterOrder = []FilterID{FilterAnalysis}
+	withUnrelatedFilterFields.DS201LPFreq = 12000
+	withUnrelatedFilterFields.DS201GateRatio = 4.0
+	withUnrelatedFilterFields.LA2AThreshold = -30.0
 
-	gotSpec := buildLoudnormFilterSpec(&withPassState, measurement, 0, -1.0, false)
+	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, 0, -1.0, false)
 	if gotSpec != controlSpec {
-		t.Fatalf("buildLoudnormFilterSpec() changed when pass state or diagnostics changed\ncontrol: %s\ngot:     %s", controlSpec, gotSpec)
+		t.Fatalf("buildLoudnormFilterSpec() changed when unrelated filter fields changed\ncontrol: %s\ngot:     %s", controlSpec, gotSpec)
 	}
 }
 

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -44,12 +44,16 @@ func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 
 	// Adapt config to show what would be used in Pass 2
 	adaptationStart := time.Now()
-	effectiveConfig := AdaptConfig(config, measurements)
+	effectiveConfig, _ := AdaptConfig(config, measurements)
 	adaptationDuration := time.Since(adaptationStart)
+	var resultConfig *FilterChainConfig
+	if effectiveConfig != nil {
+		resultConfig = &effectiveConfig.FilterChainConfig
+	}
 
 	return &AnalysisResult{
 		Measurements:       measurements,
-		Config:             effectiveConfig,
+		Config:             resultConfig,
 		AnalysisDuration:   analysisDuration,
 		AdaptationDuration: adaptationDuration,
 	}, nil
@@ -79,7 +83,11 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	}
 
 	// Adapt filter configuration based on Pass 1 measurements
-	effectiveConfig := AdaptConfig(config, measurements)
+	effectiveConfig, _ := AdaptConfig(config, measurements)
+	if effectiveConfig == nil {
+		return nil, fmt.Errorf("adaptive config failed")
+	}
+	filterConfig := &effectiveConfig.FilterChainConfig
 
 	// Pass 2: Processing
 	if progressCallback != nil {
@@ -90,17 +98,17 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	outputPath := generateOutputPath(inputPath)
 
 	// Enable output analysis to measure processed audio characteristics
-	effectiveConfig.OutputAnalysisEnabled = true
+	filterConfig.OutputAnalysisEnabled = true
 
 	// Set Pass 2 configuration for filter chain
-	effectiveConfig.Pass = PassProcessing
-	effectiveConfig.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
+	filterConfig.Pass = PassProcessing
+	filterConfig.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
 
 	// Track output measurements from Pass 2 (filtered but not yet normalised)
 	var filteredMeasurements *OutputMeasurements
 	var regionTimings RegionMeasurementTimings
 
-	inputMetadata, err := processWithFilters(inputPath, outputPath, effectiveConfig, progressCallback, measurements, &filteredMeasurements)
+	inputMetadata, err := processWithFilters(inputPath, outputPath, filterConfig, progressCallback, measurements, &filteredMeasurements)
 	if err != nil {
 		return nil, fmt.Errorf("pass 2 failed: %w", err)
 	}
@@ -125,7 +133,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	// The FinalMeasurements in the result include region measurements captured in Pass 4
 	var normResult *NormalisationResult
 	if filteredMeasurements != nil {
-		normResult, err = ApplyNormalisation(outputPath, effectiveConfig, filteredMeasurements, measurements, progressCallback)
+		normResult, err = ApplyNormalisation(outputPath, filterConfig, filteredMeasurements, measurements, progressCallback)
 		if err != nil {
 			return nil, fmt.Errorf("pass 3 failed: %w", err)
 		}
@@ -139,7 +147,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 		OutputLUFS:           0.0, // Will be set to final value below
 		NoiseFloor:           measurements.NoiseFloor,
 		Measurements:         measurements,
-		Config:               effectiveConfig, // Include per-file config for logging adaptive parameters
+		Config:               filterConfig, // Include per-file config for logging adaptive parameters
 		InputMetadata:        inputMetadata,
 		RegionTimings:        regionTimings,
 		FilteredMeasurements: filteredMeasurements,
@@ -229,7 +237,7 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 	// (no measure-only mode). Loudnorm measurement is done separately in Pass 3.
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := CreateProcessingFilterGraph(
 		reader.GetDecoderContext(),
-		config,
+		effectiveFromFilterChainConfig(config),
 	)
 	if err != nil {
 		return InputMetadata{}, fmt.Errorf("failed to create filter graph: %w", err)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -92,8 +92,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	// Generate output filename: input.flac → input-processed.flac
 	outputPath := generateOutputPath(inputPath)
 
-	// Set Pass 2 configuration for filter chain
-	effectiveConfig.Pass = PassProcessing
+	// Set Pass 2 filter chain order
 	effectiveConfig.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
 
 	// Track output measurements from Pass 2 (filtered but not yet normalised)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -16,7 +16,8 @@ import (
 // AnalysisResult contains analysis-only measurements and stage timings.
 type AnalysisResult struct {
 	Measurements       *AudioMeasurements
-	Config             *FilterChainConfig
+	Config             *EffectiveFilterConfig
+	Diagnostics        *AdaptiveDiagnostics
 	AnalysisDuration   time.Duration
 	AdaptationDuration time.Duration
 }
@@ -31,8 +32,7 @@ func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 	}
 
 	analysisStart := time.Now()
-	analysisConfig := derivePerFileConfig(config)
-	measurements, err := AnalyzeAudio(inputPath, analysisConfig, progressCallback)
+	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("analysis failed: %w", err)
 	}
@@ -44,16 +44,13 @@ func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 
 	// Adapt config to show what would be used in Pass 2
 	adaptationStart := time.Now()
-	effectiveConfig, _ := AdaptConfig(config, measurements)
+	effectiveConfig, diagnostics := AdaptConfig(config, measurements)
 	adaptationDuration := time.Since(adaptationStart)
-	var resultConfig *FilterChainConfig
-	if effectiveConfig != nil {
-		resultConfig = &effectiveConfig.FilterChainConfig
-	}
 
 	return &AnalysisResult{
 		Measurements:       measurements,
-		Config:             resultConfig,
+		Config:             effectiveConfig,
+		Diagnostics:        diagnostics,
 		AnalysisDuration:   analysisDuration,
 		AdaptationDuration: adaptationDuration,
 	}, nil
@@ -72,8 +69,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 		progressCallback(PassAnalysis, "Analyzing", 0.0, 0.0, nil)
 	}
 
-	analysisConfig := derivePerFileConfig(config)
-	measurements, err := AnalyzeAudio(inputPath, analysisConfig, progressCallback)
+	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("pass 1 failed: %w", err)
 	}
@@ -83,11 +79,10 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	}
 
 	// Adapt filter configuration based on Pass 1 measurements
-	effectiveConfig, _ := AdaptConfig(config, measurements)
+	effectiveConfig, diagnostics := AdaptConfig(config, measurements)
 	if effectiveConfig == nil {
 		return nil, fmt.Errorf("adaptive config failed")
 	}
-	filterConfig := &effectiveConfig.FilterChainConfig
 
 	// Pass 2: Processing
 	if progressCallback != nil {
@@ -97,18 +92,15 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	// Generate output filename: input.flac → input-processed.flac
 	outputPath := generateOutputPath(inputPath)
 
-	// Enable output analysis to measure processed audio characteristics
-	filterConfig.OutputAnalysisEnabled = true
-
 	// Set Pass 2 configuration for filter chain
-	filterConfig.Pass = PassProcessing
-	filterConfig.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
+	effectiveConfig.Pass = PassProcessing
+	effectiveConfig.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
 
 	// Track output measurements from Pass 2 (filtered but not yet normalised)
 	var filteredMeasurements *OutputMeasurements
 	var regionTimings RegionMeasurementTimings
 
-	inputMetadata, err := processWithFilters(inputPath, outputPath, filterConfig, progressCallback, measurements, &filteredMeasurements)
+	inputMetadata, err := processWithFilters(inputPath, outputPath, effectiveConfig, progressCallback, measurements, &filteredMeasurements)
 	if err != nil {
 		return nil, fmt.Errorf("pass 2 failed: %w", err)
 	}
@@ -133,7 +125,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	// The FinalMeasurements in the result include region measurements captured in Pass 4
 	var normResult *NormalisationResult
 	if filteredMeasurements != nil {
-		normResult, err = ApplyNormalisation(outputPath, filterConfig, filteredMeasurements, measurements, progressCallback)
+		normResult, err = ApplyNormalisation(outputPath, effectiveConfig, filteredMeasurements, measurements, progressCallback)
 		if err != nil {
 			return nil, fmt.Errorf("pass 3 failed: %w", err)
 		}
@@ -147,7 +139,8 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 		OutputLUFS:           0.0, // Will be set to final value below
 		NoiseFloor:           measurements.NoiseFloor,
 		Measurements:         measurements,
-		Config:               filterConfig, // Include per-file config for logging adaptive parameters
+		Config:               effectiveConfig, // Include per-file config for logging adaptive parameters
+		Diagnostics:          diagnostics,
 		InputMetadata:        inputMetadata,
 		RegionTimings:        regionTimings,
 		FilteredMeasurements: filteredMeasurements,
@@ -192,12 +185,13 @@ type ProcessingResult struct {
 	OutputLUFS   float64 // Final output loudness (after normalisation if applied)
 	NoiseFloor   float64
 	Measurements *AudioMeasurements
-	Config       *FilterChainConfig // Contains adaptive parameters used
+	Config       *EffectiveFilterConfig // Contains adaptive parameters used
+	Diagnostics  *AdaptiveDiagnostics
 
 	InputMetadata InputMetadata
 	RegionTimings RegionMeasurementTimings
 
-	// Pass 2 output analysis (populated when OutputAnalysisEnabled is true)
+	// Pass 2 output analysis (populated when requested by the processing pass)
 	// Contains measurements after filter chain but before normalisation
 	FilteredMeasurements *OutputMeasurements
 
@@ -209,8 +203,8 @@ type ProcessingResult struct {
 // processWithFilters performs audio processing using the standard single-input filter graph.
 // Applies the filter chain built by BuildFilterSpec() which includes asendcmd for noise profile learning
 // when NoiseProfileStart/End timestamps are set in the config.
-// If outputMeasurements is non-nil and config.OutputAnalysisEnabled is true, populates it with Pass 2 output analysis.
-func processWithFilters(inputPath, outputPath string, config *FilterChainConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements), measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) (InputMetadata, error) {
+// If outputMeasurements is non-nil, populates it with Pass 2 output analysis.
+func processWithFilters(inputPath, outputPath string, config *EffectiveFilterConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements), measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) (InputMetadata, error) {
 	// Open input audio file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
@@ -237,7 +231,7 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 	// (no measure-only mode). Loudnorm measurement is done separately in Pass 3.
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := CreateProcessingFilterGraph(
 		reader.GetDecoderContext(),
-		effectiveFromFilterChainConfig(config),
+		config,
 	)
 	if err != nil {
 		return InputMetadata{}, fmt.Errorf("failed to create filter graph: %w", err)
@@ -251,9 +245,9 @@ func processWithFilters(inputPath, outputPath string, config *FilterChainConfig,
 	}
 	defer encoder.Close()
 
-	// Initialize output measurement accumulators if output analysis is enabled
+	// Initialize output measurement accumulators if the caller requested output analysis.
 	var outputAcc *outputMetadataAccumulators
-	if config.OutputAnalysisEnabled && outputMeasurements != nil {
+	if outputMeasurements != nil {
 		outputAcc = &outputMetadataAccumulators{}
 	}
 

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -22,7 +22,7 @@ type AnalysisResult struct {
 }
 
 // AnalyzeOnlyDetailed performs Pass 1 analysis and returns stage timing details.
-func AnalyzeOnlyDetailed(inputPath string, config *FilterChainConfig,
+func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
 ) (*AnalysisResult, error) {
 	// Pass 1: Analysis
@@ -31,7 +31,8 @@ func AnalyzeOnlyDetailed(inputPath string, config *FilterChainConfig,
 	}
 
 	analysisStart := time.Now()
-	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
+	analysisConfig := derivePerFileConfig(config)
+	measurements, err := AnalyzeAudio(inputPath, analysisConfig, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("analysis failed: %w", err)
 	}
@@ -61,13 +62,14 @@ func AnalyzeOnlyDetailed(inputPath string, config *FilterChainConfig,
 //
 // The output file will be named <basename>-LUFS-NN-processed.<ext> in the same directory as the input
 // If progressCallback is not nil, it will be called with progress updates
-func ProcessAudio(inputPath string, config *FilterChainConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*ProcessingResult, error) {
+func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*ProcessingResult, error) {
 	// Pass 1: Analysis
 	if progressCallback != nil {
 		progressCallback(PassAnalysis, "Analyzing", 0.0, 0.0, nil)
 	}
 
-	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
+	analysisConfig := derivePerFileConfig(config)
+	measurements, err := AnalyzeAudio(inputPath, analysisConfig, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("pass 1 failed: %w", err)
 	}

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -127,6 +127,45 @@ func TestProcessorSeedParameterOwnershipBoundary(t *testing.T) {
 	}
 }
 
+func TestProcessorResultsExposeEffectiveConfigAndDiagnostics(t *testing.T) {
+	effectiveConfigType := reflect.TypeFor[*EffectiveFilterConfig]()
+	diagnosticsType := reflect.TypeFor[*AdaptiveDiagnostics]()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{
+			name: "AnalysisResult",
+			typ:  reflect.TypeFor[AnalysisResult](),
+		},
+		{
+			name: "ProcessingResult",
+			typ:  reflect.TypeFor[ProcessingResult](),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configField, ok := tt.typ.FieldByName("Config")
+			if !ok {
+				t.Fatalf("%s has no Config field", tt.name)
+			}
+			if configField.Type != effectiveConfigType {
+				t.Fatalf("%s.Config = %s, want %s", tt.name, configField.Type, effectiveConfigType)
+			}
+
+			diagnosticsField, ok := tt.typ.FieldByName("Diagnostics")
+			if !ok {
+				t.Fatalf("%s has no Diagnostics field", tt.name)
+			}
+			if diagnosticsField.Type != diagnosticsType {
+				t.Fatalf("%s.Diagnostics = %s, want %s", tt.name, diagnosticsField.Type, diagnosticsType)
+			}
+		})
+	}
+}
+
 // TestProcessAudio tests the complete three-pass processing pipeline
 func TestProcessAudio(t *testing.T) {
 	// Generate synthetic test audio: 3-second 440Hz tone at -18 dBFS input level
@@ -218,6 +257,9 @@ func TestProcessAudio(t *testing.T) {
 	if result.Config == nil {
 		t.Fatal("ProcessAudio returned nil config")
 	}
+	if result.Diagnostics == nil {
+		t.Fatal("ProcessAudio returned nil diagnostics")
+	}
 	if result.Config.Measurements != result.Measurements {
 		t.Fatal("result config Measurements does not point at Pass 1 measurements")
 	}
@@ -226,9 +268,6 @@ func TestProcessAudio(t *testing.T) {
 	}
 	if !reflect.DeepEqual(result.Config.FilterOrder, Pass2FilterOrder) {
 		t.Errorf("result config FilterOrder = %v, want %v", result.Config.FilterOrder, Pass2FilterOrder)
-	}
-	if !result.Config.OutputAnalysisEnabled {
-		t.Fatal("result config OutputAnalysisEnabled = false, want true")
 	}
 	if result.Config.DS201HPFreq == 95.0 {
 		t.Fatal("result config DS201HPFreq did not adapt from base seed value")
@@ -357,6 +396,9 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	}
 	if result.Config == nil {
 		t.Fatal("AnalyzeOnlyDetailed returned nil config")
+	}
+	if result.Diagnostics == nil {
+		t.Fatal("AnalyzeOnlyDetailed returned nil diagnostics")
 	}
 	if result.Config.Measurements != result.Measurements {
 		t.Fatal("result config Measurements does not point at Pass 1 measurements")

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -260,12 +260,7 @@ func TestProcessAudio(t *testing.T) {
 	if result.Diagnostics == nil {
 		t.Fatal("ProcessAudio returned nil diagnostics")
 	}
-	if result.Config.Measurements != result.Measurements {
-		t.Fatal("result config Measurements does not point at Pass 1 measurements")
-	}
-	if result.Config.Pass != PassProcessing {
-		t.Errorf("result config Pass = %d, want %d", result.Config.Pass, PassProcessing)
-	}
+	assertNoStaleEffectiveConfigFields(t)
 	if !reflect.DeepEqual(result.Config.FilterOrder, Pass2FilterOrder) {
 		t.Errorf("result config FilterOrder = %v, want %v", result.Config.FilterOrder, Pass2FilterOrder)
 	}
@@ -400,9 +395,7 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	if result.Diagnostics == nil {
 		t.Fatal("AnalyzeOnlyDetailed returned nil diagnostics")
 	}
-	if result.Config.Measurements != result.Measurements {
-		t.Fatal("result config Measurements does not point at Pass 1 measurements")
-	}
+	assertNoStaleEffectiveConfigFields(t)
 	if !reflect.DeepEqual(config.FilterOrder, baseFilterOrder) {
 		t.Errorf("base FilterOrder = %v, want %v", config.FilterOrder, baseFilterOrder)
 	}
@@ -432,16 +425,6 @@ func TestFilterChainBuilder(t *testing.T) {
 	// Should contain filter chain
 	if filterSpec == "" {
 		t.Error("Filter spec is empty")
-	}
-
-	// Test Pass 2 (processing) filter spec with measurements
-	config.Measurements = &AudioMeasurements{
-		InputI:       -23.4,
-		InputTP:      -3.2,
-		InputLRA:     8.7,
-		InputThresh:  -45.0,
-		TargetOffset: 0.5,
-		NoiseFloor:   -60.0,
 	}
 
 	// Enable additional filters for Pass 2 test

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -61,7 +61,7 @@ func TestGenerateLUFSOutputPath(t *testing.T) {
 }
 
 func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
-	base := newTestConfig()
+	base := newTestBaseConfig()
 	base.FilterOrder = []FilterID{FilterAnalysis, FilterDeesser}
 
 	first := AdaptConfig(base, &AudioMeasurements{
@@ -91,6 +91,39 @@ func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
 	}
 }
 
+func TestProcessorSeedParameterOwnershipBoundary(t *testing.T) {
+	tests := []struct {
+		name       string
+		fn         any
+		configArg  int
+		parameters int
+	}{
+		{
+			name:       "ProcessAudio",
+			fn:         ProcessAudio,
+			configArg:  1,
+			parameters: 3,
+		},
+		{
+			name:       "AnalyzeOnlyDetailed",
+			fn:         AnalyzeOnlyDetailed,
+			configArg:  1,
+			parameters: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typ := reflect.TypeOf(tt.fn)
+			if typ.NumIn() != tt.parameters {
+				t.Fatalf("%s has %d parameters, want %d", tt.name, typ.NumIn(), tt.parameters)
+			}
+
+			assertSeedConfigTypeCannotOwnPerFileState(t, typ.In(tt.configArg))
+		})
+	}
+}
+
 // TestProcessAudio tests the complete three-pass processing pipeline
 func TestProcessAudio(t *testing.T) {
 	// Generate synthetic test audio: 3-second 440Hz tone at -18 dBFS input level
@@ -114,16 +147,13 @@ func TestProcessAudio(t *testing.T) {
 
 	// Create isolated test config with minimal filters for integration test
 	// This ensures the test doesn't break when application defaults change
-	config := newTestConfig()
+	config := newTestBaseConfig()
 	config.DownmixEnabled = true
 	config.AnalysisEnabled = true
 	config.ResampleEnabled = true
 	config.DS201HPEnabled = true // Basic processing
 	config.DS201HPFreq = 95.0
-	basePass := config.Pass
 	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
-	baseMeasurements := config.Measurements
-	baseOutputAnalysisEnabled := config.OutputAnalysisEnabled
 
 	// Process the audio with a no-op progress callback
 	result, err := ProcessAudio(testFile, config, func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
@@ -176,26 +206,14 @@ func TestProcessAudio(t *testing.T) {
 	if result.Measurements == nil {
 		t.Error("ProcessAudio returned nil measurements")
 	}
-	if config.Pass != basePass {
-		t.Errorf("base Pass = %d, want %d", config.Pass, basePass)
-	}
 	if !reflect.DeepEqual(config.FilterOrder, baseFilterOrder) {
 		t.Errorf("base FilterOrder = %v, want %v", config.FilterOrder, baseFilterOrder)
-	}
-	if config.Measurements != baseMeasurements {
-		t.Fatal("base Measurements was mutated")
-	}
-	if config.OutputAnalysisEnabled != baseOutputAnalysisEnabled {
-		t.Errorf("base OutputAnalysisEnabled = %v, want %v", config.OutputAnalysisEnabled, baseOutputAnalysisEnabled)
 	}
 	if config.DS201HPFreq != 95.0 {
 		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", config.DS201HPFreq)
 	}
 	if result.Config == nil {
 		t.Fatal("ProcessAudio returned nil config")
-	}
-	if result.Config == config {
-		t.Fatal("ProcessAudio returned the caller seed config")
 	}
 	if result.Config.Measurements != result.Measurements {
 		t.Fatal("result config Measurements does not point at Pass 1 measurements")
@@ -319,15 +337,12 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	})
 	defer cleanupTestAudio(t, testFile)
 
-	config := newTestConfig()
+	config := newTestBaseConfig()
 	config.DownmixEnabled = true
 	config.AnalysisEnabled = true
 	config.DS201HPEnabled = true
 	config.DS201HPFreq = 95.0
-	basePass := config.Pass
 	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
-	baseMeasurements := config.Measurements
-	baseOutputAnalysisEnabled := config.OutputAnalysisEnabled
 
 	result, err := AnalyzeOnlyDetailed(testFile, config, nil)
 	if err != nil {
@@ -340,23 +355,11 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	if result.Config == nil {
 		t.Fatal("AnalyzeOnlyDetailed returned nil config")
 	}
-	if result.Config == config {
-		t.Fatal("AnalyzeOnlyDetailed returned the caller seed config")
-	}
 	if result.Config.Measurements != result.Measurements {
 		t.Fatal("result config Measurements does not point at Pass 1 measurements")
 	}
-	if config.Pass != basePass {
-		t.Errorf("base Pass = %d, want %d", config.Pass, basePass)
-	}
 	if !reflect.DeepEqual(config.FilterOrder, baseFilterOrder) {
 		t.Errorf("base FilterOrder = %v, want %v", config.FilterOrder, baseFilterOrder)
-	}
-	if config.Measurements != baseMeasurements {
-		t.Fatal("base Measurements was mutated")
-	}
-	if config.OutputAnalysisEnabled != baseOutputAnalysisEnabled {
-		t.Errorf("base OutputAnalysisEnabled = %v, want %v", config.OutputAnalysisEnabled, baseOutputAnalysisEnabled)
 	}
 	if config.DS201HPFreq != 95.0 {
 		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", config.DS201HPFreq)

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -64,18 +64,21 @@ func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
 	base := newTestBaseConfig()
 	base.FilterOrder = []FilterID{FilterAnalysis, FilterDeesser}
 
-	first := AdaptConfig(base, &AudioMeasurements{
+	first, firstDiagnostics := AdaptConfig(base, &AudioMeasurements{
 		BaseMeasurements: BaseMeasurements{
 			SpectralCentroid: 5000,
 		},
 	})
-	second := AdaptConfig(base, &AudioMeasurements{
+	second, secondDiagnostics := AdaptConfig(base, &AudioMeasurements{
 		BaseMeasurements: BaseMeasurements{
 			SpectralCentroid: 2000,
 		},
 	})
 	if first == nil || second == nil {
 		t.Fatal("AdaptConfig returned nil")
+	}
+	if firstDiagnostics == nil || secondDiagnostics == nil {
+		t.Fatal("AdaptConfig returned nil diagnostics")
 	}
 
 	first.FilterOrder[0] = FilterDownmix

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -31,7 +31,7 @@ type AnalysisModel struct {
 	// Results (populated when complete)
 	Result       *processor.AnalysisResult
 	Measurements *processor.AudioMeasurements
-	Config       *processor.FilterChainConfig
+	Config       *processor.EffectiveFilterConfig
 	Error        error
 	Done         bool
 
@@ -56,7 +56,7 @@ type AnalysisProgressMsg struct {
 type AnalysisCompleteMsg struct {
 	Result       *processor.AnalysisResult
 	Measurements *processor.AudioMeasurements
-	Config       *processor.FilterChainConfig
+	Config       *processor.EffectiveFilterConfig
 	Error        error
 }
 


### PR DESCRIPTION
## Summary
Split the processor configuration into base, effective, and adaptive layers so the pipeline can carry the derived settings explicitly and the compatibility layer can be removed.

## Changes
- Split the filter config model into base and effective config, plus adaptive diagnostics
- Thread the effective config through the processing pipeline and normalisation steps
- Remove the `FilterChainConfig` compatibility layer
- Update tests and documentation to match the new config flow

## Testing
- Reported passing: `just test`, `just lint`, `just build`

## Related Issues
- None