### PR TITLE
fix(processor): harden temp output publishing and debug log setup

### DIFF
--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -25,6 +25,10 @@ var version = "dev"
 
 var errCancelledByUser = errors.New("cancelled by user")
 
+const debugLogPath = "jivetalking-debug.log"
+
+var createDebugLogFile = os.Create
+
 // CLI defines the command-line interface
 type CLI struct {
 	Version             bool          `short:"v" help:"Show version information"`
@@ -73,9 +77,12 @@ func main() {
 	config.SilenceScanDuration = cliArgs.SilenceScanDuration
 
 	// Open debug log file if --debug flag is set
-	var debugLog *os.File
-	if cliArgs.Debug {
-		debugLog, _ = os.Create("jivetalking-debug.log")
+	debugLog, err := openDebugLog(cliArgs.Debug)
+	if err != nil {
+		cli.PrintError(err.Error())
+		os.Exit(1)
+	}
+	if debugLog != nil {
 		defer debugLog.Close()
 	}
 	log := func(format string, args ...any) {
@@ -171,6 +178,18 @@ func main() {
 			return
 		}
 	}
+}
+
+func openDebugLog(enabled bool) (*os.File, error) {
+	if !enabled {
+		return nil, nil
+	}
+
+	logFile, err := createDebugLogFile(debugLogPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open debug log %s: %w", debugLogPath, err)
+	}
+	return logFile, nil
 }
 
 func buildProcessingReportData(inputPath string, fileStartTime time.Time, timings logging.ProcessingTimings, result *processor.ProcessingResult) logging.ReportData {

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,6 +14,85 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/logging"
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
+
+func TestOpenDebugLog_DisabledReturnsNilWithoutCreatingFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	originalCreate := createDebugLogFile
+	t.Cleanup(func() {
+		createDebugLogFile = originalCreate
+	})
+
+	createDebugLogFile = func(string) (*os.File, error) {
+		t.Fatal("createDebugLogFile should not be called when debug logging is disabled")
+		return nil, nil
+	}
+
+	logFile, err := openDebugLog(false)
+	if err != nil {
+		t.Fatalf("openDebugLog(false) error = %v, want nil", err)
+	}
+	if logFile != nil {
+		t.Fatalf("openDebugLog(false) file = %v, want nil", logFile)
+	}
+	if _, err := os.Stat(debugLogPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("debug log stat error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestOpenDebugLog_EnabledCreatesLogFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	logFile, err := openDebugLog(true)
+	if err != nil {
+		t.Fatalf("openDebugLog(true) error = %v, want nil", err)
+	}
+	if logFile == nil {
+		t.Fatal("openDebugLog(true) file = nil, want open file")
+	}
+	if _, err := logFile.WriteString("debug line\n"); err != nil {
+		t.Fatalf("write debug log: %v", err)
+	}
+	if err := logFile.Close(); err != nil {
+		t.Fatalf("close debug log: %v", err)
+	}
+
+	contents, err := os.ReadFile(debugLogPath)
+	if err != nil {
+		t.Fatalf("read debug log: %v", err)
+	}
+	if string(contents) != "debug line\n" {
+		t.Fatalf("debug log contents = %q, want %q", contents, "debug line\n")
+	}
+}
+
+func TestOpenDebugLog_CreateFailureIncludesPath(t *testing.T) {
+	sentinel := errors.New("create failed")
+	originalCreate := createDebugLogFile
+	t.Cleanup(func() {
+		createDebugLogFile = originalCreate
+	})
+
+	var gotPath string
+	createDebugLogFile = func(path string) (*os.File, error) {
+		gotPath = path
+		return nil, sentinel
+	}
+
+	logFile, err := openDebugLog(true)
+	if logFile != nil {
+		t.Fatalf("openDebugLog(true) file = %v, want nil", logFile)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("openDebugLog(true) error = %v, want sentinel wrapped", err)
+	}
+	if gotPath != debugLogPath {
+		t.Fatalf("createDebugLogFile path = %q, want %q", gotPath, debugLogPath)
+	}
+	if !strings.Contains(err.Error(), debugLogPath) {
+		t.Fatalf("openDebugLog(true) error = %q, want path %q", err, debugLogPath)
+	}
+}
 
 func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 	inputPath := ".bench/analysis/input/sample.wav"

--- a/internal/processor/file_write.go
+++ b/internal/processor/file_write.go
@@ -1,0 +1,68 @@
+package processor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrOutputExists is returned when a publish destination already exists.
+var ErrOutputExists = errors.New("output already exists")
+
+var (
+	processorLink   = os.Link
+	processorRemove = os.Remove
+)
+
+// DestinationExistsError identifies the output path that blocked a no-clobber publish.
+type DestinationExistsError struct {
+	Path string
+}
+
+func (e *DestinationExistsError) Error() string {
+	return fmt.Sprintf("output already exists: %s", e.Path)
+}
+
+func (e *DestinationExistsError) Unwrap() error {
+	return ErrOutputExists
+}
+
+// createSiblingTempPath creates a hidden, same-directory temp path whose basename
+// includes the marker and ends in .tmp.flac; tests pin the exact naming pattern.
+func createSiblingTempPath(targetPath, marker string) (string, error) {
+	if marker == "" || filepath.Base(marker) != marker {
+		return "", fmt.Errorf("invalid temp marker: %q", marker)
+	}
+
+	tempFile, err := os.CreateTemp(filepath.Dir(targetPath), "."+marker+"-*.tmp.flac")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary output next to %s: %w", targetPath, err)
+	}
+
+	tempPath := tempFile.Name()
+	if err := tempFile.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("failed to close temporary output %s: %w", tempPath, err)
+	}
+
+	return tempPath, nil
+}
+
+// renameNoClobber publishes a same-directory temp file by linking src to dst,
+// then removing src. The link provides atomic no-clobber behaviour and avoids a
+// check-then-use destination reservation that os.Rename could later overwrite.
+func renameNoClobber(src, dst string) error {
+	if err := processorLink(src, dst); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return &DestinationExistsError{Path: dst}
+		}
+		return fmt.Errorf("failed to publish output to %s: %w", dst, err)
+	}
+
+	if err := processorRemove(src); err != nil {
+		return fmt.Errorf("published output to %s but failed to remove temporary source %s: %w", dst, src, err)
+	}
+
+	return nil
+}

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -653,7 +652,13 @@ func applyLoudnormAndMeasure(
 	defer reader.Close()
 
 	// Create temporary output file - always FLAC since output is pinned to FLAC
-	tempPath := strings.TrimSuffix(inputPath, filepath.Ext(inputPath)) + ".loudnorm.tmp.flac"
+	tempPath, err := createSiblingTempPath(inputPath, "loudnorm")
+	if err != nil {
+		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create loudnorm temp output: %w", err)
+	}
+	removeTemp := func() {
+		_ = os.Remove(tempPath)
+	}
 
 	// Build Pass 4 filter graph: loudnorm (second pass with linear=true) → ebur128 (validation)
 	filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, ceiling, needsLimiting)
@@ -664,6 +669,7 @@ func applyLoudnormAndMeasure(
 		filterSpec,
 	)
 	if err != nil {
+		removeTemp()
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create filter graph: %w", err)
 	}
 	// Note: We free the filter graph explicitly before getting stats, not via defer.
@@ -673,6 +679,7 @@ func applyLoudnormAndMeasure(
 	encoder, err := loudnormCreateEncoder(tempPath, metadata, bufferSinkCtx)
 	if err != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
+		removeTemp()
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create encoder: %w", err)
 	}
 	encoderClosed := false
@@ -720,12 +727,18 @@ func applyLoudnormAndMeasure(
 	})
 	if loopErr != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
+		encoderClosed = true
+		_ = encoder.Close()
+		removeTemp()
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, loopErr
 	}
 
 	// Flush encoder
 	if err := encoder.Flush(); err != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
+		encoderClosed = true
+		_ = encoder.Close()
+		removeTemp()
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to flush encoder: %w", err)
 	}
 
@@ -733,12 +746,14 @@ func applyLoudnormAndMeasure(
 	encoderClosed = true
 	if err := encoder.Close(); err != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
+		removeTemp()
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to close encoder: %w", err)
 	}
 
 	// Atomic rename: temp file → original file (in-place update)
 	if err := loudnormRename(tempPath, inputPath); err != nil {
 		loudnormAVFilterGraphFree(&filterGraph)
+		removeTemp()
 		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to rename output: %w", err)
 	}
 

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -516,6 +517,40 @@ func generateLoudnormApplicationTestAudio(t *testing.T) string {
 	return testFile
 }
 
+func oldFixedLoudnormTempPath(inputPath string) string {
+	return strings.TrimSuffix(inputPath, filepath.Ext(inputPath)) + ".loudnorm.tmp.flac"
+}
+
+func requireLoudnormTempPath(t *testing.T, inputPath, tempPath string) {
+	t.Helper()
+
+	if filepath.Dir(tempPath) != filepath.Dir(inputPath) {
+		t.Fatalf("temp file dir = %q, want %q", filepath.Dir(tempPath), filepath.Dir(inputPath))
+	}
+	base := filepath.Base(tempPath)
+	if !strings.HasPrefix(base, ".loudnorm-") || !strings.HasSuffix(base, ".tmp.flac") {
+		t.Fatalf("temp file basename = %q, want .loudnorm-*.tmp.flac", base)
+	}
+	if tempPath == oldFixedLoudnormTempPath(inputPath) {
+		t.Fatalf("temp file path = %q, want non-fixed loudnorm temp path", tempPath)
+	}
+}
+
+func requireNoLoudnormTempFiles(t *testing.T, inputPath string) {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(inputPath), ".loudnorm-*.tmp.flac"))
+	if err != nil {
+		t.Fatalf("failed to glob loudnorm temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("loudnorm temp files remain: %v", matches)
+	}
+	if _, err := os.Stat(oldFixedLoudnormTempPath(inputPath)); !os.IsNotExist(err) {
+		t.Fatalf("old fixed loudnorm temp stat error = %v, want not exist", err)
+	}
+}
+
 func applyLoudnormTest(
 	t *testing.T,
 	inputPath string,
@@ -575,6 +610,7 @@ func TestApplyLoudnormAndMeasureSetupErrorStopsCaptureWithoutFree(t *testing.T) 
 		t.Fatalf("graph free count = %d, want 0", recorder.freeCount())
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	requireNoLoudnormTempFiles(t, testFile)
 }
 
 func TestApplyLoudnormAndMeasureEncoderCreationErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
@@ -583,11 +619,14 @@ func TestApplyLoudnormAndMeasureEncoderCreationErrorFreesGraphBeforeStoppingCapt
 	replaceApplyLoudnormGraphFree(t, recorder, true)
 
 	createErr := errors.New("injected encoder creation failure")
+	var tempPath string
 	replaceApplyLoudnormCreateEncoder(t, func(
-		string,
-		*audio.Metadata,
-		*ffmpeg.AVFilterContext,
+		outputPath string,
+		_ *audio.Metadata,
+		_ *ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
+		tempPath = outputPath
+		requireLoudnormTempPath(t, testFile, outputPath)
 		return nil, createErr
 	})
 
@@ -602,6 +641,13 @@ func TestApplyLoudnormAndMeasureEncoderCreationErrorFreesGraphBeforeStoppingCapt
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if tempPath == "" {
+		t.Fatal("encoder was not given a temp output path")
+	}
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file stat error = %v, want not exist after encoder creation failure", err)
+	}
+	requireNoLoudnormTempFiles(t, testFile)
 }
 
 func TestApplyLoudnormAndMeasureLoopErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
@@ -609,11 +655,14 @@ func TestApplyLoudnormAndMeasureLoopErrorFreesGraphBeforeStoppingCapture(t *test
 	recorder := installLoudnormCleanupRecorder(t)
 	replaceApplyLoudnormGraphFree(t, recorder, true)
 	encoder := &loudnormTestEncoder{}
+	var tempPath string
 	replaceApplyLoudnormCreateEncoder(t, func(
-		string,
-		*audio.Metadata,
-		*ffmpeg.AVFilterContext,
+		outputPath string,
+		_ *audio.Metadata,
+		_ *ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
+		tempPath = outputPath
+		requireLoudnormTempPath(t, testFile, outputPath)
 		return encoder, nil
 	})
 
@@ -641,6 +690,13 @@ func TestApplyLoudnormAndMeasureLoopErrorFreesGraphBeforeStoppingCapture(t *test
 		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if tempPath == "" {
+		t.Fatal("encoder was not given a temp output path")
+	}
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file stat error = %v, want not exist after loop failure", err)
+	}
+	requireNoLoudnormTempFiles(t, testFile)
 }
 
 func TestApplyLoudnormAndMeasureFlushErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
@@ -650,11 +706,14 @@ func TestApplyLoudnormAndMeasureFlushErrorFreesGraphBeforeStoppingCapture(t *tes
 
 	flushErr := errors.New("injected flush failure")
 	encoder := &loudnormTestEncoder{flushErr: flushErr}
+	var tempPath string
 	replaceApplyLoudnormCreateEncoder(t, func(
-		string,
-		*audio.Metadata,
-		*ffmpeg.AVFilterContext,
+		outputPath string,
+		_ *audio.Metadata,
+		_ *ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
+		tempPath = outputPath
+		requireLoudnormTempPath(t, testFile, outputPath)
 		return encoder, nil
 	})
 
@@ -684,6 +743,13 @@ func TestApplyLoudnormAndMeasureFlushErrorFreesGraphBeforeStoppingCapture(t *tes
 		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if tempPath == "" {
+		t.Fatal("encoder was not given a temp output path")
+	}
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file stat error = %v, want not exist after flush failure", err)
+	}
+	requireNoLoudnormTempFiles(t, testFile)
 }
 
 func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
@@ -693,11 +759,14 @@ func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *tes
 
 	closeErr := errors.New("injected close failure")
 	encoder := &loudnormTestEncoder{closeErr: closeErr}
+	var tempPath string
 	replaceApplyLoudnormCreateEncoder(t, func(
-		string,
-		*audio.Metadata,
-		*ffmpeg.AVFilterContext,
+		outputPath string,
+		_ *audio.Metadata,
+		_ *ffmpeg.AVFilterContext,
 	) (loudnormOutputEncoder, error) {
+		tempPath = outputPath
+		requireLoudnormTempPath(t, testFile, outputPath)
 		return encoder, nil
 	})
 
@@ -727,6 +796,13 @@ func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *tes
 		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if tempPath == "" {
+		t.Fatal("encoder was not given a temp output path")
+	}
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file stat error = %v, want not exist after close failure", err)
+	}
+	requireNoLoudnormTempFiles(t, testFile)
 }
 
 func TestApplyLoudnormAndMeasureRenameErrorFreesGraphBeforeStoppingCapture(t *testing.T) {
@@ -755,13 +831,10 @@ func TestApplyLoudnormAndMeasureRenameErrorFreesGraphBeforeStoppingCapture(t *te
 	})
 
 	renameErr := errors.New("injected rename failure")
+	var tempPath string
 	replaceApplyLoudnormRename(t, func(oldPath, newPath string) error {
-		if filepath.Dir(oldPath) != filepath.Dir(testFile) {
-			t.Fatalf("temp file dir = %q, want %q", filepath.Dir(oldPath), filepath.Dir(testFile))
-		}
-		if !strings.HasSuffix(oldPath, ".loudnorm.tmp.flac") {
-			t.Fatalf("temp file path = %q, want .loudnorm.tmp.flac suffix", oldPath)
-		}
+		tempPath = oldPath
+		requireLoudnormTempPath(t, testFile, oldPath)
 		if newPath != testFile {
 			t.Fatalf("rename target = %q, want %q", newPath, testFile)
 		}
@@ -782,12 +855,25 @@ func TestApplyLoudnormAndMeasureRenameErrorFreesGraphBeforeStoppingCapture(t *te
 		t.Fatalf("encoder close calls = %d, want 1", encoder.closeN)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if tempPath == "" {
+		t.Fatal("rename was not given a temp output path")
+	}
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file stat error = %v, want not exist after rename failure", err)
+	}
+	requireNoLoudnormTempFiles(t, testFile)
 }
 
 func TestApplyLoudnormAndMeasureSuccessFreesGraphBeforeStoppingCapture(t *testing.T) {
 	testFile := generateLoudnormApplicationTestAudio(t)
 	recorder := installLoudnormCleanupRecorder(t)
 	replaceApplyLoudnormGraphFree(t, recorder, true)
+	var tempPath string
+	replaceApplyLoudnormRename(t, func(oldPath, newPath string) error {
+		tempPath = oldPath
+		requireLoudnormTempPath(t, testFile, oldPath)
+		return os.Rename(oldPath, newPath)
+	})
 
 	finalLUFS, _, finalMeasurements, stats, _, err := applyLoudnormTest(t, testFile)
 	if err != nil {
@@ -809,6 +895,13 @@ func TestApplyLoudnormAndMeasureSuccessFreesGraphBeforeStoppingCapture(t *testin
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if tempPath == "" {
+		t.Fatal("rename was not given a temp output path")
+	}
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file stat error = %v, want not exist after successful rename", err)
+	}
+	requireNoLoudnormTempFiles(t, testFile)
 }
 
 func TestCalculateLinearModeTarget(t *testing.T) {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -13,6 +13,8 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
 
+var processorCreateSiblingTempPath = createSiblingTempPath
+
 // AnalysisResult contains analysis-only measurements and stage timings.
 type AnalysisResult struct {
 	Measurements       *AudioMeasurements
@@ -89,8 +91,16 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 		progressCallback(PassProcessing, "Processing", 0.0, 0.0, measurements)
 	}
 
-	// Generate output filename: input.flac → input-processed.flac
-	outputPath := generateOutputPath(inputPath)
+	outputPath, err := processorCreateSiblingTempPath(inputPath, "processing")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pass 2 temp output: %w", err)
+	}
+	cleanupTempOutput := true
+	defer func() {
+		if cleanupTempOutput {
+			_ = os.Remove(outputPath)
+		}
+	}()
 
 	// Set Pass 2 filter chain order
 	effectiveConfig.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
@@ -156,9 +166,10 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	// Rename output file to include LUFS value: <name>-processed.<ext> → <name>-LUFS-NN-processed.<ext>
 	lufsValue := int(math.Abs(result.OutputLUFS))
 	finalPath := generateLUFSOutputPath(inputPath, lufsValue)
-	if err := os.Rename(outputPath, finalPath); err != nil {
-		return nil, fmt.Errorf("failed to rename output: %w", err)
+	if err := renameNoClobber(outputPath, finalPath); err != nil {
+		return nil, fmt.Errorf("failed to publish output: %w", err)
 	}
+	cleanupTempOutput = false
 	result.OutputPath = finalPath
 
 	return result, nil
@@ -314,19 +325,6 @@ func processWithFilters(inputPath, outputPath string, config *EffectiveFilterCon
 	}
 
 	return inputMetadata, nil
-}
-
-// generateOutputPath creates the intermediate output filename from the input filename.
-// This path is used during processing; the file is later renamed by generateLUFSOutputPath
-// to include the measured LUFS value. Output is always FLAC regardless of input extension.
-// Example: /path/to/audio.flac → /path/to/audio-processed.flac
-// Example: /path/to/audio.wav  → /path/to/audio-processed.flac
-func generateOutputPath(inputPath string) string {
-	dir := filepath.Dir(inputPath)
-	filename := filepath.Base(inputPath)
-	nameWithoutExt := strings.TrimSuffix(filename, filepath.Ext(filename))
-
-	return filepath.Join(dir, nameWithoutExt+"-processed.flac")
 }
 
 // generateLUFSOutputPath creates the final output filename with the measured LUFS value.

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -2,38 +2,16 @@ package processor
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
-
-// TestGenerateOutputPath verifies the intermediate output path is always FLAC.
-func TestGenerateOutputPath(t *testing.T) {
-	cases := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"lowercase wav", "/tmp/foo.wav", "/tmp/foo-processed.flac"},
-		{"uppercase WAV", "/tmp/foo.WAV", "/tmp/foo-processed.flac"},
-		{"flac input", "/tmp/foo.flac", "/tmp/foo-processed.flac"},
-		{"mp3 input", "/tmp/foo.mp3", "/tmp/foo-processed.flac"},
-		{"no extension", "/tmp/foo", "/tmp/foo-processed.flac"},
-		{"multi-dot", "/tmp/foo.bar.wav", "/tmp/foo.bar-processed.flac"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := generateOutputPath(tc.input)
-			if got != tc.want {
-				t.Errorf("generateOutputPath(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
-	}
-}
 
 // TestGenerateLUFSOutputPath verifies the final LUFS-tagged output path is always FLAC.
 func TestGenerateLUFSOutputPath(t *testing.T) {
@@ -57,6 +35,359 @@ func TestGenerateLUFSOutputPath(t *testing.T) {
 				t.Errorf("generateLUFSOutputPath(%q, 16) = %q, want %q", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCreateSiblingTempPath(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "presenter.wav")
+
+	first, err := createSiblingTempPath(targetPath, "processing")
+	if err != nil {
+		t.Fatalf("createSiblingTempPath() first call failed: %v", err)
+	}
+	defer os.Remove(first)
+
+	second, err := createSiblingTempPath(targetPath, "processing")
+	if err != nil {
+		t.Fatalf("createSiblingTempPath() second call failed: %v", err)
+	}
+	defer os.Remove(second)
+
+	if first == second {
+		t.Fatalf("createSiblingTempPath() returned duplicate path %q", first)
+	}
+
+	for _, tempPath := range []string{first, second} {
+		if filepath.Dir(tempPath) != dir {
+			t.Errorf("temp dir = %q, want %q", filepath.Dir(tempPath), dir)
+		}
+		if base := filepath.Base(tempPath); !strings.Contains(base, "processing") {
+			t.Errorf("temp basename = %q, want marker %q", base, "processing")
+		}
+		if ext := filepath.Ext(tempPath); ext != ".flac" {
+			t.Errorf("temp extension = %q, want .flac", ext)
+		}
+		if !strings.HasSuffix(tempPath, ".tmp.flac") {
+			t.Errorf("temp path = %q, want .tmp.flac suffix", tempPath)
+		}
+
+		info, err := os.Stat(tempPath)
+		if err != nil {
+			t.Fatalf("temp path %q was not reserved: %v", tempPath, err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("temp path %q size = %d, want 0", tempPath, info.Size())
+		}
+	}
+}
+
+func TestRenameNoClobberPublishesSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.flac")
+	dst := filepath.Join(dir, "output.flac")
+	want := []byte("published audio")
+
+	if err := os.WriteFile(src, want, 0o600); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	if err := renameNoClobber(src, dst); err != nil {
+		t.Fatalf("renameNoClobber() failed: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("destination bytes = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Errorf("source stat error = %v, want not exist", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read publish directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("publish directory entries = %d, want only destination", len(entries))
+	}
+	if entries[0].Name() != filepath.Base(dst) {
+		t.Fatalf("publish directory entry = %q, want %q", entries[0].Name(), filepath.Base(dst))
+	}
+	info, err := entries[0].Info()
+	if err != nil {
+		t.Fatalf("failed to stat published destination: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("published destination is zero bytes, want source bytes without reservation file")
+	}
+}
+
+func TestRenameNoClobberRefusesExistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.flac")
+	dst := filepath.Join(dir, "output.flac")
+	sourceBytes := []byte("new audio")
+	existingBytes := []byte("existing audio")
+
+	if err := os.WriteFile(src, sourceBytes, 0o600); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	if err := os.WriteFile(dst, existingBytes, 0o600); err != nil {
+		t.Fatalf("failed to write destination: %v", err)
+	}
+
+	err := renameNoClobber(src, dst)
+	if err == nil {
+		t.Fatal("renameNoClobber() succeeded, want destination-exists error")
+	}
+	if !errors.Is(err, ErrOutputExists) {
+		t.Fatalf("renameNoClobber() error = %v, want ErrOutputExists", err)
+	}
+
+	var existsErr *DestinationExistsError
+	if !errors.As(err, &existsErr) {
+		t.Fatalf("renameNoClobber() error = %T, want DestinationExistsError", err)
+	}
+	if existsErr.Path != dst {
+		t.Errorf("DestinationExistsError.Path = %q, want %q", existsErr.Path, dst)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if !bytes.Equal(got, existingBytes) {
+		t.Errorf("destination bytes = %q, want preserved %q", got, existingBytes)
+	}
+
+	got, err = os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("failed to read source after failed publish: %v", err)
+	}
+	if !bytes.Equal(got, sourceBytes) {
+		t.Errorf("source bytes = %q, want preserved %q", got, sourceBytes)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read publish directory: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("publish directory entries = %d, want source and destination only", len(entries))
+	}
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatalf("failed to stat %q: %v", entry.Name(), err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("publish directory contains zero-byte entry %q", entry.Name())
+		}
+	}
+}
+
+func TestRenameNoClobberConcurrentPublishRace(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "output.flac")
+
+	const publisherCount = 12
+	sources := make([]string, publisherCount)
+	sourceBytes := make([][]byte, publisherCount)
+	for i := range publisherCount {
+		sources[i] = filepath.Join(dir, "source-"+string(rune('a'+i))+".flac")
+		sourceBytes[i] = []byte(strings.Repeat(string(rune('A'+i)), 64))
+		if err := os.WriteFile(sources[i], sourceBytes[i], 0o600); err != nil {
+			t.Fatalf("failed to write source %d: %v", i, err)
+		}
+	}
+
+	start := make(chan struct{})
+	errs := make([]error, publisherCount)
+	var wg sync.WaitGroup
+	wg.Add(publisherCount)
+	for i := range publisherCount {
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			errs[index] = renameNoClobber(sources[index], dst)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	successIndex := -1
+	var successBytes []byte
+	for i, err := range errs {
+		if err == nil {
+			if successIndex != -1 {
+				t.Fatalf("publishers %d and %d both succeeded, want exactly one success", successIndex, i)
+			}
+			successIndex = i
+			successBytes = sourceBytes[i]
+			continue
+		}
+		if !errors.Is(err, ErrOutputExists) {
+			t.Fatalf("publisher %d error = %v, want ErrOutputExists", i, err)
+		}
+	}
+	if successIndex == -1 {
+		t.Fatal("no publisher succeeded, want exactly one success")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("destination is zero bytes after concurrent publish")
+	}
+	if !bytes.Equal(got, successBytes) {
+		t.Fatalf("destination bytes = %q, want complete source bytes from publisher %d", got, successIndex)
+	}
+
+	for i, source := range sources {
+		got, err := os.ReadFile(source)
+		if i == successIndex {
+			if !os.IsNotExist(err) {
+				t.Fatalf("winning source stat/read error = %v, want not exist", err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("failed to read losing source %d: %v", i, err)
+		}
+		if !bytes.Equal(got, sourceBytes[i]) {
+			t.Fatalf("losing source %d bytes = %q, want preserved %q", i, got, sourceBytes[i])
+		}
+	}
+}
+
+func TestRenameNoClobberRefusesStaleZeroByteDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.flac")
+	dst := filepath.Join(dir, "output.flac")
+	sourceBytes := []byte("new audio")
+
+	if err := os.WriteFile(src, sourceBytes, 0o600); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	if err := os.WriteFile(dst, nil, 0o600); err != nil {
+		t.Fatalf("failed to write stale destination: %v", err)
+	}
+
+	err := renameNoClobber(src, dst)
+	if err == nil {
+		t.Fatal("renameNoClobber() succeeded, want destination-exists error")
+	}
+	if !errors.Is(err, ErrOutputExists) {
+		t.Fatalf("renameNoClobber() error = %v, want ErrOutputExists", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read stale destination: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("stale destination bytes = %q, want unchanged zero-byte file", got)
+	}
+
+	got, err = os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("failed to read source after stale destination collision: %v", err)
+	}
+	if !bytes.Equal(got, sourceBytes) {
+		t.Fatalf("source bytes = %q, want preserved %q", got, sourceBytes)
+	}
+}
+
+func TestRenameNoClobberPreservesSourceAfterLinkFailure(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.flac")
+	dst := filepath.Join(dir, "output.flac")
+	linkErr := errors.New("injected link failure")
+
+	if err := os.WriteFile(src, []byte("new audio"), 0o600); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	oldLink := processorLink
+	processorLink = func(_, _ string) error {
+		return linkErr
+	}
+	t.Cleanup(func() {
+		processorLink = oldLink
+	})
+
+	err := renameNoClobber(src, dst)
+	if err == nil {
+		t.Fatal("renameNoClobber() succeeded, want injected link error")
+	}
+	if !errors.Is(err, linkErr) {
+		t.Fatalf("renameNoClobber() error = %v, want injected link error", err)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("destination stat error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("source was not preserved after failed publish: %v", err)
+	}
+}
+
+func TestRenameNoClobberReportsSourceCleanupFailureAfterPublish(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.flac")
+	dst := filepath.Join(dir, "output.flac")
+	want := []byte("published audio")
+	removeErr := errors.New("injected remove failure")
+
+	if err := os.WriteFile(src, want, 0o600); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	oldRemove := processorRemove
+	processorRemove = func(path string) error {
+		if path != src {
+			t.Fatalf("processorRemove(%q), want %q", path, src)
+		}
+		return removeErr
+	}
+	t.Cleanup(func() {
+		processorRemove = oldRemove
+	})
+
+	err := renameNoClobber(src, dst)
+	if err == nil {
+		t.Fatal("renameNoClobber() succeeded, want source cleanup error")
+	}
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("renameNoClobber() error = %v, want injected remove error", err)
+	}
+	if errors.Is(err, ErrOutputExists) {
+		t.Fatalf("renameNoClobber() error = %v, want non-collision cleanup error", err)
+	}
+	if !strings.Contains(err.Error(), src) {
+		t.Fatalf("renameNoClobber() error = %v, want source path %q", err, src)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("destination bytes = %q, want %q", got, want)
+	}
+
+	got, err = os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("failed to read source after cleanup failure: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("source bytes = %q, want preserved %q", got, want)
 	}
 }
 
@@ -355,6 +686,97 @@ func TestProcessAudio(t *testing.T) {
 	t.Logf("Output LUFS: %.2f", result.OutputLUFS)
 	t.Logf("Noise Floor: %.2f", result.NoiseFloor)
 	t.Logf("Output: %s", result.OutputPath)
+}
+
+func TestProcessAudioFinalCollisionPreservesOutputAndCleansTemp(t *testing.T) {
+	dir := t.TempDir()
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 1.5,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -18.0,
+		NoiseLevel:   -55.0,
+		Dir:          dir,
+	})
+	defer cleanupTestAudio(t, testFile)
+
+	config := newTestBaseConfig()
+	config.DownmixEnabled = true
+	config.AnalysisEnabled = true
+	config.ResampleEnabled = true
+	config.LoudnormEnabled = false
+	config.AdeclickEnabled = false
+
+	var tempPaths []string
+	oldCreateSiblingTempPath := processorCreateSiblingTempPath
+	processorCreateSiblingTempPath = func(targetPath, marker string) (string, error) {
+		tempPath, err := oldCreateSiblingTempPath(targetPath, marker)
+		if err == nil && marker == "processing" {
+			tempPaths = append(tempPaths, tempPath)
+		}
+		return tempPath, err
+	}
+	t.Cleanup(func() {
+		processorCreateSiblingTempPath = oldCreateSiblingTempPath
+	})
+
+	firstResult, err := ProcessAudio(testFile, config, nil)
+	if err != nil {
+		t.Fatalf("first ProcessAudio() failed: %v", err)
+	}
+	if firstResult.OutputPath == "" {
+		t.Fatal("first ProcessAudio() returned empty output path")
+	}
+
+	existingBytes, err := os.ReadFile(firstResult.OutputPath)
+	if err != nil {
+		t.Fatalf("failed to read first output: %v", err)
+	}
+
+	secondResult, err := ProcessAudio(testFile, config, nil)
+	if err == nil {
+		if secondResult != nil && secondResult.OutputPath != "" {
+			_ = os.Remove(secondResult.OutputPath)
+		}
+		t.Fatal("second ProcessAudio() succeeded, want final output collision")
+	}
+	if !errors.Is(err, ErrOutputExists) {
+		t.Fatalf("second ProcessAudio() error = %v, want ErrOutputExists", err)
+	}
+	if !strings.Contains(err.Error(), firstResult.OutputPath) {
+		t.Fatalf("second ProcessAudio() error = %v, want final path %q", err, firstResult.OutputPath)
+	}
+	if count := strings.Count(err.Error(), firstResult.OutputPath); count != 1 {
+		t.Fatalf("second ProcessAudio() error contains final path %d times, want 1: %v", count, err)
+	}
+
+	gotBytes, err := os.ReadFile(firstResult.OutputPath)
+	if err != nil {
+		t.Fatalf("failed to read preserved output: %v", err)
+	}
+	if !bytes.Equal(gotBytes, existingBytes) {
+		t.Fatal("existing final output bytes changed after collision")
+	}
+
+	assertNoProcessingTempFiles(t, dir)
+
+	if len(tempPaths) != 2 {
+		t.Fatalf("recorded processing temp paths = %d, want 2: %v", len(tempPaths), tempPaths)
+	}
+	if tempPaths[0] == tempPaths[1] {
+		t.Fatalf("ProcessAudio() reused processing temp path %q", tempPaths[0])
+	}
+	for _, tempPath := range tempPaths {
+		if filepath.Dir(tempPath) != dir {
+			t.Errorf("processing temp dir = %q, want %q", filepath.Dir(tempPath), dir)
+		}
+		if base := filepath.Base(tempPath); !strings.HasPrefix(base, ".processing-") || !strings.HasSuffix(base, ".tmp.flac") {
+			t.Errorf("processing temp basename = %q, want .processing-*.tmp.flac", base)
+		}
+		if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+			t.Errorf("processing temp stat error = %v, want not exist after publish/collision", err)
+		}
+	}
 }
 
 func TestAnalyzeOnlyDetailedTimings(t *testing.T) {

--- a/internal/processor/testutil_test.go
+++ b/internal/processor/testutil_test.go
@@ -231,4 +231,53 @@ func cleanupTestAudio(tb testing.TB, path string) {
 			os.Remove(match)
 		}
 	}
+
+	tempPatterns := []string{
+		filepath.Join(filepath.Dir(path), ".processing-*.tmp.flac"),
+		filepath.Join(filepath.Dir(path), ".loudnorm-*.tmp.flac"),
+	}
+	for _, pattern := range tempPatterns {
+		matches, _ := filepath.Glob(pattern)
+		for _, match := range matches {
+			os.Remove(match)
+		}
+	}
+}
+
+func assertNoProcessingTempFiles(tb testing.TB, dir string) {
+	tb.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(dir, ".processing-*.tmp.flac"))
+	if err != nil {
+		tb.Fatalf("failed to glob processing temp files in %s: %v", dir, err)
+	}
+	if len(matches) > 0 {
+		tb.Fatalf("processing temp files remain in %s: %v", dir, matches)
+	}
+}
+
+func TestCleanupTestAudioRemovesProcessorTempSiblings(t *testing.T) {
+	dir := t.TempDir()
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 0.1,
+		Dir:          dir,
+	})
+
+	tempPaths := []string{
+		filepath.Join(dir, ".processing-leftover.tmp.flac"),
+		filepath.Join(dir, ".loudnorm-leftover.tmp.flac"),
+	}
+	for _, tempPath := range tempPaths {
+		if err := os.WriteFile(tempPath, []byte("temporary audio"), 0o600); err != nil {
+			t.Fatalf("failed to create temp sibling %s: %v", tempPath, err)
+		}
+	}
+
+	cleanupTestAudio(t, testFile)
+
+	for _, tempPath := range tempPaths {
+		if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+			t.Fatalf("temp sibling stat error for %s = %v, want not exist", tempPath, err)
+		}
+	}
 }


### PR DESCRIPTION
- Create same-directory temp files for processing and loudnorm passes
- Publish outputs with no-clobber semantics and remove temp files on failure
- Surface debug log creation errors instead of ignoring create failures
- Add tests for collision handling, cleanup, and concurrent publishing