### PR TITLE
fix(processor): isolate loudnorm capture to graph finalisation

### DIFF
--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -82,10 +82,10 @@ func loudnormLogCallback(_ *ffmpeg.LogCtx, _ int, msg string) {
 }
 
 // startLoudnormCapture begins capturing loudnorm log output.
-// Must be called before processing frames through the loudnorm filter.
 // Temporarily raises log level to INFO since loudnorm outputs JSON at that level.
 // FFmpeg logging is process-global, so capture is serialised from start through
-// stop for both Pass 3 measurement and Pass 4 application.
+// stop. The narrow capture boundary is graph finalisation, where loudnorm emits
+// JSON as the filter graph is freed.
 func startLoudnormCapture() {
 	loudnormLogCapture.lifecycleMu.Lock()
 
@@ -99,7 +99,8 @@ func startLoudnormCapture() {
 	loudnormAVLogSetCallback(loudnormLogCallback)
 }
 
-// stopLoudnormCapture ends capture, restores default logging, and parses the JSON.
+// stopLoudnormCapture ends capture, restores default logging, and parses the JSON
+// emitted while loudnorm graph finalisation was captured.
 // Returns the parsed LoudnormStats or an error if JSON was not found/parseable.
 func stopLoudnormCapture() (*LoudnormStats, error) {
 	defer loudnormLogCapture.lifecycleMu.Unlock()
@@ -136,11 +137,15 @@ type loudnormCaptureSession struct {
 	stopped bool
 }
 
+// beginLoudnormCapture starts a capture session for a graph-finalisation boundary.
+// The returned session must be stopped once graph free has completed.
 func beginLoudnormCapture() *loudnormCaptureSession {
 	startLoudnormCapture()
 	return &loudnormCaptureSession{}
 }
 
+// Stop restores FFmpeg logging and parses the captured graph-finalisation output.
+// Repeated calls are safe and do not restore logging twice.
 func (session *loudnormCaptureSession) Stop() (*LoudnormStats, error) {
 	if session == nil {
 		return nil, nil
@@ -157,8 +162,20 @@ func (session *loudnormCaptureSession) Stop() (*LoudnormStats, error) {
 	return stopLoudnormCapture()
 }
 
+// StopDiscard restores FFmpeg logging and discards any graph-finalisation stats.
 func (session *loudnormCaptureSession) StopDiscard() {
 	_, _ = session.Stop()
+}
+
+func captureLoudnormGraphFinalisation(graph **ffmpeg.AVFilterGraph) (*LoudnormStats, error) {
+	capture := beginLoudnormCapture()
+	loudnormAVFilterGraphFree(graph)
+
+	stats, err := capture.Stop()
+	if err != nil {
+		return nil, fmt.Errorf("failed to capture loudnorm graph finalisation: %w", err)
+	}
+	return stats, nil
 }
 
 // LoudnormMeasurement holds the results from loudnorm's first pass (measurement mode).
@@ -191,10 +208,6 @@ type LoudnormMeasurement struct {
 //   - measurement: Loudnorm measurements for second pass
 //   - err: Error if measurement failed
 func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filterPrefix string, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*LoudnormMeasurement, error) {
-	// Start capturing loudnorm log output
-	capture := beginLoudnormCapture()
-	defer capture.StopDiscard()
-
 	// Open input file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
@@ -224,7 +237,7 @@ func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filter
 	}
 
 	// Create filter graph
-	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(
+	filterGraph, bufferSrcCtx, bufferSinkCtx, err := loudnormSetupFilterGraph(
 		reader.GetDecoderContext(),
 		filterSpec,
 	)
@@ -248,16 +261,13 @@ func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filter
 		},
 	})
 
-	// Free filter graph to trigger loudnorm JSON output
-	loudnormAVFilterGraphFree(&filterGraph)
-
-	// Capture loudnorm stats from log output
-	stats, err := capture.Stop()
+	// Free filter graph to trigger loudnorm JSON output and capture only that boundary.
+	stats, captureErr := captureLoudnormGraphFinalisation(&filterGraph)
 	if loopErr != nil {
 		return nil, fmt.Errorf("loudnorm measurement loop failed: %w", loopErr)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to capture loudnorm measurements: %w", err)
+	if captureErr != nil {
+		return nil, fmt.Errorf("failed to capture loudnorm measurements: %w", captureErr)
 	}
 
 	// Parse string values to measurement struct
@@ -634,27 +644,17 @@ func applyLoudnormAndMeasure(
 	needsLimiting bool,
 	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
 ) (float64, float64, *OutputMeasurements, *LoudnormStats, time.Duration, error) {
-	// Start capturing loudnorm's JSON output for diagnostics
-	capture := beginLoudnormCapture()
-	defer capture.StopDiscard()
-
-	// Helper to stop capture and return stats (may be nil if capture failed)
-	getLoudnormStats := func() *LoudnormStats {
-		stats, _ := capture.Stop()
-		return stats
-	}
-
 	// Open input file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to open input: %w", err)
+		return 0.0, 0.0, nil, nil, 0, fmt.Errorf("failed to open input: %w", err)
 	}
 	defer reader.Close()
 
 	// Create temporary output file - always FLAC since output is pinned to FLAC
 	tempPath, err := createSiblingTempPath(inputPath, "loudnorm")
 	if err != nil {
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create loudnorm temp output: %w", err)
+		return 0.0, 0.0, nil, nil, 0, fmt.Errorf("failed to create loudnorm temp output: %w", err)
 	}
 	removeTemp := func() {
 		_ = os.Remove(tempPath)
@@ -670,17 +670,25 @@ func applyLoudnormAndMeasure(
 	)
 	if err != nil {
 		removeTemp()
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create filter graph: %w", err)
+		return 0.0, 0.0, nil, nil, 0, fmt.Errorf("failed to create filter graph: %w", err)
 	}
 	// Note: We free the filter graph explicitly before getting stats, not via defer.
 	// loudnorm outputs its JSON when the filter graph is freed.
+	captureGraphStats := func() *LoudnormStats {
+		stats, err := captureLoudnormGraphFinalisation(&filterGraph)
+		if err != nil {
+			debugLog("Warning: failed to capture Pass 4 loudnorm diagnostics: %v", err)
+			return nil
+		}
+		return stats
+	}
 
 	// Create output encoder (same format as input)
 	encoder, err := loudnormCreateEncoder(tempPath, metadata, bufferSinkCtx)
 	if err != nil {
-		loudnormAVFilterGraphFree(&filterGraph)
+		stats := captureGraphStats()
 		removeTemp()
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to create encoder: %w", err)
+		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to create encoder: %w", err)
 	}
 	encoderClosed := false
 	defer func() {
@@ -726,42 +734,39 @@ func applyLoudnormAndMeasure(
 		},
 	})
 	if loopErr != nil {
-		loudnormAVFilterGraphFree(&filterGraph)
+		stats := captureGraphStats()
 		encoderClosed = true
 		_ = encoder.Close()
 		removeTemp()
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, loopErr
+		return 0.0, 0.0, nil, stats, 0, loopErr
 	}
 
 	// Flush encoder
 	if err := encoder.Flush(); err != nil {
-		loudnormAVFilterGraphFree(&filterGraph)
+		stats := captureGraphStats()
 		encoderClosed = true
 		_ = encoder.Close()
 		removeTemp()
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to flush encoder: %w", err)
+		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to flush encoder: %w", err)
 	}
 
 	// Close encoder before rename
 	encoderClosed = true
 	if err := encoder.Close(); err != nil {
-		loudnormAVFilterGraphFree(&filterGraph)
+		stats := captureGraphStats()
 		removeTemp()
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to close encoder: %w", err)
+		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to close encoder: %w", err)
 	}
 
 	// Atomic rename: temp file → original file (in-place update)
 	if err := loudnormRename(tempPath, inputPath); err != nil {
-		loudnormAVFilterGraphFree(&filterGraph)
+		stats := captureGraphStats()
 		removeTemp()
-		return 0.0, 0.0, nil, getLoudnormStats(), 0, fmt.Errorf("failed to rename output: %w", err)
+		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to rename output: %w", err)
 	}
 
 	// Free filter graph before getting stats — loudnorm outputs JSON on graph destruction
-	loudnormAVFilterGraphFree(&filterGraph)
-
-	// Capture loudnorm stats (JSON output captured during filter graph free)
-	stats := getLoudnormStats()
+	stats := captureGraphStats()
 
 	// Build complete OutputMeasurements from accumulators
 	finalMeasurements := finalizeOutputMeasurements(&acc)

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -227,15 +227,237 @@ func TestLoudnormCaptureSessionMalformedJSONRestoresLogOps(t *testing.T) {
 	}
 }
 
-func TestMeasureWithLoudnormStopsCaptureOnOpenError(t *testing.T) {
-	var callbackStops int
+func TestCaptureLoudnormGraphFinalisationSuccess(t *testing.T) {
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+
+	var graph *ffmpeg.AVFilterGraph
+	stats, err := captureLoudnormGraphFinalisation(&graph)
+	if err != nil {
+		t.Fatalf("captureLoudnormGraphFinalisation() error = %v", err)
+	}
+	if stats.InputI != "-23.0" {
+		t.Fatalf("stats.InputI = %q, want -23.0", stats.InputI)
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	if recorder.freeCount() != 1 {
+		t.Fatalf("graph free count = %d, want 1", recorder.freeCount())
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestCaptureLoudnormGraphFinalisationMalformedJSON(t *testing.T) {
+	recorder := installLoudnormCleanupRecorder(t)
+
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		recorder.recordFree()
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, "{not-json}")
+		if graph != nil && *graph != nil {
+			oldFree(graph)
+		}
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+
+	var graph *ffmpeg.AVFilterGraph
+	_, err := captureLoudnormGraphFinalisation(&graph)
+	if err == nil {
+		t.Fatal("captureLoudnormGraphFinalisation() error = nil, want malformed JSON error")
+	}
+	if !strings.Contains(err.Error(), "failed to capture loudnorm graph finalisation") {
+		t.Fatalf("captureLoudnormGraphFinalisation() error = %q, want graph finalisation context", err.Error())
+	}
+	if !strings.Contains(err.Error(), "failed to parse loudnorm JSON") {
+		t.Fatalf("captureLoudnormGraphFinalisation() error = %q, want malformed JSON context", err.Error())
+	}
+	if recorder.freeCount() != 1 {
+		t.Fatalf("graph free count = %d, want 1", recorder.freeCount())
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestCaptureLoudnormGraphFinalisationMissingJSON(t *testing.T) {
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, false)
+
+	var graph *ffmpeg.AVFilterGraph
+	_, err := captureLoudnormGraphFinalisation(&graph)
+	if err == nil {
+		t.Fatal("captureLoudnormGraphFinalisation() error = nil, want missing JSON error")
+	}
+	if !strings.Contains(err.Error(), "failed to capture loudnorm graph finalisation") {
+		t.Fatalf("captureLoudnormGraphFinalisation() error = %q, want graph finalisation context", err.Error())
+	}
+	if !strings.Contains(err.Error(), "no JSON found in loudnorm output") {
+		t.Fatalf("captureLoudnormGraphFinalisation() error = %q, want missing JSON context", err.Error())
+	}
+	if recorder.freeCount() != 1 {
+		t.Fatalf("graph free count = %d, want 1", recorder.freeCount())
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestCaptureLoudnormGraphFinalisationSerialisesGlobalCapture(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		order          []string
+		getLevelCalls  int
+		graphFreeCalls int
+	)
+	record := func(value string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, value)
+	}
+	orderString := func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return strings.Join(order, ",")
+	}
+
+	replaceLoudnormLogOps(t,
+		func() (int, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			getLevelCalls++
+			order = append(order, fmt.Sprintf("get-level-%d", getLevelCalls))
+			return 20 + getLevelCalls, nil
+		},
+		func(level int) {
+			if level == ffmpeg.AVLogInfo {
+				record("set-level-info")
+				return
+			}
+			record(fmt.Sprintf("restore-level-%d", level))
+		},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				record("set-callback-nil")
+				return
+			}
+			record("set-callback-capture")
+		},
+	)
+
+	firstFreeEntered := make(chan struct{})
+	releaseFirstFree := make(chan struct{})
+
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		mu.Lock()
+		graphFreeCalls++
+		call := graphFreeCalls
+		order = append(order, fmt.Sprintf("free-%d", call))
+		mu.Unlock()
+
+		if call == 1 {
+			close(firstFreeEntered)
+			<-releaseFirstFree
+		}
+
+		jsonOutput := strings.Replace(loudnormCaptureTestJSON, `"input_i":"-23.0"`, fmt.Sprintf(`"input_i":"-%d.0"`, 20+call), 1)
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, jsonOutput)
+		if graph != nil && *graph != nil {
+			oldFree(graph)
+		}
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+
+	type captureResult struct {
+		stats *LoudnormStats
+		err   error
+	}
+	firstDone := make(chan captureResult, 1)
+	secondDone := make(chan captureResult, 1)
+
+	var firstGraph *ffmpeg.AVFilterGraph
+	go func() {
+		stats, err := captureLoudnormGraphFinalisation(&firstGraph)
+		firstDone <- captureResult{stats: stats, err: err}
+	}()
+
+	select {
+	case <-firstFreeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first graph free did not start")
+	}
+
+	var secondGraph *ffmpeg.AVFilterGraph
+	go func() {
+		stats, err := captureLoudnormGraphFinalisation(&secondGraph)
+		secondDone <- captureResult{stats: stats, err: err}
+	}()
+
+	select {
+	case result := <-secondDone:
+		t.Fatalf("second capture completed before first capture stopped: %+v", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	wantBlockedOrder := "get-level-1,set-level-info,set-callback-capture,free-1"
+	if gotOrder := orderString(); gotOrder != wantBlockedOrder {
+		t.Fatalf("order while first graph free is blocked = %s, want %s", gotOrder, wantBlockedOrder)
+	}
+
+	close(releaseFirstFree)
+
+	firstResult := <-firstDone
+	if firstResult.err != nil {
+		t.Fatalf("first captureLoudnormGraphFinalisation() error = %v", firstResult.err)
+	}
+	if firstResult.stats.InputI != "-21.0" {
+		t.Fatalf("first stats.InputI = %q, want -21.0", firstResult.stats.InputI)
+	}
+
+	var secondResult captureResult
+	select {
+	case secondResult = <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("second capture did not complete after first capture stopped")
+	}
+	if secondResult.err != nil {
+		t.Fatalf("second captureLoudnormGraphFinalisation() error = %v", secondResult.err)
+	}
+	if secondResult.stats.InputI != "-22.0" {
+		t.Fatalf("second stats.InputI = %q, want -22.0", secondResult.stats.InputI)
+	}
+
+	wantOrder := strings.Join([]string{
+		"get-level-1",
+		"set-level-info",
+		"set-callback-capture",
+		"free-1",
+		"set-callback-nil",
+		"restore-level-21",
+		"get-level-2",
+		"set-level-info",
+		"set-callback-capture",
+		"free-2",
+		"set-callback-nil",
+		"restore-level-22",
+	}, ",")
+	if gotOrder := orderString(); gotOrder != wantOrder {
+		t.Fatalf("serialised order = %s, want %s", gotOrder, wantOrder)
+	}
+}
+
+func TestMeasureWithLoudnormDoesNotStartCaptureOnOpenError(t *testing.T) {
+	var callbackStarts, callbackStops int
 	replaceLoudnormLogOps(t,
 		func() (int, error) { return 7, nil },
 		func(int) {},
 		func(callback ffmpeg.LogCallback) {
 			if callback == nil {
 				callbackStops++
+				return
 			}
+			callbackStarts++
 		},
 	)
 
@@ -243,8 +465,42 @@ func TestMeasureWithLoudnormStopsCaptureOnOpenError(t *testing.T) {
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want open error")
 	}
-	if callbackStops != 1 {
-		t.Fatalf("stop callback count = %d, want 1", callbackStops)
+	if callbackStarts != 0 {
+		t.Fatalf("capture callback install count = %d, want 0", callbackStarts)
+	}
+	if callbackStops != 0 {
+		t.Fatalf("capture callback stop count = %d, want 0", callbackStops)
+	}
+}
+
+func TestMeasureWithLoudnormDoesNotStartCaptureOnSetupError(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+
+	var callbackStarts, callbackStops int
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(int) {},
+		func(callback ffmpeg.LogCallback) {
+			if callback == nil {
+				callbackStops++
+				return
+			}
+			callbackStarts++
+		},
+	)
+
+	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "not_a_real_filter", nil)
+	if err == nil {
+		t.Fatal("measureWithLoudnorm() error = nil, want setup error")
+	}
+	if !strings.Contains(err.Error(), "failed to create filter graph") {
+		t.Fatalf("measureWithLoudnorm() error = %q, want filter graph context", err.Error())
+	}
+	if callbackStarts != 0 {
+		t.Fatalf("capture callback install count = %d, want 0", callbackStarts)
+	}
+	if callbackStops != 0 {
+		t.Fatalf("capture callback stop count = %d, want 0", callbackStops)
 	}
 }
 
@@ -258,30 +514,12 @@ func TestMeasureWithLoudnormLoopErrorFreesGraphBeforeStoppingCapture(t *testing.
 	})
 	defer cleanupTestAudio(t, testFile)
 
-	var (
-		mu    sync.Mutex
-		order []string
-	)
-	record := func(value string) {
-		mu.Lock()
-		defer mu.Unlock()
-		order = append(order, value)
-	}
-
-	replaceLoudnormLogOps(t,
-		func() (int, error) { return 7, nil },
-		func(int) {},
-		func(callback ffmpeg.LogCallback) {
-			if callback == nil {
-				record("stop")
-			}
-		},
-	)
+	recorder := installLoudnormCleanupRecorder(t)
 
 	oldFree := loudnormAVFilterGraphFree
 	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
-		record("free")
-		loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+		recorder.recordFree()
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, "{not-json}")
 		oldFree(graph)
 	}
 	t.Cleanup(func() {
@@ -308,10 +546,206 @@ func TestMeasureWithLoudnormLoopErrorFreesGraphBeforeStoppingCapture(t *testing.
 	if !strings.Contains(err.Error(), "loudnorm measurement loop failed") {
 		t.Fatalf("measureWithLoudnorm() error = %q, want measurement loop context", err.Error())
 	}
+	if strings.Contains(err.Error(), "failed to capture loudnorm measurements") {
+		t.Fatalf("measureWithLoudnorm() error = %q, want loop error precedence over capture error", err.Error())
+	}
 
-	gotOrder := strings.Join(order, ",")
-	if gotOrder != "free,stop" {
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	if recorder.freeCount() != 1 {
+		t.Fatalf("graph free count = %d, want 1", recorder.freeCount())
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestMeasureWithLoudnormSuccessfulLoopRequiresCapturedJSON(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, false)
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	if err == nil {
+		t.Fatal("measureWithLoudnorm() error = nil, want missing JSON error")
+	}
+	if !strings.Contains(err.Error(), "failed to capture loudnorm measurements") {
+		t.Fatalf("measureWithLoudnorm() error = %q, want capture context", err.Error())
+	}
+	if !strings.Contains(err.Error(), "no JSON found in loudnorm output") {
+		t.Fatalf("measureWithLoudnorm() error = %q, want missing JSON context", err.Error())
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestMeasureWithLoudnormSuccessfulLoopRejectsMalformedJSON(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		recorder.recordFree()
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, "{not-json}")
+		oldFree(graph)
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	if err == nil {
+		t.Fatal("measureWithLoudnorm() error = nil, want malformed JSON error")
+	}
+	if !strings.Contains(err.Error(), "failed to capture loudnorm measurements") {
+		t.Fatalf("measureWithLoudnorm() error = %q, want capture context", err.Error())
+	}
+	if !strings.Contains(err.Error(), "failed to parse loudnorm JSON") {
+		t.Fatalf("measureWithLoudnorm() error = %q, want malformed JSON context", err.Error())
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestMeasureWithLoudnormSuccessfulLoopParsesCapturedJSON(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	measurement, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	if err != nil {
+		t.Fatalf("measureWithLoudnorm() error = %v", err)
+	}
+	if measurement.InputI != -23.0 {
+		t.Fatalf("measurement.InputI = %.1f, want -23.0", measurement.InputI)
+	}
+	if measurement.InputTP != -4.0 {
+		t.Fatalf("measurement.InputTP = %.1f, want -4.0", measurement.InputTP)
+	}
+	if measurement.InputLRA != 5.0 {
+		t.Fatalf("measurement.InputLRA = %.1f, want 5.0", measurement.InputLRA)
+	}
+	if measurement.InputThresh != -33.0 {
+		t.Fatalf("measurement.InputThresh = %.1f, want -33.0", measurement.InputThresh)
+	}
+	if measurement.TargetOffset != 0.0 {
+		t.Fatalf("measurement.TargetOffset = %.1f, want 0.0", measurement.TargetOffset)
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestMeasureWithLoudnormSuccessfulLoopRejectsInvalidNumericField(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		recorder.recordFree()
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, strings.Replace(loudnormCaptureTestJSON, `"input_i":"-23.0"`, `"input_i":"not-a-number"`, 1))
+		oldFree(graph)
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	if err == nil {
+		t.Fatal("measureWithLoudnorm() error = nil, want invalid numeric field error")
+	}
+	if !strings.Contains(err.Error(), `invalid loudnorm input_i value "not-a-number"`) {
+		t.Fatalf("measureWithLoudnorm() error = %q, want input_i parse context", err.Error())
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
+func TestMeasureWithLoudnormGeneratedAudioCapturesGraphFinalisationJSON(t *testing.T) {
+	testFile := generateTestAudio(t, TestAudioOptions{
+		DurationSecs: 0.5,
+		SampleRate:   44100,
+		ToneFreq:     440.0,
+		ToneLevel:    -18.0,
+		Dir:          t.TempDir(),
+	})
+	t.Cleanup(func() {
+		cleanupTestAudio(t, testFile)
+	})
+
+	measurement, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	if err != nil {
+		t.Fatalf("measureWithLoudnorm() error = %v", err)
+	}
+	if measurement == nil {
+		t.Fatal("measureWithLoudnorm() measurement = nil, want captured loudnorm measurement")
+	}
+
+	values := map[string]float64{
+		"InputI":       measurement.InputI,
+		"InputTP":      measurement.InputTP,
+		"InputLRA":     measurement.InputLRA,
+		"InputThresh":  measurement.InputThresh,
+		"TargetOffset": measurement.TargetOffset,
+	}
+	for name, value := range values {
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			t.Fatalf("measurement.%s = %v, want finite value from graph-finalisation JSON", name, value)
+		}
 	}
 }
 
@@ -322,10 +756,10 @@ type loudnormCleanupRecorder struct {
 	stops  int
 }
 
-func (r *loudnormCleanupRecorder) record(value string) {
+func (r *loudnormCleanupRecorder) recordFree() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.order = append(r.order, value)
+	r.order = append(r.order, "free")
 }
 
 func (r *loudnormCleanupRecorder) recordLevel(level int) {
@@ -408,7 +842,7 @@ func replaceApplyLoudnormGraphFree(t *testing.T, recorder *loudnormCleanupRecord
 
 	oldFree := loudnormAVFilterGraphFree
 	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
-		recorder.record("free")
+		recorder.recordFree()
 		if emitJSON {
 			loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
 		}
@@ -458,22 +892,34 @@ func replaceApplyLoudnormRename(t *testing.T, rename func(string, string) error)
 }
 
 type loudnormTestEncoder struct {
-	flushErr error
-	closeErr error
-	closed   bool
-	closeN   int
+	writeFrame func(*ffmpeg.AVFrame) error
+	flush      func() error
+	close      func() error
+	flushErr   error
+	closeErr   error
+	closed     bool
+	closeN     int
 }
 
-func (e *loudnormTestEncoder) WriteFrame(*ffmpeg.AVFrame) error {
+func (e *loudnormTestEncoder) WriteFrame(frame *ffmpeg.AVFrame) error {
+	if e.writeFrame != nil {
+		return e.writeFrame(frame)
+	}
 	return nil
 }
 
 func (e *loudnormTestEncoder) Flush() error {
+	if e.flush != nil {
+		return e.flush()
+	}
 	return e.flushErr
 }
 
 func (e *loudnormTestEncoder) Close() error {
 	e.closeN++
+	if e.close != nil {
+		return e.close()
+	}
 	if e.closed {
 		return nil
 	}
@@ -569,7 +1015,7 @@ func applyLoudnormTest(
 	)
 }
 
-func TestApplyLoudnormAndMeasureStopsCaptureOnOpenError(t *testing.T) {
+func TestApplyLoudnormAndMeasureDoesNotStartCaptureOnOpenError(t *testing.T) {
 	recorder := installLoudnormCleanupRecorder(t)
 	replaceApplyLoudnormGraphFree(t, recorder, false)
 
@@ -583,10 +1029,12 @@ func TestApplyLoudnormAndMeasureStopsCaptureOnOpenError(t *testing.T) {
 	if recorder.freeCount() != 0 {
 		t.Fatalf("graph free count = %d, want 0", recorder.freeCount())
 	}
-	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if recorder.stopCount() != 0 {
+		t.Fatalf("capture stop count = %d, want 0", recorder.stopCount())
+	}
 }
 
-func TestApplyLoudnormAndMeasureSetupErrorStopsCaptureWithoutFree(t *testing.T) {
+func TestApplyLoudnormAndMeasureSetupErrorDoesNotStartCaptureOrFreeGraph(t *testing.T) {
 	testFile := generateLoudnormApplicationTestAudio(t)
 	recorder := installLoudnormCleanupRecorder(t)
 	replaceApplyLoudnormGraphFree(t, recorder, false)
@@ -609,7 +1057,9 @@ func TestApplyLoudnormAndMeasureSetupErrorStopsCaptureWithoutFree(t *testing.T) 
 	if recorder.freeCount() != 0 {
 		t.Fatalf("graph free count = %d, want 0", recorder.freeCount())
 	}
-	requireLoudnormCaptureStoppedOnce(t, recorder)
+	if recorder.stopCount() != 0 {
+		t.Fatalf("capture stop count = %d, want 0", recorder.stopCount())
+	}
 	requireNoLoudnormTempFiles(t, testFile)
 }
 
@@ -901,6 +1351,229 @@ func TestApplyLoudnormAndMeasureSuccessFreesGraphBeforeStoppingCapture(t *testin
 	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
 		t.Fatalf("temp file stat error = %v, want not exist after successful rename", err)
 	}
+	requireNoLoudnormTempFiles(t, testFile)
+}
+
+func TestApplyLoudnormAndMeasureEncodingAndPublishRunOutsideCapture(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+
+	var (
+		mu               sync.Mutex
+		captureActive    bool
+		callbackStarts   int
+		opsDuringCapture []string
+		encoderPath      string
+		renameOldPath    string
+		renameNewPath    string
+	)
+	recordOperation := func(name string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if captureActive {
+			opsDuringCapture = append(opsDuringCapture, name)
+		}
+	}
+	callbackStartCount := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return callbackStarts
+	}
+	operationsDuringCapture := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), opsDuringCapture...)
+	}
+
+	replaceLoudnormLogOps(t,
+		func() (int, error) { return 7, nil },
+		func(int) {},
+		func(callback ffmpeg.LogCallback) {
+			mu.Lock()
+			defer mu.Unlock()
+			if callback == nil {
+				captureActive = false
+				return
+			}
+			captureActive = true
+			callbackStarts++
+		},
+	)
+
+	graphFinalisationEntered := make(chan struct{})
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		recordOperation("graph-free")
+		close(graphFinalisationEntered)
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+		oldFree(graph)
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+
+	flushEntered := make(chan struct{})
+	releaseFlush := make(chan struct{})
+	encoder := &loudnormTestEncoder{
+		writeFrame: func(*ffmpeg.AVFrame) error {
+			recordOperation("write-frame")
+			return nil
+		},
+		flush: func() error {
+			recordOperation("flush")
+			close(flushEntered)
+			<-releaseFlush
+			return nil
+		},
+		close: func() error {
+			recordOperation("close")
+			return nil
+		},
+	}
+	replaceApplyLoudnormCreateEncoder(t, func(
+		outputPath string,
+		_ *audio.Metadata,
+		_ *ffmpeg.AVFilterContext,
+	) (loudnormOutputEncoder, error) {
+		mu.Lock()
+		encoderPath = outputPath
+		mu.Unlock()
+		recordOperation("create-encoder")
+		return encoder, nil
+	})
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = func(
+		reader *audio.Reader,
+		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		frame := ffmpeg.AVFrameAlloc()
+		defer ffmpeg.AVFrameFree(&frame)
+		return config.OnFrame(nil, frame)
+	}
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+
+	replaceApplyLoudnormRename(t, func(oldPath, newPath string) error {
+		mu.Lock()
+		renameOldPath = oldPath
+		renameNewPath = newPath
+		mu.Unlock()
+		recordOperation("rename")
+		return os.Rename(oldPath, newPath)
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+		done <- err
+	}()
+
+	select {
+	case <-flushEntered:
+	case <-time.After(time.Second):
+		t.Fatal("flush did not start")
+	}
+	if got := callbackStartCount(); got != 0 {
+		t.Fatalf("capture callback install count while flush blocked = %d, want 0", got)
+	}
+
+	close(releaseFlush)
+
+	select {
+	case <-graphFinalisationEntered:
+	case <-time.After(time.Second):
+		t.Fatal("graph finalisation did not start")
+	}
+	if got := callbackStartCount(); got != 1 {
+		t.Fatalf("capture callback install count after graph finalisation starts = %d, want 1", got)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("applyLoudnormAndMeasure() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("applyLoudnormAndMeasure() did not complete")
+	}
+
+	if got := operationsDuringCapture(); strings.Join(got, ",") != "graph-free" {
+		t.Fatalf("operations during capture = %v, want [graph-free]", got)
+	}
+
+	mu.Lock()
+	gotEncoderPath := encoderPath
+	gotRenameOldPath := renameOldPath
+	gotRenameNewPath := renameNewPath
+	mu.Unlock()
+	requireLoudnormTempPath(t, testFile, gotEncoderPath)
+	requireLoudnormTempPath(t, testFile, gotRenameOldPath)
+	if gotRenameNewPath != testFile {
+		t.Fatalf("rename target = %q, want %q", gotRenameNewPath, testFile)
+	}
+}
+
+func TestApplyLoudnormAndMeasureMissingPass4JSONReturnsNilStatsWithoutError(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, false)
+	replaceApplyLoudnormRename(t, func(oldPath, newPath string) error {
+		requireLoudnormTempPath(t, testFile, oldPath)
+		return os.Rename(oldPath, newPath)
+	})
+
+	_, _, finalMeasurements, stats, _, err := applyLoudnormTest(t, testFile)
+	if err != nil {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v", err)
+	}
+	if stats != nil {
+		t.Fatalf("loudnorm stats = %+v, want nil", stats)
+	}
+	if finalMeasurements == nil {
+		t.Fatal("final measurements = nil, want measurements")
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+	requireNoLoudnormTempFiles(t, testFile)
+}
+
+func TestApplyLoudnormAndMeasureMalformedPass4JSONReturnsNilStatsWithoutError(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		recorder.recordFree()
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, "{not-json}")
+		oldFree(graph)
+	}
+	t.Cleanup(func() {
+		loudnormAVFilterGraphFree = oldFree
+	})
+
+	replaceApplyLoudnormRename(t, func(oldPath, newPath string) error {
+		requireLoudnormTempPath(t, testFile, oldPath)
+		return os.Rename(oldPath, newPath)
+	})
+
+	_, _, finalMeasurements, stats, _, err := applyLoudnormTest(t, testFile)
+	if err != nil {
+		t.Fatalf("applyLoudnormAndMeasure() error = %v", err)
+	}
+	if stats != nil {
+		t.Fatalf("loudnorm stats = %+v, want nil", stats)
+	}
+	if finalMeasurements == nil {
+		t.Fatal("final measurements = nil, want measurements")
+	}
+	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
+		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
+	}
+	requireLoudnormCaptureStoppedOnce(t, recorder)
 	requireNoLoudnormTempFiles(t, testFile)
 }
 


### PR DESCRIPTION
- Capture loudnorm JSON only while freeing the filter graph, where FFmpeg emits it.
- Avoid starting process-global log capture until graph teardown in Pass 3 and Pass 4.
- Tighten error handling so setup, loop, and encoder failures do not start capture.
- Expand tests for malformed JSON, missing JSON, serialised capture, and clean-up order.