### PR TITLE
refactor(processor): nest spectral metrics under shared model

### DIFF
--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -194,17 +194,17 @@ func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMea
 func writeAnalysisSpectralSummary(w io.Writer, measurements *processor.AudioMeasurements) {
 	writeAnalysisSection(w, "SPECTRAL SUMMARY")
 	writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
-		{"Centroid", fmt.Sprintf("%.0f Hz (%s)", measurements.SpectralCentroid, interpretCentroid(measurements.SpectralCentroid))},
-		{"Spread", fmt.Sprintf("%.0f Hz (%s)", measurements.SpectralSpread, interpretSpread(measurements.SpectralSpread))},
-		{"Rolloff", fmt.Sprintf("%.0f Hz (%s)", measurements.SpectralRolloff, interpretRolloff(measurements.SpectralRolloff))},
-		{"Flatness", fmt.Sprintf("%.3f (%s)", measurements.SpectralFlatness, interpretFlatness(measurements.SpectralFlatness))},
-		{"Kurtosis", fmt.Sprintf("%.1f (%s)", measurements.SpectralKurtosis, interpretKurtosis(measurements.SpectralKurtosis))},
-		{"Skewness", fmt.Sprintf("%.2f (%s)", measurements.SpectralSkewness, interpretSkewness(measurements.SpectralSkewness))},
-		{"Crest", fmt.Sprintf("%.1f (%s)", measurements.SpectralCrest, interpretCrest(measurements.SpectralCrest))},
-		{"Slope", fmt.Sprintf("%.2e (%s)", measurements.SpectralSlope, interpretSlope(measurements.SpectralSlope))},
-		{"Decrease", fmt.Sprintf("%.4f (%s)", measurements.SpectralDecrease, interpretDecrease(measurements.SpectralDecrease))},
-		{"Entropy", fmt.Sprintf("%.3f (%s)", measurements.SpectralEntropy, interpretEntropy(measurements.SpectralEntropy))},
-		{"Flux", fmt.Sprintf("%.4f (%s)", measurements.SpectralFlux, interpretFlux(measurements.SpectralFlux))},
+		{"Centroid", fmt.Sprintf("%.0f Hz (%s)", measurements.Spectral.Centroid, interpretCentroid(measurements.Spectral.Centroid))},
+		{"Spread", fmt.Sprintf("%.0f Hz (%s)", measurements.Spectral.Spread, interpretSpread(measurements.Spectral.Spread))},
+		{"Rolloff", fmt.Sprintf("%.0f Hz (%s)", measurements.Spectral.Rolloff, interpretRolloff(measurements.Spectral.Rolloff))},
+		{"Flatness", fmt.Sprintf("%.3f (%s)", measurements.Spectral.Flatness, interpretFlatness(measurements.Spectral.Flatness))},
+		{"Kurtosis", fmt.Sprintf("%.1f (%s)", measurements.Spectral.Kurtosis, interpretKurtosis(measurements.Spectral.Kurtosis))},
+		{"Skewness", fmt.Sprintf("%.2f (%s)", measurements.Spectral.Skewness, interpretSkewness(measurements.Spectral.Skewness))},
+		{"Crest", fmt.Sprintf("%.1f (%s)", measurements.Spectral.Crest, interpretCrest(measurements.Spectral.Crest))},
+		{"Slope", fmt.Sprintf("%.2e (%s)", measurements.Spectral.Slope, interpretSlope(measurements.Spectral.Slope))},
+		{"Decrease", fmt.Sprintf("%.4f (%s)", measurements.Spectral.Decrease, interpretDecrease(measurements.Spectral.Decrease))},
+		{"Entropy", fmt.Sprintf("%.3f (%s)", measurements.Spectral.Entropy, interpretEntropy(measurements.Spectral.Entropy))},
+		{"Flux", fmt.Sprintf("%.4f (%s)", measurements.Spectral.Flux, interpretFlux(measurements.Spectral.Flux))},
 	})
 }
 

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -50,17 +50,17 @@ func makeFullAnalysisMeasurements() *processor.AudioMeasurements {
 	m.NoiseFloorSource = "silence_profile"
 	m.SuggestedGateThreshold = processor.DbToLinear(-52.4)
 	m.NoiseReductionHeadroom = 24.6
-	m.SpectralCentroid = 2450
-	m.SpectralSpread = 1800
-	m.SpectralRolloff = 7200
-	m.SpectralFlatness = 0.210
-	m.SpectralKurtosis = 9.7
-	m.SpectralSkewness = 0.82
-	m.SpectralCrest = 12.6
-	m.SpectralSlope = -1.20e-03
-	m.SpectralDecrease = -0.0123
-	m.SpectralEntropy = 0.365
-	m.SpectralFlux = 0.0820
+	m.Spectral.Centroid = 2450
+	m.Spectral.Spread = 1800
+	m.Spectral.Rolloff = 7200
+	m.Spectral.Flatness = 0.210
+	m.Spectral.Kurtosis = 9.7
+	m.Spectral.Skewness = 0.82
+	m.Spectral.Crest = 12.6
+	m.Spectral.Slope = -1.20e-03
+	m.Spectral.Decrease = -0.0123
+	m.Spectral.Entropy = 0.365
+	m.Spectral.Flux = 0.0820
 	m.NoiseProfile = &processor.NoiseProfile{
 		Start:              6 * time.Second,
 		Duration:           4 * time.Second,

--- a/internal/logging/recording_tips.go
+++ b/internal/logging/recording_tips.go
@@ -310,8 +310,8 @@ func tipTooFarFromMic(m *processor.AudioMeasurements, _ *processor.EffectiveFilt
 // spectralDecreaseWarm = -0.05. Skewness > 2.5 is tip-specific (stricter
 // than adaptive.go's spectralSkewnessLFEmphasis = 1.0).
 func tipProximityEffect(m *processor.AudioMeasurements, _ *processor.EffectiveFilterConfig) *RecordingTip {
-	decrease := m.SpectralDecrease
-	skewness := m.SpectralSkewness
+	decrease := m.Spectral.Decrease
+	skewness := m.Spectral.Skewness
 	if m.SpeechProfile != nil {
 		decrease = m.SpeechProfile.Spectral.Decrease
 		skewness = m.SpeechProfile.Spectral.Skewness
@@ -340,8 +340,8 @@ func tipSibilance(m *processor.AudioMeasurements, config *processor.EffectiveFil
 		return nil
 	}
 
-	centroid := m.SpectralCentroid
-	rolloff := m.SpectralRolloff
+	centroid := m.Spectral.Centroid
+	rolloff := m.Spectral.Rolloff
 	if m.SpeechProfile != nil {
 		if m.SpeechProfile.Spectral.Centroid > 0 {
 			centroid = m.SpeechProfile.Spectral.Centroid

--- a/internal/logging/recording_tips_test.go
+++ b/internal/logging/recording_tips_test.go
@@ -568,8 +568,8 @@ func TestTipProximityEffect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &processor.AudioMeasurements{}
-			m.SpectralDecrease = tt.spectralDecrease
-			m.SpectralSkewness = tt.spectralSkewness
+			m.Spectral.Decrease = tt.spectralDecrease
+			m.Spectral.Skewness = tt.spectralSkewness
 			m.SpeechProfile = tt.speechProfile
 			tip := tipProximityEffect(m, nil)
 			if (tip != nil) != tt.wantTip {
@@ -657,8 +657,8 @@ func TestTipSibilance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &processor.AudioMeasurements{}
-			m.SpectralCentroid = tt.centroid
-			m.SpectralRolloff = tt.rolloff
+			m.Spectral.Centroid = tt.centroid
+			m.Spectral.Rolloff = tt.rolloff
 			m.SpeechProfile = tt.speechProfile
 			tip := tipSibilance(m, tt.config)
 			if (tip != nil) != tt.wantTip {
@@ -895,7 +895,7 @@ func TestGenerateRecordingTips(t *testing.T) {
 				m.InputTP = 0.5
 				m.AstatsNoiseFloor = -42.0
 				m.NoiseReductionHeadroom = 8.0
-				m.SpectralDecrease = -0.15
+				m.Spectral.Decrease = -0.15
 				m.InputLRA = 20.0
 				m.CrestFactor = 4.0
 				return m
@@ -912,8 +912,8 @@ func TestGenerateRecordingTips(t *testing.T) {
 				m.AstatsNoiseFloor = -70.0
 				m.CrestFactor = 12.0
 				m.NoiseReductionHeadroom = 25.0
-				m.SpectralDecrease = -0.02
-				m.SpectralSkewness = 0.5
+				m.Spectral.Decrease = -0.02
+				m.Spectral.Skewness = 0.5
 				return m
 			}(),
 			wantEmpty: true,
@@ -928,8 +928,8 @@ func TestGenerateRecordingTips(t *testing.T) {
 				m.AstatsNoiseFloor = -70.0
 				m.CrestFactor = 12.0
 				m.NoiseReductionHeadroom = 25.0
-				m.SpectralCentroid = 4500.0
-				m.SpectralRolloff = 11000.0
+				m.Spectral.Centroid = 4500.0
+				m.Spectral.Rolloff = 11000.0
 				return m
 			}(),
 			config:      &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
@@ -967,7 +967,7 @@ func TestGenerateRecordingTips(t *testing.T) {
 				m.InputTP = 0.5
 				m.AstatsNoiseFloor = -42.0
 				m.NoiseReductionHeadroom = 8.0
-				m.SpectralDecrease = -0.15
+				m.Spectral.Decrease = -0.15
 				m.InputLRA = 20.0
 				m.CrestFactor = 4.0
 				m.NoiseProfile = &processor.NoiseProfile{

--- a/internal/logging/report_filters.go
+++ b/internal/logging/report_filters.go
@@ -87,21 +87,21 @@ func formatDS201HighpassFilter(f *os.File, cfg *processor.EffectiveFilterConfig,
 	fmt.Fprintln(f, header)
 
 	// Show adaptive rationale
-	if m != nil && m.SpectralCentroid > 0 {
+	if m != nil && m.Spectral.Centroid > 0 {
 		voiceType := "normal"
-		if m.SpectralCentroid > 6000 {
+		if m.Spectral.Centroid > 6000 {
 			voiceType = "bright"
-		} else if m.SpectralCentroid < 4000 {
+		} else if m.Spectral.Centroid < 4000 {
 			voiceType = "dark/warm"
 		}
-		fmt.Fprintf(f, "        Rationale: %s voice (centroid %.0f Hz)\n", voiceType, m.SpectralCentroid)
+		fmt.Fprintf(f, "        Rationale: %s voice (centroid %.0f Hz)\n", voiceType, m.Spectral.Centroid)
 
 		// Show warm voice protection if applicable (using mix)
 		if cfg.DS201HPMix > 0 && cfg.DS201HPMix < 1.0 {
 			reason := "warm voice"
-			if m.SpectralDecrease < -0.08 {
+			if m.Spectral.Decrease < -0.08 {
 				reason = "very warm voice"
-			} else if m.SpectralSkewness > 1.0 {
+			} else if m.Spectral.Skewness > 1.0 {
 				reason = "LF emphasis"
 			}
 			fmt.Fprintf(f, "        Mix: %.0f%% (%s — blending filtered with dry signal)\n", cfg.DS201HPMix*100, reason)
@@ -172,7 +172,7 @@ func formatDS201LowPassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, 
 			contentType = diagnostics.DS201LPContentType
 		}
 		fmt.Fprintf(f, "        Content type: %s (kurtosis %.1f, flatness %.3f, flux %.4f)\n",
-			contentType.String(), m.SpectralKurtosis, m.SpectralFlatness, m.SpectralFlux)
+			contentType.String(), m.Spectral.Kurtosis, m.Spectral.Flatness, m.Spectral.Flux)
 
 		// Show the triggering metric details
 		lpReason := ""
@@ -184,12 +184,12 @@ func formatDS201LowPassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, 
 		switch lpReason {
 		case "rolloff/centroid gap":
 			fmt.Fprintf(f, "        Rolloff/centroid ratio: %.2f > 2.5 (rolloff %.0f Hz, centroid %.0f Hz)\n",
-				rolloffRatio, m.SpectralRolloff, m.SpectralCentroid)
+				rolloffRatio, m.Spectral.Rolloff, m.Spectral.Centroid)
 		case "flat spectral slope":
-			fmt.Fprintf(f, "        Spectral slope: %.2e > -1e-05 (unusual HF emphasis)\n", m.SpectralSlope)
+			fmt.Fprintf(f, "        Spectral slope: %.2e > -1e-05 (unusual HF emphasis)\n", m.Spectral.Slope)
 		case "high ZCR with low centroid":
 			fmt.Fprintf(f, "        ZCR: %.4f > 0.10, centroid %.0f Hz < 4000 Hz (HF noise pattern)\n",
-				m.ZeroCrossingsRate, m.SpectralCentroid)
+				m.ZeroCrossingsRate, m.Spectral.Centroid)
 		}
 	}
 }
@@ -353,8 +353,8 @@ func formatLA2ACompressorFilter(f *os.File, cfg *processor.EffectiveFilterConfig
 		fmt.Fprintf(f, "        Rationale: DR %.1f dB (%s), LRA %.1f LU\n", m.DynamicRange, dynamicsType, m.InputLRA)
 
 		// Show kurtosis and flux with sources (used for ratio and release tuning)
-		kurtosis := m.SpectralKurtosis
-		flux := m.SpectralFlux
+		kurtosis := m.Spectral.Kurtosis
+		flux := m.Spectral.Flux
 		kurtosisSource := "full-file"
 		fluxSource := "full-file"
 		if m.SpeechProfile != nil {
@@ -411,10 +411,10 @@ func formatDeesserFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *pr
 		prefix, cfg.DeessIntensity*100, cfg.DeessAmount*100, cfg.DeessFreq*100)
 
 	// Show rationale with measurement source
-	if m != nil && m.SpectralCentroid > 0 {
+	if m != nil && m.Spectral.Centroid > 0 {
 		// Determine which values were used and their sources
-		centroid := m.SpectralCentroid
-		rolloff := m.SpectralRolloff
+		centroid := m.Spectral.Centroid
+		rolloff := m.Spectral.Rolloff
 		centroidSource := "full-file"
 		rolloffSource := "full-file"
 		if m.SpeechProfile != nil {

--- a/internal/logging/report_metrics.go
+++ b/internal/logging/report_metrics.go
@@ -27,6 +27,65 @@ type threeColMetricSpec struct {
 	interpret   func(float64) string // optional interpretation of final value; nil = no interpretation
 }
 
+type spectralMetricDescriptor struct {
+	name        string
+	label       string
+	decimals    int
+	unit        string
+	gainScaling int
+	value       func(processor.SpectralMetrics) float64
+	interpret   func(float64) string
+}
+
+var spectralMetricDescriptors = []spectralMetricDescriptor{
+	{"mean", "Spectral Mean", 6, "", 1, func(m processor.SpectralMetrics) float64 { return m.Mean }, nil},
+	{"variance", "Spectral Variance", 6, "", 2, func(m processor.SpectralMetrics) float64 { return m.Variance }, nil},
+	{"centroid", "Spectral Centroid", 0, "Hz", 0, func(m processor.SpectralMetrics) float64 { return m.Centroid }, interpretCentroid},
+	{"spread", "Spectral Spread", 0, "Hz", 0, func(m processor.SpectralMetrics) float64 { return m.Spread }, interpretSpread},
+	{"skewness", "Spectral Skewness", 3, "", 0, func(m processor.SpectralMetrics) float64 { return m.Skewness }, interpretSkewness},
+	{"kurtosis", "Spectral Kurtosis", 3, "", 0, func(m processor.SpectralMetrics) float64 { return m.Kurtosis }, interpretKurtosis},
+	{"entropy", "Spectral Entropy", 6, "", 0, func(m processor.SpectralMetrics) float64 { return m.Entropy }, interpretEntropy},
+	{"flatness", "Spectral Flatness", 6, "", 0, func(m processor.SpectralMetrics) float64 { return m.Flatness }, interpretFlatness},
+	{"crest", "Spectral Crest", 3, "", 0, func(m processor.SpectralMetrics) float64 { return m.Crest }, interpretCrest},
+	{"flux", "Spectral Flux", 6, "", 2, func(m processor.SpectralMetrics) float64 { return m.Flux }, interpretFlux},
+	{"slope", "Spectral Slope", 9, "", 1, func(m processor.SpectralMetrics) float64 { return m.Slope }, interpretSlope},
+	{"decrease", "Spectral Decrease", 6, "", 0, func(m processor.SpectralMetrics) float64 { return m.Decrease }, interpretDecrease},
+	{"rolloff", "Spectral Rolloff", 0, "Hz", 0, func(m processor.SpectralMetrics) float64 { return m.Rolloff }, interpretRolloff},
+}
+
+func buildSpectralMetricRows(values func(spectralMetricDescriptor) [3]float64, includeInterpretations bool) []threeColMetricSpec {
+	specs := make([]threeColMetricSpec, 0, len(spectralMetricDescriptors))
+	for _, d := range spectralMetricDescriptors {
+		interpret := d.interpret
+		if !includeInterpretations {
+			interpret = nil
+		}
+		specs = append(specs, threeColMetricSpec{
+			label:       d.label,
+			vals:        values(d),
+			decimals:    d.decimals,
+			unit:        d.unit,
+			gainScaling: d.gainScaling,
+			interpret:   interpret,
+		})
+	}
+	return specs
+}
+
+func silenceSpectralValueOr(src *processor.SilenceCandidateMetrics, descriptor spectralMetricDescriptor) float64 {
+	if src == nil {
+		return math.NaN()
+	}
+	return descriptor.value(src.Spectral)
+}
+
+func speechSpectralValueOr(src *processor.SpeechCandidateMetrics, descriptor spectralMetricDescriptor) float64 {
+	if src == nil {
+		return math.NaN()
+	}
+	return descriptor.value(src.Spectral)
+}
+
 // noiseFloorFormatter identifies which formatter to use for each value column
 // in the noise-floor table. Spectral metrics use formatMetricSpectral
 // (showing "n/a" for digital silence); loudness metrics use specialised
@@ -340,21 +399,16 @@ func writeNoiseFloorTable(f *os.File, inputMeasurements *processor.AudioMeasurem
 		}
 	}
 
-	addNoiseFloorMetricRows(table, []threeColMetricSpec{
-		{"Spectral Mean", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Mean }), 6, "", 1, nil},
-		{"Spectral Variance", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Variance }), 6, "", 2, nil},
-		{"Spectral Centroid", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Centroid }), 0, "Hz", 0, nil},
-		{"Spectral Spread", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Spread }), 0, "Hz", 0, nil},
-		{"Spectral Skewness", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Skewness }), 3, "", 0, nil},
-		{"Spectral Kurtosis", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Kurtosis }), 3, "", 0, nil},
-		{"Spectral Entropy", [3]float64{inputEntropy, filteredEntropy, finalEntropy}, 6, "", 0, nil},
-		{"Spectral Flatness", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Flatness }), 6, "", 0, nil},
-		{"Spectral Crest", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Crest }), 3, "", 0, nil},
-		{"Spectral Flux", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Flux }), 6, "", 2, nil},
-		{"Spectral Slope", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Slope }), 9, "", 1, nil},
-		{"Spectral Decrease", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Decrease }), 6, "", 0, nil},
-		{"Spectral Rolloff", v(func(m *processor.SilenceCandidateMetrics) float64 { return m.Spectral.Rolloff }), 0, "Hz", 0, nil},
-	}, nfFmtSpectral, gainNormalise, effectiveGainDB, filteredIsDigitalSilence, finalIsDigitalSilence)
+	addNoiseFloorMetricRows(table, buildSpectralMetricRows(func(d spectralMetricDescriptor) [3]float64 {
+		if d.name == "entropy" {
+			return [3]float64{inputEntropy, filteredEntropy, finalEntropy}
+		}
+		return [3]float64{
+			silenceSpectralValueOr(inputNoise, d),
+			silenceSpectralValueOr(filteredNoise, d),
+			silenceSpectralValueOr(finalNoise, d),
+		}
+	}, false), nfFmtSpectral, gainNormalise, effectiveGainDB, filteredIsDigitalSilence, finalIsDigitalSilence)
 
 	// ========== LOUDNESS METRICS ==========
 
@@ -497,21 +551,20 @@ func writeSpeechRegionTable(f *os.File, inputMeasurements *processor.AudioMeasur
 		}
 	}
 
-	addSpeechMetricRows(table, []threeColMetricSpec{
-		{"Spectral Mean", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Mean }), 6, "", 1, nil},
-		{"Spectral Variance", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Variance }), 6, "", 2, nil},
-		{"Spectral Centroid", [3]float64{inputCentroid, filteredCentroid, finalCentroid}, 0, "Hz", 0, interpretCentroid},
-		{"Spectral Spread", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Spread }), 0, "Hz", 0, interpretSpread},
-		{"Spectral Skewness", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Skewness }), 3, "", 0, interpretSkewness},
-		{"Spectral Kurtosis", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Kurtosis }), 3, "", 0, interpretKurtosis},
-		{"Spectral Entropy", [3]float64{inputEntropy, filteredEntropy, finalEntropy}, 6, "", 0, interpretEntropy},
-		{"Spectral Flatness", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Flatness }), 6, "", 0, interpretFlatness},
-		{"Spectral Crest", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Crest }), 3, "", 0, interpretCrest},
-		{"Spectral Flux", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Flux }), 6, "", 2, interpretFlux},
-		{"Spectral Slope", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Slope }), 9, "", 1, interpretSlope},
-		{"Spectral Decrease", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Decrease }), 6, "", 0, interpretDecrease},
-		{"Spectral Rolloff", sv(func(m *processor.SpeechCandidateMetrics) float64 { return m.Spectral.Rolloff }), 0, "Hz", 0, interpretRolloff},
-	}, gainNormalise, effectiveGainDB)
+	addSpeechMetricRows(table, buildSpectralMetricRows(func(d spectralMetricDescriptor) [3]float64 {
+		switch d.name {
+		case "centroid":
+			return [3]float64{inputCentroid, filteredCentroid, finalCentroid}
+		case "entropy":
+			return [3]float64{inputEntropy, filteredEntropy, finalEntropy}
+		default:
+			return [3]float64{
+				speechSpectralValueOr(inputSpeech, d),
+				speechSpectralValueOr(filteredSpeech, d),
+				speechSpectralValueOr(finalSpeech, d),
+			}
+		}
+	}, true), gainNormalise, effectiveGainDB)
 
 	// ========== LOUDNESS METRICS ==========
 

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -70,11 +70,7 @@ func makeInputMeasurements() *processor.AudioMeasurements {
 
 	return &processor.AudioMeasurements{
 		BaseMeasurements: processor.BaseMeasurements{
-			SpectralCentroid:  2200,
-			SpectralKurtosis:  7.2,
-			SpectralFlatness:  0.18,
-			SpectralFlux:      0.004,
-			DynamicRange:      22.0,
+			Spectral: processor.SpectralMetrics{Centroid: 2200, Kurtosis: 7.2, Flatness: 0.18, Flux: 0.004}, DynamicRange: 22.0,
 			MomentaryLoudness: -25.0,
 			ShortTermLoudness: -24.5,
 			SamplePeak:        -4.0,
@@ -236,6 +232,34 @@ func TestGenerateReport_AudioMetricTables(t *testing.T) {
 	}
 }
 
+func TestGenerateReport_SpectralRowCounts(t *testing.T) {
+	output := generateReportText(t, makeReportData(t))
+
+	sections := []struct {
+		name      string
+		title     string
+		nextTitle string
+	}{
+		{"noise_floor", "Noise Floor Analysis", "Speech Region Analysis"},
+		{"speech", "Speech Region Analysis", ""},
+	}
+
+	if got := len(spectralMetricDescriptors); got != 13 {
+		t.Fatalf("spectral metric descriptor count = %d, want 13", got)
+	}
+
+	for _, section := range sections {
+		t.Run(section.name, func(t *testing.T) {
+			text := reportSection(t, output, section.title, section.nextTitle)
+			for _, descriptor := range spectralMetricDescriptors {
+				if count := strings.Count(text, descriptor.label); count != 1 {
+					t.Errorf("%s row count in %s section = %d, want 1", descriptor.label, section.title, count)
+				}
+			}
+		})
+	}
+}
+
 func TestGenerateReport_FilterChainUsesProcessingDiagnostics(t *testing.T) {
 	data := makeReportData(t)
 	data.Result.Diagnostics = &processor.AdaptiveDiagnostics{
@@ -375,6 +399,27 @@ func generateReportText(t *testing.T, data ReportData) string {
 		t.Fatalf("failed to read report: %v", err)
 	}
 	return string(text)
+}
+
+func reportSection(t *testing.T, output, title, nextTitle string) string {
+	t.Helper()
+
+	header := title + "\n" + strings.Repeat("-", len(title)) + "\n"
+	_, text, ok := strings.Cut(output, header)
+	if !ok {
+		t.Fatalf("report missing section %q", title)
+	}
+
+	if nextTitle == "" {
+		return text
+	}
+
+	nextHeader := nextTitle + "\n" + strings.Repeat("-", len(nextTitle)) + "\n"
+	text, _, ok = strings.Cut(text, nextHeader)
+	if !ok {
+		t.Fatalf("report section %q missing following section %q", title, nextTitle)
+	}
+	return text
 }
 
 func TestGenerateReport_ProcessingTimingLabels(t *testing.T) {

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -55,30 +55,30 @@ func detectContentType(m *AudioMeasurements) ContentType {
 	musicScore := 0
 
 	// Kurtosis: speech is peaked, music is spread
-	if m.SpectralKurtosis > lpContentKurtosisSpeech {
+	if m.Spectral.Kurtosis > lpContentKurtosisSpeech {
 		speechScore++
-	} else if m.SpectralKurtosis < lpContentKurtosisMusic {
+	} else if m.Spectral.Kurtosis < lpContentKurtosisMusic {
 		musicScore++
 	}
 
 	// Flatness: speech is tonal, music is flatter
-	if m.SpectralFlatness < lpContentFlatnessSpeech {
+	if m.Spectral.Flatness < lpContentFlatnessSpeech {
 		speechScore++
-	} else if m.SpectralFlatness > lpContentFlatnessMusic {
+	} else if m.Spectral.Flatness > lpContentFlatnessMusic {
 		musicScore++
 	}
 
 	// Flux: speech is stable, music varies
-	if m.SpectralFlux < lpContentFluxSpeech {
+	if m.Spectral.Flux < lpContentFluxSpeech {
 		speechScore++
-	} else if m.SpectralFlux > lpContentFluxMusic {
+	} else if m.Spectral.Flux > lpContentFluxMusic {
 		musicScore++
 	}
 
 	// Crest: speech has dominant peaks
-	if m.SpectralCrest > lpContentCrestSpeech {
+	if m.Spectral.Crest > lpContentCrestSpeech {
 		speechScore++
-	} else if m.SpectralCrest < lpContentCrestMusic {
+	} else if m.Spectral.Crest < lpContentCrestMusic {
 		musicScore++
 	}
 

--- a/internal/processor/adaptive_deesser.go
+++ b/internal/processor/adaptive_deesser.go
@@ -39,13 +39,13 @@ func tuneDeesser(config *EffectiveFilterConfig, measurements *AudioMeasurements)
 	}
 
 	// Both centroid and rolloff available - full adaptive logic
-	if measurements.SpectralCentroid > 0 && measurements.SpectralRolloff > 0 {
+	if measurements.Spectral.Centroid > 0 && measurements.Spectral.Rolloff > 0 {
 		tuneDeesserFull(config, measurements)
 		return
 	}
 
 	// Only centroid available - simplified fallback
-	if measurements.SpectralCentroid > 0 {
+	if measurements.Spectral.Centroid > 0 {
 		tuneDeesserCentroidOnly(config, measurements)
 		return
 	}
@@ -56,8 +56,8 @@ func tuneDeesser(config *EffectiveFilterConfig, measurements *AudioMeasurements)
 // tuneDeesserFull uses both centroid and rolloff for precise de-esser tuning
 func tuneDeesserFull(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	// Prefer speech-specific measurements for sibilance detection
-	centroid := measurements.SpectralCentroid
-	rolloff := measurements.SpectralRolloff
+	centroid := measurements.Spectral.Centroid
+	rolloff := measurements.Spectral.Rolloff
 	if measurements.SpeechProfile != nil {
 		centroid = preferSpeechMetric(centroid, measurements.SpeechProfile.Spectral.Centroid)
 		rolloff = preferSpeechMetric(rolloff, measurements.SpeechProfile.Spectral.Rolloff)
@@ -101,7 +101,7 @@ func tuneDeesserFull(config *EffectiveFilterConfig, measurements *AudioMeasureme
 func tuneDeesserCentroidOnly(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
 	// Prefer speech-specific centroid when available.
 	// Full-file averages are diluted by silence in multi-track recordings.
-	centroid := measurements.SpectralCentroid
+	centroid := measurements.Spectral.Centroid
 	if measurements.SpeechProfile != nil {
 		centroid = preferSpeechMetric(centroid, measurements.SpeechProfile.Spectral.Centroid)
 	}

--- a/internal/processor/adaptive_ds201_gate.go
+++ b/internal/processor/adaptive_ds201_gate.go
@@ -226,8 +226,8 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 	// DS201-inspired: supports sub-millisecond attack for transient preservation
 	config.DS201GateAttack = calculateDS201GateAttack(
 		measurements.MaxDifference,
-		measurements.SpectralFlux,
-		measurements.SpectralCrest,
+		measurements.Spectral.Flux,
+		measurements.Spectral.Crest,
 	)
 
 	// 4. Release: based on flux, ZCR, noise character (entropy), and LRA
@@ -235,7 +235,7 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 	// Higher entropy = more broadband noise = faster release to cut noise quickly
 	// Low LRA = narrow dynamics = extend release to prevent pumping
 	config.DS201GateRelease = calculateDS201GateRelease(
-		measurements.SpectralFlux,
+		measurements.Spectral.Flux,
 		measurements.ZeroCrossingsRate,
 		silenceEntropy,
 		measurements.InputLRA,
@@ -249,7 +249,7 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 	config.DS201GateRange = DbToLinear(rangeDB)
 
 	// 6. Knee: based on spectral crest - soft knee for natural transitions
-	config.DS201GateKnee = calculateDS201GateKnee(measurements.SpectralCrest)
+	config.DS201GateKnee = calculateDS201GateKnee(measurements.Spectral.Crest)
 
 	// 7. Detection: RMS for bleed, peak for clean
 	config.DS201GateDetection = calculateDS201GateDetection(silenceEntropy, silenceCrest)

--- a/internal/processor/adaptive_ds201_highpass.go
+++ b/internal/processor/adaptive_ds201_highpass.go
@@ -69,7 +69,7 @@ func tuneDS201HighPass(config *EffectiveFilterConfig, measurements *AudioMeasure
 	config.DS201HPMix = ds201HPDefaultMix
 	config.DS201HPTransform = ds201HPDefaultTransform
 
-	if measurements.SpectralCentroid <= 0 {
+	if measurements.Spectral.Centroid <= 0 {
 		// No spectral analysis available - keep default
 		return
 	}
@@ -77,7 +77,7 @@ func tuneDS201HighPass(config *EffectiveFilterConfig, measurements *AudioMeasure
 	// Prefer speech-specific spectral metrics when available.
 	// Full-file averages are diluted by silence in multi-track recordings.
 	hasSpeech := measurements.SpeechProfile != nil
-	centroid := measurements.SpectralCentroid
+	centroid := measurements.Spectral.Centroid
 	if hasSpeech {
 		centroid = preferSpeechMetric(centroid, measurements.SpeechProfile.Spectral.Centroid)
 	}
@@ -86,8 +86,8 @@ func tuneDS201HighPass(config *EffectiveFilterConfig, measurements *AudioMeasure
 		speechDecrease = measurements.SpeechProfile.Spectral.Decrease
 		speechSkewness = measurements.SpeechProfile.Spectral.Skewness
 	}
-	decrease := preferSpeechMetricSigned(measurements.SpectralDecrease, speechDecrease, hasSpeech)
-	skewness := preferSpeechMetricSigned(measurements.SpectralSkewness, speechSkewness, hasSpeech)
+	decrease := preferSpeechMetricSigned(measurements.Spectral.Decrease, speechDecrease, hasSpeech)
+	skewness := preferSpeechMetricSigned(measurements.Spectral.Skewness, speechSkewness, hasSpeech)
 
 	// Determine base frequency from spectral centroid
 	var baseFreq float64

--- a/internal/processor/adaptive_ds201_lowpass.go
+++ b/internal/processor/adaptive_ds201_lowpass.go
@@ -59,8 +59,8 @@ func tuneDS201LowPass(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagno
 	diagnostics.DS201LPContentType = contentType
 
 	// Calculate rolloff/centroid ratio for logging
-	rolloff := m.SpectralRolloff
-	centroid := m.SpectralCentroid
+	rolloff := m.Spectral.Rolloff
+	centroid := m.Spectral.Centroid
 	if m.SpeechProfile != nil {
 		rolloff = preferSpeechMetric(rolloff, m.SpeechProfile.Spectral.Rolloff)
 		centroid = preferSpeechMetric(centroid, m.SpeechProfile.Spectral.Centroid)
@@ -110,8 +110,8 @@ func tuneDS201LowPassForSpeech(config *EffectiveFilterConfig, diagnostics *Adapt
 
 	// Prefer speech-specific spectral metrics when available.
 	// Full-file averages are diluted by silence in multi-track recordings.
-	rolloff := m.SpectralRolloff
-	centroid := m.SpectralCentroid
+	rolloff := m.Spectral.Rolloff
+	centroid := m.Spectral.Centroid
 	if m.SpeechProfile != nil {
 		rolloff = preferSpeechMetric(rolloff, m.SpeechProfile.Spectral.Rolloff)
 		centroid = preferSpeechMetric(centroid, m.SpeechProfile.Spectral.Centroid)

--- a/internal/processor/adaptive_la2a.go
+++ b/internal/processor/adaptive_la2a.go
@@ -210,7 +210,7 @@ func tuneLA2AAttack(config *EffectiveFilterConfig, measurements *AudioMeasuremen
 // - Warm voices (high skewness) get extra release to preserve body
 func tuneLA2ARelease(config *EffectiveFilterConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
 	// Prefer speech-specific flux for timing decisions
-	flux := measurements.SpectralFlux
+	flux := measurements.Spectral.Flux
 	if measurements.SpeechProfile != nil {
 		flux = preferSpeechMetric(flux, measurements.SpeechProfile.Spectral.Flux)
 	}
@@ -220,7 +220,7 @@ func tuneLA2ARelease(config *EffectiveFilterConfig, measurements *AudioMeasureme
 	if measurements.SpeechProfile != nil {
 		speechSkewness = measurements.SpeechProfile.Spectral.Skewness
 	}
-	skewness := preferSpeechMetricSigned(measurements.SpectralSkewness, speechSkewness, measurements.SpeechProfile != nil)
+	skewness := preferSpeechMetricSigned(measurements.Spectral.Skewness, speechSkewness, measurements.SpeechProfile != nil)
 
 	// Start with standard LA-2A-style release
 	release := la2aReleaseStandard
@@ -280,7 +280,7 @@ func tuneLA2ARelease(config *EffectiveFilterConfig, measurements *AudioMeasureme
 // Speech typically ranges 5-10 (leptokurtic, clear harmonics).
 func tuneLA2ARatio(config *EffectiveFilterConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
 	// Prefer speech-specific kurtosis for harmonic structure
-	kurtosis := measurements.SpectralKurtosis
+	kurtosis := measurements.Spectral.Kurtosis
 	if measurements.SpeechProfile != nil {
 		kurtosis = preferSpeechMetric(kurtosis, measurements.SpeechProfile.Spectral.Kurtosis)
 	}
@@ -389,7 +389,7 @@ func tuneLA2AKnee(config *EffectiveFilterConfig, measurements *AudioMeasurements
 	// Prefer speech-specific spectral metrics when available.
 	// Full-file averages are diluted by silence in multi-track recordings.
 	hasSpeech := measurements.SpeechProfile != nil
-	centroid := measurements.SpectralCentroid
+	centroid := measurements.Spectral.Centroid
 	if hasSpeech {
 		centroid = preferSpeechMetric(centroid, measurements.SpeechProfile.Spectral.Centroid)
 	}
@@ -397,7 +397,7 @@ func tuneLA2AKnee(config *EffectiveFilterConfig, measurements *AudioMeasurements
 	if hasSpeech {
 		speechSkewness = measurements.SpeechProfile.Spectral.Skewness
 	}
-	skewness := preferSpeechMetricSigned(measurements.SpectralSkewness, speechSkewness, hasSpeech)
+	skewness := preferSpeechMetricSigned(measurements.Spectral.Skewness, speechSkewness, hasSpeech)
 
 	// Adjust based on spectral centroid (voice brightness)
 	if centroid > 0 {

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -9,13 +9,9 @@ import (
 func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	measurements := &AudioMeasurements{
 		BaseMeasurements: BaseMeasurements{
-			SpectralCentroid: 5000,
-			SpectralDecrease: -0.12,
-			SpectralSkewness: 1.2,
-			DynamicRange:     32.0,
-			SpectralKurtosis: 4.0,
-			SpectralFlux:     0.01,
-			PeakLevel:        -8.0,
+			Spectral: SpectralMetrics{Centroid: 5000, Decrease: -0.12, Skewness: 1.2, Kurtosis: 4.0, Flux: 0.01}, DynamicRange: 32.0,
+
+			PeakLevel: -8.0,
 		},
 		InputI:     -28.0,
 		InputTP:    -4.0,
@@ -178,16 +174,8 @@ func newOrderIndependenceSeed() *BaseFilterConfig {
 func orderIndependenceWarmNoProfileMeasurements() *AudioMeasurements {
 	return &AudioMeasurements{
 		BaseMeasurements: BaseMeasurements{
-			SpectralCentroid: 6500,
-			SpectralDecrease: -0.12,
-			SpectralSkewness: 1.6,
-			SpectralKurtosis: 4.0,
-			SpectralFlatness: 0.62,
-			SpectralFlux:     0.008,
-			SpectralCrest:    20.0,
-			SpectralRolloff:  18000,
-			DynamicRange:     90.0,
-			PeakLevel:        -10.0,
+			Spectral: SpectralMetrics{Centroid: 6500, Decrease: -0.12, Skewness: 1.6, Kurtosis: 4.0, Flatness: 0.62, Flux: 0.008, Crest: 20.0, Rolloff: 18000}, DynamicRange: 90.0,
+			PeakLevel: -10.0,
 		},
 		InputI:     -42.1,
 		InputTP:    -4.9,
@@ -199,15 +187,7 @@ func orderIndependenceWarmNoProfileMeasurements() *AudioMeasurements {
 func orderIndependenceBrightSpeechMeasurements() *AudioMeasurements {
 	return &AudioMeasurements{
 		BaseMeasurements: BaseMeasurements{
-			SpectralCentroid:  5000,
-			SpectralDecrease:  0.0,
-			SpectralSkewness:  0.0,
-			SpectralKurtosis:  9.0,
-			SpectralFlatness:  0.38,
-			SpectralFlux:      0.002,
-			SpectralCrest:     45.0,
-			SpectralRolloff:   15000,
-			DynamicRange:      32.0,
+			Spectral: SpectralMetrics{Centroid: 5000, Decrease: 0.0, Skewness: 0.0, Kurtosis: 9.0, Flatness: 0.38, Flux: 0.002, Crest: 45.0, Rolloff: 15000}, DynamicRange: 32.0,
 			PeakLevel:         -6.0,
 			ZeroCrossingsRate: 0.05,
 		},
@@ -550,12 +530,8 @@ func TestTuneDS201HighPass(t *testing.T) {
 			// Start with highpass enabled to test tuning behavior
 			config.DS201HPEnabled = true
 			measurements := &AudioMeasurements{
-				BaseMeasurements: BaseMeasurements{
-					SpectralCentroid: tt.centroid,
-					SpectralDecrease: tt.spectralDecrease,
-					SpectralSkewness: tt.spectralSkewness,
-				},
-				NoiseProfile: tt.noiseProfile,
+				BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: tt.centroid, Decrease: tt.spectralDecrease, Skewness: tt.spectralSkewness}},
+				NoiseProfile:     tt.noiseProfile,
 			}
 
 			// Execute
@@ -602,11 +578,8 @@ func TestTuneDS201HighPass(t *testing.T) {
 		config.DS201HPEnabled = true
 
 		tuneDS201HighPass(config, &AudioMeasurements{
-			BaseMeasurements: BaseMeasurements{
-				SpectralCentroid: 5000,
-				SpectralDecrease: -0.12,
-			},
-			NoiseProfile: makeNoiseProfile(-50.0, 0.8),
+			BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: 5000, Decrease: -0.12}},
+			NoiseProfile:     makeNoiseProfile(-50.0, 0.8),
 		})
 
 		if config.DS201HPPoles != 1 || config.DS201HPWidth != ds201HPVeryWarmWidth || config.DS201HPMix != ds201HPVeryWarmMix {
@@ -615,9 +588,7 @@ func TestTuneDS201HighPass(t *testing.T) {
 		}
 
 		tuneDS201HighPass(config, &AudioMeasurements{
-			BaseMeasurements: BaseMeasurements{
-				SpectralCentroid: 5000,
-			},
+			BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: 5000}},
 		})
 
 		if config.DS201HPFreq != ds201HPBrightFreq {
@@ -709,12 +680,7 @@ func TestDetectContentType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &AudioMeasurements{
-				BaseMeasurements: BaseMeasurements{
-					SpectralKurtosis: tt.kurtosis,
-					SpectralFlatness: tt.flatness,
-					SpectralFlux:     tt.flux,
-					SpectralCrest:    tt.crest,
-				},
+				BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Kurtosis: tt.kurtosis, Flatness: tt.flatness, Flux: tt.flux, Crest: tt.crest}},
 			}
 
 			got := detectContentType(m)
@@ -899,16 +865,7 @@ func TestTuneDS201LowPass(t *testing.T) {
 			config := newTestConfig()
 			diagnostics := &AdaptiveDiagnostics{}
 			m := &AudioMeasurements{
-				BaseMeasurements: BaseMeasurements{
-					SpectralKurtosis:  tt.kurtosis,
-					SpectralFlatness:  tt.flatness,
-					SpectralFlux:      tt.flux,
-					SpectralCrest:     tt.crest,
-					SpectralRolloff:   tt.rolloff,
-					SpectralCentroid:  tt.centroid,
-					SpectralSlope:     tt.slope,
-					ZeroCrossingsRate: tt.zcr,
-				},
+				BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Kurtosis: tt.kurtosis, Flatness: tt.flatness, Flux: tt.flux, Crest: tt.crest, Rolloff: tt.rolloff, Centroid: tt.centroid, Slope: tt.slope}, ZeroCrossingsRate: tt.zcr},
 			}
 
 			tuneDS201LowPass(config, diagnostics, m)
@@ -1157,11 +1114,8 @@ func TestTuneDeesser(t *testing.T) {
 			// Start with deesser disabled - tuneDeesser should set intensity based on spectral data
 			config.DeessIntensity = 0.0
 			measurements := &AudioMeasurements{
-				BaseMeasurements: BaseMeasurements{
-					SpectralCentroid: tt.centroid,
-					SpectralRolloff:  tt.rolloff,
-				},
-				SpeechProfile: tt.speechProfile,
+				BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: tt.centroid, Rolloff: tt.rolloff}},
+				SpeechProfile:    tt.speechProfile,
 			}
 
 			// Execute
@@ -1340,11 +1294,8 @@ func TestTuneDS201Gate(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
 				measurements := &AudioMeasurements{
-					BaseMeasurements: BaseMeasurements{
-						MaxDifference: tt.maxDiff,
-						SpectralFlux:  tt.spectralFlux,
-					},
-					NoiseFloor: -55.0,
+					BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Flux: tt.spectralFlux}, MaxDifference: tt.maxDiff},
+					NoiseFloor:       -55.0,
 				}
 
 				tuneDS201GateForTest(config, measurements)
@@ -1530,9 +1481,8 @@ func TestTuneDS201Gate(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
 				measurements := &AudioMeasurements{
-					BaseMeasurements: BaseMeasurements{
-						SpectralFlux: 0.02, // Moderate flux (uses ds201GateReleaseMod)
-					},
+					BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Flux: 0.02}}, // Moderate flux (uses ds201GateReleaseMod)
+
 					NoiseFloor: -55.0,
 					InputLRA:   15.0, // Above LRA threshold (10 LU) to avoid LRA-based extension
 					NoiseProfile: &NoiseProfile{
@@ -1604,9 +1554,8 @@ func TestTuneDS201Gate(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
 				measurements := &AudioMeasurements{
-					BaseMeasurements: BaseMeasurements{
-						SpectralFlux: 0.02, // Moderate flux
-					},
+					BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Flux: 0.02}}, // Moderate flux
+
 					NoiseFloor: -55.0,
 					InputLRA:   tt.lra,
 					NoiseProfile: &NoiseProfile{
@@ -1629,13 +1578,10 @@ func TestTuneDS201Gate(t *testing.T) {
 	t.Run("populates diagnostics with speech metrics", func(t *testing.T) {
 		config := newTestConfig()
 		diagnostics := tuneDS201GateForTest(config, &AudioMeasurements{
-			BaseMeasurements: BaseMeasurements{
-				SpectralFlux:  0.02,
-				SpectralCrest: 20.0,
-			},
-			InputI:     -48.0,
-			InputLRA:   6.0,
-			NoiseFloor: -70.0,
+			BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Flux: 0.02, Crest: 20.0}},
+			InputI:           -48.0,
+			InputLRA:         6.0,
+			NoiseFloor:       -70.0,
 			NoiseProfile: &NoiseProfile{
 				PeakLevel:   -65.0,
 				CrestFactor: 12.0,
@@ -1668,12 +1614,10 @@ func TestTuneDS201Gate(t *testing.T) {
 	t.Run("fresh diagnostics without speech metrics", func(t *testing.T) {
 		config := newTestConfig()
 		diagnostics := tuneDS201GateForTest(config, &AudioMeasurements{
-			BaseMeasurements: BaseMeasurements{
-				SpectralFlux: 0.02,
-			},
-			InputI:     -20.0,
-			InputLRA:   16.0,
-			NoiseFloor: -55.0,
+			BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Flux: 0.02}},
+			InputI:           -20.0,
+			InputLRA:         16.0,
+			NoiseFloor:       -55.0,
 		})
 
 		if diagnostics.DS201GateGentleMode {
@@ -2880,12 +2824,9 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
-				DynamicRange:     86.3,
-				SpectralKurtosis: 5.4,
-				SpectralFlux:     0.0003,
-				PeakLevel:        -10.1,
-				SpectralCentroid: 968,
-				SpectralSkewness: 1.50,
+				Spectral: SpectralMetrics{Kurtosis: 5.4, Flux: 0.0003, Centroid: 968, Skewness: 1.50}, DynamicRange: 86.3,
+
+				PeakLevel: -10.1,
 			},
 			InputI:        -39.1,
 			InputTP:       -4.9,
@@ -2933,12 +2874,9 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
-				DynamicRange:     88.9,
-				SpectralKurtosis: 12.7,
-				SpectralFlux:     0.0018,
-				PeakLevel:        -7.4,
-				SpectralCentroid: 1555,
-				SpectralSkewness: 2.32,
+				Spectral: SpectralMetrics{Kurtosis: 12.7, Flux: 0.0018, Centroid: 1555, Skewness: 2.32}, DynamicRange: 88.9,
+
+				PeakLevel: -7.4,
 			},
 			InputI:        -20.2,
 			InputTP:       -2.5,
@@ -2997,12 +2935,9 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 				diagnostics := &AdaptiveDiagnostics{}
 				measurements := &AudioMeasurements{
 					BaseMeasurements: BaseMeasurements{
-						DynamicRange:     60.0,
-						SpectralKurtosis: 10.0,
-						SpectralFlux:     0.001,
-						PeakLevel:        tt.inputTP,
-						SpectralCentroid: 2500,
-						SpectralSkewness: 1.0,
+						Spectral: SpectralMetrics{Kurtosis: 10.0, Flux: 0.001, Centroid: 2500, Skewness: 1.0}, DynamicRange: 60.0,
+
+						PeakLevel: tt.inputTP,
 					},
 					InputI:        tt.inputI,
 					InputTP:       tt.inputTP,
@@ -3029,12 +2964,9 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
-				DynamicRange:     90.0,
-				SpectralKurtosis: 5.0,
-				SpectralFlux:     0.0003,
-				PeakLevel:        -5.0,
-				SpectralCentroid: 2000,
-				SpectralSkewness: 1.0,
+				Spectral: SpectralMetrics{Kurtosis: 5.0, Flux: 0.0003, Centroid: 2000, Skewness: 1.0}, DynamicRange: 90.0,
+
+				PeakLevel: -5.0,
 			},
 			InputI:        -44.5,
 			InputTP:       -5.0,

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -145,19 +145,7 @@ type SpeechCandidateMetrics struct {
 // Embedded in both AudioMeasurements and OutputMeasurements to avoid duplication.
 type BaseMeasurements struct {
 	// Spectral analysis from aspectralstats (all measurements averaged across frames)
-	SpectralMean     float64 `json:"spectral_mean"`     // Mean spectral magnitude
-	SpectralVariance float64 `json:"spectral_variance"` // Spectral magnitude variance
-	SpectralCentroid float64 `json:"spectral_centroid"` // Spectral centroid (Hz) - where energy is concentrated
-	SpectralSpread   float64 `json:"spectral_spread"`   // Spectral spread (Hz) - bandwidth/fullness indicator
-	SpectralSkewness float64 `json:"spectral_skewness"` // Spectral asymmetry - positive=bright, negative=dark
-	SpectralKurtosis float64 `json:"spectral_kurtosis"` // Spectral peakiness - tonal vs broadband content
-	SpectralEntropy  float64 `json:"spectral_entropy"`  // Spectral randomness (0-1) - noise classification
-	SpectralFlatness float64 `json:"spectral_flatness"` // Noise vs tonal ratio (0-1) - low=tonal, high=noisy
-	SpectralCrest    float64 `json:"spectral_crest"`    // Spectral peak-to-RMS - transient indicator
-	SpectralFlux     float64 `json:"spectral_flux"`     // Frame-to-frame spectral change
-	SpectralSlope    float64 `json:"spectral_slope"`    // Spectral tilt - negative=more bass
-	SpectralDecrease float64 `json:"spectral_decrease"` // Average spectral decrease
-	SpectralRolloff  float64 `json:"spectral_rolloff"`  // Spectral rolloff (Hz) - HF energy dropoff point
+	Spectral SpectralMetrics `json:"-"` // Kept flat in JSON by custom marshal helpers
 
 	// Time-domain statistics from astats
 	DynamicRange float64 `json:"dynamic_range"` // Measured dynamic range (dB)
@@ -400,7 +388,7 @@ func buildInputMeasurements(filename string, collection *analysisFrameCollection
 	measurements.ShortTermLoudness = acc.ebur128InputS
 	measurements.SamplePeak = acc.ebur128InputSP
 
-	acc.finalizeSpectral().writeSpectralTo(&measurements.BaseMeasurements)
+	measurements.Spectral = acc.finalizeSpectral()
 	assignAstatsMeasurements(measurements, acc)
 	assignInputNoiseFloor(measurements, acc)
 

--- a/internal/processor/analyzer_candidates_shared.go
+++ b/internal/processor/analyzer_candidates_shared.go
@@ -119,7 +119,7 @@ func measureSilenceCandidateFromIntervals(region SilenceRegion, intervals []Inte
 			peakMax = interval.PeakLevel
 		}
 
-		spectralSum.add(interval.spectralFields())
+		spectralSum.add(interval.Spectral)
 
 		momentarySum += interval.MomentaryLUFS
 		shortTermSum += interval.ShortTermLUFS
@@ -195,13 +195,13 @@ func scoreSpeechIntervalWindow(intervals []IntervalSample) float64 {
 	kurtosisValues := make([]float64, len(intervals))
 
 	for i, interval := range intervals {
-		kurtosisSum += interval.SpectralKurtosis
-		flatnessSum += interval.SpectralFlatness
-		centroidSum += interval.SpectralCentroid
+		kurtosisSum += interval.Spectral.Kurtosis
+		flatnessSum += interval.Spectral.Flatness
+		centroidSum += interval.Spectral.Centroid
 		rmsSum += interval.RMSLevel
-		rolloffSum += interval.SpectralRolloff
-		fluxSum += interval.SpectralFlux
-		kurtosisValues[i] = interval.SpectralKurtosis
+		rolloffSum += interval.Spectral.Rolloff
+		fluxSum += interval.Spectral.Flux
+		kurtosisValues[i] = interval.Spectral.Kurtosis
 	}
 
 	avgKurtosis := kurtosisSum / n
@@ -321,7 +321,7 @@ func measureSpeechCandidateFromIntervals(region SpeechRegion, intervals []Interv
 			peakMax = interval.PeakLevel
 		}
 
-		spectralSum.add(interval.spectralFields())
+		spectralSum.add(interval.Spectral)
 
 		momentarySum += interval.MomentaryLUFS
 		shortTermSum += interval.ShortTermLUFS
@@ -340,7 +340,7 @@ func measureSpeechCandidateFromIntervals(region SpeechRegion, intervals []Interv
 	// Calculate voicing density for stability assessment
 	voicedCount := 0
 	for _, interval := range regionIntervals {
-		if interval.SpectralKurtosis > voicedKurtosisThreshold {
+		if interval.Spectral.Kurtosis > voicedKurtosisThreshold {
 			voicedCount++
 		}
 	}

--- a/internal/processor/analyzer_candidates_silence.go
+++ b/internal/processor/analyzer_candidates_silence.go
@@ -73,9 +73,9 @@ func roomToneScore(interval IntervalSample, rmsP50, fluxP50 float64) float64 {
 	// Flux component: room tone is stable (low flux)
 	// Score 1.0 if at or below median, decreasing above
 	fluxScore := 1.0
-	if fluxP50 > 0 && interval.SpectralFlux > fluxP50 {
+	if fluxP50 > 0 && interval.Spectral.Flux > fluxP50 {
 		// Exponential decay based on ratio above median
-		ratio := interval.SpectralFlux / fluxP50
+		ratio := interval.Spectral.Flux / fluxP50
 		if ratio > 1 {
 			// ratio 1 = 1.0, ratio 2 = 0.5, ratio 4 = 0.25
 			fluxScore = 1.0 / ratio
@@ -104,7 +104,7 @@ func computeSilenceMedians(searchIntervals []IntervalSample) silenceMedians {
 	fluxValues := make([]float64, len(searchIntervals))
 	for i, interval := range searchIntervals {
 		rmsLevels[i] = interval.RMSLevel
-		fluxValues[i] = interval.SpectralFlux
+		fluxValues[i] = interval.Spectral.Flux
 	}
 	sort.Float64s(rmsLevels)
 	sort.Float64s(fluxValues)
@@ -349,10 +349,10 @@ func extractNoiseProfileFromIntervals(region *SilenceRegion, intervals []Interva
 		if interval.PeakLevel > peakMax {
 			peakMax = interval.PeakLevel
 		}
-		entropySum += interval.SpectralEntropy
-		centroidSum += interval.SpectralCentroid
-		flatnessSum += interval.SpectralFlatness
-		kurtosisSum += interval.SpectralKurtosis
+		entropySum += interval.Spectral.Entropy
+		centroidSum += interval.Spectral.Centroid
+		flatnessSum += interval.Spectral.Flatness
+		kurtosisSum += interval.Spectral.Kurtosis
 	}
 
 	n := float64(len(regionIntervals))

--- a/internal/processor/analyzer_candidates_silence_scoring.go
+++ b/internal/processor/analyzer_candidates_silence_scoring.go
@@ -322,7 +322,7 @@ func calculateStabilityScore(intervals []IntervalSample) float64 {
 
 	var fluxSum float64
 	for _, iv := range intervals {
-		fluxSum += iv.SpectralFlux
+		fluxSum += iv.Spectral.Flux
 	}
 	avgFlux := fluxSum / n
 

--- a/internal/processor/analyzer_candidates_speech.go
+++ b/internal/processor/analyzer_candidates_speech.go
@@ -245,18 +245,18 @@ func speechScore(interval IntervalSample, rmsP50 float64, speechRMSMin float64) 
 
 	// Centroid score: voice range (200-4500 Hz) = good
 	centroidScore := 0.0
-	if interval.SpectralCentroid >= speechCentroidMin && interval.SpectralCentroid <= speechCentroidMax {
+	if interval.Spectral.Centroid >= speechCentroidMin && interval.Spectral.Centroid <= speechCentroidMax {
 		// In voice range - score based on how central
 		voiceMid := (speechCentroidMin + speechCentroidMax) / 2
 		voiceHalfWidth := (speechCentroidMax - speechCentroidMin) / 2
-		distFromMid := math.Abs(interval.SpectralCentroid - voiceMid)
+		distFromMid := math.Abs(interval.Spectral.Centroid - voiceMid)
 		centroidScore = 1.0 - (distFromMid / voiceHalfWidth * 0.5)
 	}
 
 	// Entropy score: lower entropy = more structured = more speech-like
 	entropyScore := 0.0
-	if interval.SpectralEntropy < speechEntropyMax {
-		entropyScore = 1.0 - (interval.SpectralEntropy / speechEntropyMax)
+	if interval.Spectral.Entropy < speechEntropyMax {
+		entropyScore = 1.0 - (interval.Spectral.Entropy / speechEntropyMax)
 	}
 
 	// Weighted combination: amplitude most important, then centroid, then entropy

--- a/internal/processor/analyzer_metrics.go
+++ b/internal/processor/analyzer_metrics.go
@@ -305,6 +305,270 @@ func (b *BaseMeasurements) fromJSON(decoded baseMeasurementsJSON) {
 	b.SamplePeak = decoded.SamplePeak
 }
 
+// MarshalJSON preserves the flat spectral_* JSON contract from BaseMeasurements
+// while retaining all input-specific analysis fields.
+func (m AudioMeasurements) MarshalJSON() ([]byte, error) {
+	object, err := baseMeasurementObject(m.BaseMeasurements)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := setJSONField(object, "input_i", m.InputI); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "input_tp", m.InputTP); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "input_lra", m.InputLRA); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "input_thresh", m.InputThresh); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "target_offset", m.TargetOffset); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "noise_floor", m.NoiseFloor); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "noise_floor_source", m.NoiseFloorSource); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "prescan_noise_floor", m.PreScanNoiseFloor); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "silence_detect_level", m.SilenceDetectLevel); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptySlice(object, "silence_regions", m.SilenceRegions); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptySlice(object, "interval_samples", m.IntervalSamples); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptySlice(object, "silence_candidates", m.SilenceCandidates); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptySlice(object, "speech_regions", m.SpeechRegions); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptySlice(object, "speech_candidates", m.SpeechCandidates); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptyPtr(object, "speech_profile", m.SpeechProfile); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "voice_activated", m.VoiceActivated); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptyPtr(object, "noise_profile", m.NoiseProfile); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "suggested_gate_threshold", m.SuggestedGateThreshold); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "noise_reduction_headroom", m.NoiseReductionHeadroom); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(object)
+}
+
+// UnmarshalJSON accepts the legacy flat spectral_* JSON contract and all
+// input-specific analysis fields.
+func (m *AudioMeasurements) UnmarshalJSON(data []byte) error {
+	if err := m.BaseMeasurements.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	var decoded audioMeasurementsJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	m.InputI = decoded.InputI
+	m.InputTP = decoded.InputTP
+	m.InputLRA = decoded.InputLRA
+	m.InputThresh = decoded.InputThresh
+	m.TargetOffset = decoded.TargetOffset
+	m.NoiseFloor = decoded.NoiseFloor
+	m.NoiseFloorSource = decoded.NoiseFloorSource
+	m.PreScanNoiseFloor = decoded.PreScanNoiseFloor
+	m.SilenceDetectLevel = decoded.SilenceDetectLevel
+	m.SilenceRegions = decoded.SilenceRegions
+	m.IntervalSamples = decoded.IntervalSamples
+	m.SilenceCandidates = decoded.SilenceCandidates
+	m.SpeechRegions = decoded.SpeechRegions
+	m.SpeechCandidates = decoded.SpeechCandidates
+	m.SpeechProfile = decoded.SpeechProfile
+	m.VoiceActivated = decoded.VoiceActivated
+	m.NoiseProfile = decoded.NoiseProfile
+	m.SuggestedGateThreshold = decoded.SuggestedGateThreshold
+	m.NoiseReductionHeadroom = decoded.NoiseReductionHeadroom
+
+	return nil
+}
+
+type audioMeasurementsJSON struct {
+	InputI           float64 `json:"input_i"`
+	InputTP          float64 `json:"input_tp"`
+	InputLRA         float64 `json:"input_lra"`
+	InputThresh      float64 `json:"input_thresh"`
+	TargetOffset     float64 `json:"target_offset"`
+	NoiseFloor       float64 `json:"noise_floor"`
+	NoiseFloorSource string  `json:"noise_floor_source"`
+
+	PreScanNoiseFloor  float64 `json:"prescan_noise_floor"`
+	SilenceDetectLevel float64 `json:"silence_detect_level"`
+
+	SilenceRegions    []SilenceRegion           `json:"silence_regions,omitempty"`
+	IntervalSamples   []IntervalSample          `json:"interval_samples,omitempty"`
+	SilenceCandidates []SilenceCandidateMetrics `json:"silence_candidates,omitempty"`
+	SpeechRegions     []SpeechRegion            `json:"speech_regions,omitempty"`
+	SpeechCandidates  []SpeechCandidateMetrics  `json:"speech_candidates,omitempty"`
+	SpeechProfile     *SpeechCandidateMetrics   `json:"speech_profile,omitempty"`
+
+	VoiceActivated bool          `json:"voice_activated"`
+	NoiseProfile   *NoiseProfile `json:"noise_profile,omitempty"`
+
+	SuggestedGateThreshold float64 `json:"suggested_gate_threshold"`
+	NoiseReductionHeadroom float64 `json:"noise_reduction_headroom"`
+}
+
+// MarshalJSON preserves the flat spectral_* JSON contract from BaseMeasurements
+// while retaining all output-specific measurement fields.
+func (m OutputMeasurements) MarshalJSON() ([]byte, error) {
+	object, err := baseMeasurementObject(m.BaseMeasurements)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := setJSONField(object, "output_i", m.OutputI); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "output_tp", m.OutputTP); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "output_lra", m.OutputLRA); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "output_thresh", m.OutputThresh); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "target_offset", m.TargetOffset); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "loudnorm_input_i", m.LoudnormInputI); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "loudnorm_input_tp", m.LoudnormInputTP); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "loudnorm_input_lra", m.LoudnormInputLRA); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "loudnorm_input_thresh", m.LoudnormInputThresh); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "loudnorm_target_offset", m.LoudnormTargetOffset); err != nil {
+		return nil, err
+	}
+	if err := setJSONField(object, "loudnorm_measured", m.LoudnormMeasured); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptyPtr(object, "silence_sample", m.SilenceSample); err != nil {
+		return nil, err
+	}
+	if err := setJSONFieldOmitEmptyPtr(object, "speech_sample", m.SpeechSample); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(object)
+}
+
+// UnmarshalJSON accepts the legacy flat spectral_* JSON contract and all
+// output-specific measurement fields.
+func (m *OutputMeasurements) UnmarshalJSON(data []byte) error {
+	if err := m.BaseMeasurements.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	var decoded outputMeasurementsJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	m.OutputI = decoded.OutputI
+	m.OutputTP = decoded.OutputTP
+	m.OutputLRA = decoded.OutputLRA
+	m.OutputThresh = decoded.OutputThresh
+	m.TargetOffset = decoded.TargetOffset
+	m.LoudnormInputI = decoded.LoudnormInputI
+	m.LoudnormInputTP = decoded.LoudnormInputTP
+	m.LoudnormInputLRA = decoded.LoudnormInputLRA
+	m.LoudnormInputThresh = decoded.LoudnormInputThresh
+	m.LoudnormTargetOffset = decoded.LoudnormTargetOffset
+	m.LoudnormMeasured = decoded.LoudnormMeasured
+	m.SilenceSample = decoded.SilenceSample
+	m.SpeechSample = decoded.SpeechSample
+
+	return nil
+}
+
+type outputMeasurementsJSON struct {
+	OutputI      float64 `json:"output_i"`
+	OutputTP     float64 `json:"output_tp"`
+	OutputLRA    float64 `json:"output_lra"`
+	OutputThresh float64 `json:"output_thresh"`
+	TargetOffset float64 `json:"target_offset"`
+
+	LoudnormInputI       float64 `json:"loudnorm_input_i"`
+	LoudnormInputTP      float64 `json:"loudnorm_input_tp"`
+	LoudnormInputLRA     float64 `json:"loudnorm_input_lra"`
+	LoudnormInputThresh  float64 `json:"loudnorm_input_thresh"`
+	LoudnormTargetOffset float64 `json:"loudnorm_target_offset"`
+	LoudnormMeasured     bool    `json:"loudnorm_measured"`
+
+	SilenceSample *SilenceCandidateMetrics `json:"silence_sample,omitempty"`
+	SpeechSample  *SpeechCandidateMetrics  `json:"speech_sample,omitempty"`
+}
+
+func baseMeasurementObject(base BaseMeasurements) (map[string]json.RawMessage, error) {
+	data, err := base.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+func setJSONField(object map[string]json.RawMessage, name string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	object[name] = data
+	return nil
+}
+
+func setJSONFieldOmitEmptySlice[T any](object map[string]json.RawMessage, name string, value []T) error {
+	if len(value) == 0 {
+		return nil
+	}
+	return setJSONField(object, name, value)
+}
+
+func setJSONFieldOmitEmptyPtr[T any](object map[string]json.RawMessage, name string, value *T) error {
+	if value == nil {
+		return nil
+	}
+	return setJSONField(object, name, value)
+}
+
 func flatJSONHasSpectral(raw map[string]json.RawMessage) bool {
 	for _, key := range []string{
 		"spectral_mean",

--- a/internal/processor/analyzer_metrics.go
+++ b/internal/processor/analyzer_metrics.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"encoding/json"
 	"math"
 	"strconv"
 	"time"
@@ -20,25 +21,311 @@ type IntervalSample struct {
 	PeakLevel float64 `json:"peak_level"` // dBFS, peak level (max tracked per interval)
 
 	// ─── aspectralstats spectral metrics (valid per-window from FFmpeg) ─────────
-	SpectralMean     float64 `json:"spectral_mean"`     // Average magnitude
-	SpectralVariance float64 `json:"spectral_variance"` // Magnitude spread
-	SpectralCentroid float64 `json:"spectral_centroid"` // Hz - "brightness", speech 300-3000 Hz
-	SpectralSpread   float64 `json:"spectral_spread"`   // Hz - frequency bandwidth
-	SpectralSkewness float64 `json:"spectral_skewness"` // Distribution asymmetry
-	SpectralKurtosis float64 `json:"spectral_kurtosis"` // Distribution peakedness
-	SpectralEntropy  float64 `json:"spectral_entropy"`  // 0-1 - speech has lower entropy than noise
-	SpectralFlatness float64 `json:"spectral_flatness"` // 0-1 - high = noise-like, low = tonal
-	SpectralCrest    float64 `json:"spectral_crest"`    // Spectral peakiness
-	SpectralFlux     float64 `json:"spectral_flux"`     // Rate of spectral change (transitions)
-	SpectralSlope    float64 `json:"spectral_slope"`    // High-frequency roll-off rate
-	SpectralDecrease float64 `json:"spectral_decrease"` // High-frequency energy decay
-	SpectralRolloff  float64 `json:"spectral_rolloff"`  // Hz - frequency below which 85% energy lies
+	Spectral SpectralMetrics `json:"-"` // Kept flat in JSON by custom marshal helpers
 
 	// ─── ebur128 loudness metrics (windowed measurements) ───────────────────────
 	MomentaryLUFS float64 `json:"momentary_lufs"`  // LUFS - 400ms window loudness
 	ShortTermLUFS float64 `json:"short_term_lufs"` // LUFS - 3s window loudness
 	TruePeak      float64 `json:"true_peak"`       // dBTP - true peak level (max tracked)
 	SamplePeak    float64 `json:"sample_peak"`     // dBFS - sample peak level (max tracked)
+}
+
+type intervalSampleJSON struct {
+	Timestamp time.Duration `json:"timestamp"`
+
+	RMSLevel  float64 `json:"rms_level"`
+	PeakLevel float64 `json:"peak_level"`
+
+	SpectralMean     float64 `json:"spectral_mean"`
+	SpectralVariance float64 `json:"spectral_variance"`
+	SpectralCentroid float64 `json:"spectral_centroid"`
+	SpectralSpread   float64 `json:"spectral_spread"`
+	SpectralSkewness float64 `json:"spectral_skewness"`
+	SpectralKurtosis float64 `json:"spectral_kurtosis"`
+	SpectralEntropy  float64 `json:"spectral_entropy"`
+	SpectralFlatness float64 `json:"spectral_flatness"`
+	SpectralCrest    float64 `json:"spectral_crest"`
+	SpectralFlux     float64 `json:"spectral_flux"`
+	SpectralSlope    float64 `json:"spectral_slope"`
+	SpectralDecrease float64 `json:"spectral_decrease"`
+	SpectralRolloff  float64 `json:"spectral_rolloff"`
+
+	MomentaryLUFS float64 `json:"momentary_lufs"`
+	ShortTermLUFS float64 `json:"short_term_lufs"`
+	TruePeak      float64 `json:"true_peak"`
+	SamplePeak    float64 `json:"sample_peak"`
+}
+
+// MarshalJSON preserves the flat spectral_* JSON contract while the Go model
+// carries interval spectral data as a SpectralMetrics value.
+func (s IntervalSample) MarshalJSON() ([]byte, error) {
+	return json.Marshal(intervalSampleJSON{
+		Timestamp: s.Timestamp,
+
+		RMSLevel:  s.RMSLevel,
+		PeakLevel: s.PeakLevel,
+
+		SpectralMean:     s.Spectral.Mean,
+		SpectralVariance: s.Spectral.Variance,
+		SpectralCentroid: s.Spectral.Centroid,
+		SpectralSpread:   s.Spectral.Spread,
+		SpectralSkewness: s.Spectral.Skewness,
+		SpectralKurtosis: s.Spectral.Kurtosis,
+		SpectralEntropy:  s.Spectral.Entropy,
+		SpectralFlatness: s.Spectral.Flatness,
+		SpectralCrest:    s.Spectral.Crest,
+		SpectralFlux:     s.Spectral.Flux,
+		SpectralSlope:    s.Spectral.Slope,
+		SpectralDecrease: s.Spectral.Decrease,
+		SpectralRolloff:  s.Spectral.Rolloff,
+
+		MomentaryLUFS: s.MomentaryLUFS,
+		ShortTermLUFS: s.ShortTermLUFS,
+		TruePeak:      s.TruePeak,
+		SamplePeak:    s.SamplePeak,
+	})
+}
+
+// UnmarshalJSON accepts the legacy flat spectral_* JSON contract.
+func (s *IntervalSample) UnmarshalJSON(data []byte) error {
+	var decoded intervalSampleJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	s.Timestamp = decoded.Timestamp
+	s.RMSLevel = decoded.RMSLevel
+	s.PeakLevel = decoded.PeakLevel
+	s.Spectral = SpectralMetrics{
+		Mean:     decoded.SpectralMean,
+		Variance: decoded.SpectralVariance,
+		Centroid: decoded.SpectralCentroid,
+		Spread:   decoded.SpectralSpread,
+		Skewness: decoded.SpectralSkewness,
+		Kurtosis: decoded.SpectralKurtosis,
+		Entropy:  decoded.SpectralEntropy,
+		Flatness: decoded.SpectralFlatness,
+		Crest:    decoded.SpectralCrest,
+		Flux:     decoded.SpectralFlux,
+		Slope:    decoded.SpectralSlope,
+		Decrease: decoded.SpectralDecrease,
+		Rolloff:  decoded.SpectralRolloff,
+	}
+	s.MomentaryLUFS = decoded.MomentaryLUFS
+	s.ShortTermLUFS = decoded.ShortTermLUFS
+	s.TruePeak = decoded.TruePeak
+	s.SamplePeak = decoded.SamplePeak
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	s.Spectral.Found = intervalJSONHasSpectral(raw)
+
+	return nil
+}
+
+func intervalJSONHasSpectral(raw map[string]json.RawMessage) bool {
+	for _, key := range []string{
+		"spectral_mean",
+		"spectral_variance",
+		"spectral_centroid",
+		"spectral_spread",
+		"spectral_skewness",
+		"spectral_kurtosis",
+		"spectral_entropy",
+		"spectral_flatness",
+		"spectral_crest",
+		"spectral_flux",
+		"spectral_slope",
+		"spectral_decrease",
+		"spectral_rolloff",
+	} {
+		if _, ok := raw[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+type baseMeasurementsJSON struct {
+	SpectralMean     float64 `json:"spectral_mean"`
+	SpectralVariance float64 `json:"spectral_variance"`
+	SpectralCentroid float64 `json:"spectral_centroid"`
+	SpectralSpread   float64 `json:"spectral_spread"`
+	SpectralSkewness float64 `json:"spectral_skewness"`
+	SpectralKurtosis float64 `json:"spectral_kurtosis"`
+	SpectralEntropy  float64 `json:"spectral_entropy"`
+	SpectralFlatness float64 `json:"spectral_flatness"`
+	SpectralCrest    float64 `json:"spectral_crest"`
+	SpectralFlux     float64 `json:"spectral_flux"`
+	SpectralSlope    float64 `json:"spectral_slope"`
+	SpectralDecrease float64 `json:"spectral_decrease"`
+	SpectralRolloff  float64 `json:"spectral_rolloff"`
+
+	DynamicRange float64 `json:"dynamic_range"`
+	RMSLevel     float64 `json:"rms_level"`
+	PeakLevel    float64 `json:"peak_level"`
+	RMSTrough    float64 `json:"rms_trough"`
+	RMSPeak      float64 `json:"rms_peak"`
+
+	DCOffset          float64 `json:"dc_offset"`
+	FlatFactor        float64 `json:"flat_factor"`
+	CrestFactor       float64 `json:"crest_factor"`
+	ZeroCrossingsRate float64 `json:"zero_crossings_rate"`
+	ZeroCrossings     float64 `json:"zero_crossings"`
+	MaxDifference     float64 `json:"max_difference"`
+	MinDifference     float64 `json:"min_difference"`
+	MeanDifference    float64 `json:"mean_difference"`
+	RMSDifference     float64 `json:"rms_difference"`
+	Entropy           float64 `json:"entropy"`
+	MinLevel          float64 `json:"min_level"`
+	MaxLevel          float64 `json:"max_level"`
+	AstatsNoiseFloor  float64 `json:"astats_noise_floor"`
+	NoiseFloorCount   float64 `json:"noise_floor_count"`
+	BitDepth          float64 `json:"bit_depth"`
+	NumberOfSamples   float64 `json:"number_of_samples"`
+
+	MomentaryLoudness float64 `json:"momentary_loudness"`
+	ShortTermLoudness float64 `json:"short_term_loudness"`
+	SamplePeak        float64 `json:"sample_peak"`
+}
+
+// MarshalJSON preserves the flat spectral_* JSON contract while the Go model
+// carries shared spectral data as a SpectralMetrics value.
+func (b BaseMeasurements) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.toJSON())
+}
+
+// UnmarshalJSON accepts the legacy flat spectral_* JSON contract.
+func (b *BaseMeasurements) UnmarshalJSON(data []byte) error {
+	var decoded baseMeasurementsJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	b.fromJSON(decoded)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	b.Spectral.Found = flatJSONHasSpectral(raw)
+
+	return nil
+}
+
+func (b BaseMeasurements) toJSON() baseMeasurementsJSON {
+	return baseMeasurementsJSON{
+		SpectralMean:     b.Spectral.Mean,
+		SpectralVariance: b.Spectral.Variance,
+		SpectralCentroid: b.Spectral.Centroid,
+		SpectralSpread:   b.Spectral.Spread,
+		SpectralSkewness: b.Spectral.Skewness,
+		SpectralKurtosis: b.Spectral.Kurtosis,
+		SpectralEntropy:  b.Spectral.Entropy,
+		SpectralFlatness: b.Spectral.Flatness,
+		SpectralCrest:    b.Spectral.Crest,
+		SpectralFlux:     b.Spectral.Flux,
+		SpectralSlope:    b.Spectral.Slope,
+		SpectralDecrease: b.Spectral.Decrease,
+		SpectralRolloff:  b.Spectral.Rolloff,
+
+		DynamicRange: b.DynamicRange,
+		RMSLevel:     b.RMSLevel,
+		PeakLevel:    b.PeakLevel,
+		RMSTrough:    b.RMSTrough,
+		RMSPeak:      b.RMSPeak,
+
+		DCOffset:          b.DCOffset,
+		FlatFactor:        b.FlatFactor,
+		CrestFactor:       b.CrestFactor,
+		ZeroCrossingsRate: b.ZeroCrossingsRate,
+		ZeroCrossings:     b.ZeroCrossings,
+		MaxDifference:     b.MaxDifference,
+		MinDifference:     b.MinDifference,
+		MeanDifference:    b.MeanDifference,
+		RMSDifference:     b.RMSDifference,
+		Entropy:           b.Entropy,
+		MinLevel:          b.MinLevel,
+		MaxLevel:          b.MaxLevel,
+		AstatsNoiseFloor:  b.AstatsNoiseFloor,
+		NoiseFloorCount:   b.NoiseFloorCount,
+		BitDepth:          b.BitDepth,
+		NumberOfSamples:   b.NumberOfSamples,
+
+		MomentaryLoudness: b.MomentaryLoudness,
+		ShortTermLoudness: b.ShortTermLoudness,
+		SamplePeak:        b.SamplePeak,
+	}
+}
+
+func (b *BaseMeasurements) fromJSON(decoded baseMeasurementsJSON) {
+	b.Spectral = SpectralMetrics{
+		Mean:     decoded.SpectralMean,
+		Variance: decoded.SpectralVariance,
+		Centroid: decoded.SpectralCentroid,
+		Spread:   decoded.SpectralSpread,
+		Skewness: decoded.SpectralSkewness,
+		Kurtosis: decoded.SpectralKurtosis,
+		Entropy:  decoded.SpectralEntropy,
+		Flatness: decoded.SpectralFlatness,
+		Crest:    decoded.SpectralCrest,
+		Flux:     decoded.SpectralFlux,
+		Slope:    decoded.SpectralSlope,
+		Decrease: decoded.SpectralDecrease,
+		Rolloff:  decoded.SpectralRolloff,
+	}
+
+	b.DynamicRange = decoded.DynamicRange
+	b.RMSLevel = decoded.RMSLevel
+	b.PeakLevel = decoded.PeakLevel
+	b.RMSTrough = decoded.RMSTrough
+	b.RMSPeak = decoded.RMSPeak
+
+	b.DCOffset = decoded.DCOffset
+	b.FlatFactor = decoded.FlatFactor
+	b.CrestFactor = decoded.CrestFactor
+	b.ZeroCrossingsRate = decoded.ZeroCrossingsRate
+	b.ZeroCrossings = decoded.ZeroCrossings
+	b.MaxDifference = decoded.MaxDifference
+	b.MinDifference = decoded.MinDifference
+	b.MeanDifference = decoded.MeanDifference
+	b.RMSDifference = decoded.RMSDifference
+	b.Entropy = decoded.Entropy
+	b.MinLevel = decoded.MinLevel
+	b.MaxLevel = decoded.MaxLevel
+	b.AstatsNoiseFloor = decoded.AstatsNoiseFloor
+	b.NoiseFloorCount = decoded.NoiseFloorCount
+	b.BitDepth = decoded.BitDepth
+	b.NumberOfSamples = decoded.NumberOfSamples
+
+	b.MomentaryLoudness = decoded.MomentaryLoudness
+	b.ShortTermLoudness = decoded.ShortTermLoudness
+	b.SamplePeak = decoded.SamplePeak
+}
+
+func flatJSONHasSpectral(raw map[string]json.RawMessage) bool {
+	for _, key := range []string{
+		"spectral_mean",
+		"spectral_variance",
+		"spectral_centroid",
+		"spectral_spread",
+		"spectral_skewness",
+		"spectral_kurtosis",
+		"spectral_entropy",
+		"spectral_flatness",
+		"spectral_crest",
+		"spectral_flux",
+		"spectral_slope",
+		"spectral_decrease",
+		"spectral_rolloff",
+	} {
+		if _, ok := raw[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // intervalAccumulator holds accumulated values for a 250ms interval window.
@@ -54,19 +341,8 @@ type intervalAccumulator struct {
 	rawPeakAbs     float64 // Maximum absolute sample value (linear, 0.0-1.0) for this interval
 
 	// ─── aspectralstats accumulators (valid per-window from FFmpeg) ─────────────
-	spectralMeanSum     float64
-	spectralVarianceSum float64
-	spectralCentroidSum float64
-	spectralSpreadSum   float64
-	spectralSkewnessSum float64
-	spectralKurtosisSum float64
-	spectralEntropySum  float64
-	spectralFlatnessSum float64
-	spectralCrestSum    float64
-	spectralFluxSum     float64
-	spectralSlopeSum    float64
-	spectralDecreaseSum float64
-	spectralRolloffSum  float64
+	spectralSum   SpectralMetrics
+	spectralFound bool
 
 	// ─── ebur128 accumulators (windowed measurements) ───────────────────────────
 	momentaryLUFSSum float64
@@ -82,19 +358,7 @@ type intervalFrameMetrics struct {
 	PeakLevel float64
 
 	// aspectralstats (valid per-window)
-	SpectralMean     float64
-	SpectralVariance float64
-	SpectralCentroid float64
-	SpectralSpread   float64
-	SpectralSkewness float64
-	SpectralKurtosis float64
-	SpectralEntropy  float64
-	SpectralFlatness float64
-	SpectralCrest    float64
-	SpectralFlux     float64
-	SpectralSlope    float64
-	SpectralDecrease float64
-	SpectralRolloff  float64
+	Spectral SpectralMetrics
 
 	// ebur128 (windowed measurements)
 	MomentaryLUFS float64
@@ -114,19 +378,10 @@ func (a *intervalAccumulator) add(m intervalFrameMetrics) {
 	}
 
 	// aspectralstats sums for averaging (valid per-window measurements)
-	a.spectralMeanSum += m.SpectralMean
-	a.spectralVarianceSum += m.SpectralVariance
-	a.spectralCentroidSum += m.SpectralCentroid
-	a.spectralSpreadSum += m.SpectralSpread
-	a.spectralSkewnessSum += m.SpectralSkewness
-	a.spectralKurtosisSum += m.SpectralKurtosis
-	a.spectralEntropySum += m.SpectralEntropy
-	a.spectralFlatnessSum += m.SpectralFlatness
-	a.spectralCrestSum += m.SpectralCrest
-	a.spectralFluxSum += m.SpectralFlux
-	a.spectralSlopeSum += m.SpectralSlope
-	a.spectralDecreaseSum += m.SpectralDecrease
-	a.spectralRolloffSum += m.SpectralRolloff
+	a.spectralSum.add(m.Spectral)
+	if m.Spectral.Found {
+		a.spectralFound = true
+	}
 
 	// ebur128 sums for averaging (windowed measurements)
 	a.momentaryLUFSSum += m.MomentaryLUFS
@@ -277,19 +532,8 @@ func (a *intervalAccumulator) finalize(timestamp time.Duration) IntervalSample {
 		n := float64(a.frameCount)
 
 		// aspectralstats averages (valid per-window measurements)
-		sample.SpectralMean = a.spectralMeanSum / n
-		sample.SpectralVariance = a.spectralVarianceSum / n
-		sample.SpectralCentroid = a.spectralCentroidSum / n
-		sample.SpectralSpread = a.spectralSpreadSum / n
-		sample.SpectralSkewness = a.spectralSkewnessSum / n
-		sample.SpectralKurtosis = a.spectralKurtosisSum / n
-		sample.SpectralEntropy = a.spectralEntropySum / n
-		sample.SpectralFlatness = a.spectralFlatnessSum / n
-		sample.SpectralCrest = a.spectralCrestSum / n
-		sample.SpectralFlux = a.spectralFluxSum / n
-		sample.SpectralSlope = a.spectralSlopeSum / n
-		sample.SpectralDecrease = a.spectralDecreaseSum / n
-		sample.SpectralRolloff = a.spectralRolloffSum / n
+		sample.Spectral = a.spectralSum.average(n)
+		sample.Spectral.Found = a.spectralFound
 
 		// ebur128 averages (windowed measurements)
 		sample.MomentaryLUFS = a.momentaryLUFSSum / n
@@ -369,20 +613,7 @@ var (
 // Embedded in both metadataAccumulators and outputMetadataAccumulators to avoid duplication.
 type baseMetadataAccumulators struct {
 	// Spectral statistics from aspectralstats (averaged across frames)
-	spectralMeanSum     float64
-	spectralVarianceSum float64
-	spectralCentroidSum float64
-	spectralSpreadSum   float64
-	spectralSkewnessSum float64
-	spectralKurtosisSum float64
-	spectralEntropySum  float64
-	spectralFlatnessSum float64
-	spectralCrestSum    float64
-	spectralFluxSum     float64
-	spectralSlopeSum    float64
-	spectralDecreaseSum float64
-	spectralRolloffSum  float64
-	spectralFrameCount  int
+	spectral SpectralAccumulator
 
 	// astats measurements (cumulative - we keep latest values)
 	astatsDynamicRange      float64
@@ -411,46 +642,13 @@ type baseMetadataAccumulators struct {
 
 // accumulateSpectral adds the given spectral measurements to the running sums.
 func (b *baseMetadataAccumulators) accumulateSpectral(spectral SpectralMetrics) {
-	if !spectral.Found {
-		return
-	}
-	b.spectralMeanSum += spectral.Mean
-	b.spectralVarianceSum += spectral.Variance
-	b.spectralCentroidSum += spectral.Centroid
-	b.spectralSpreadSum += spectral.Spread
-	b.spectralSkewnessSum += spectral.Skewness
-	b.spectralKurtosisSum += spectral.Kurtosis
-	b.spectralEntropySum += spectral.Entropy
-	b.spectralFlatnessSum += spectral.Flatness
-	b.spectralCrestSum += spectral.Crest
-	b.spectralFluxSum += spectral.Flux
-	b.spectralSlopeSum += spectral.Slope
-	b.spectralDecreaseSum += spectral.Decrease
-	b.spectralRolloffSum += spectral.Rolloff
-	b.spectralFrameCount++
+	b.spectral.Add(spectral)
 }
 
 // finalizeSpectral returns averaged spectral metrics from the accumulated sums.
 // Returns zero-value SpectralMetrics when no spectral frames were accumulated.
 func (b *baseMetadataAccumulators) finalizeSpectral() SpectralMetrics {
-	if b.spectralFrameCount == 0 {
-		return SpectralMetrics{}
-	}
-	return SpectralMetrics{
-		Mean:     b.spectralMeanSum,
-		Variance: b.spectralVarianceSum,
-		Centroid: b.spectralCentroidSum,
-		Spread:   b.spectralSpreadSum,
-		Skewness: b.spectralSkewnessSum,
-		Kurtosis: b.spectralKurtosisSum,
-		Entropy:  b.spectralEntropySum,
-		Flatness: b.spectralFlatnessSum,
-		Crest:    b.spectralCrestSum,
-		Flux:     b.spectralFluxSum,
-		Slope:    b.spectralSlopeSum,
-		Decrease: b.spectralDecreaseSum,
-		Rolloff:  b.spectralRolloffSum,
-	}.average(float64(b.spectralFrameCount))
+	return b.spectral.Average()
 }
 
 // extractAstatsMetadata extracts all astats measurements from FFmpeg metadata.
@@ -601,25 +799,42 @@ type SpectralMetrics struct {
 	Found    bool    `json:"-"`        // True if any spectral metric was extracted
 }
 
-// spectralFields returns the 13 spectral measurements from this interval as a SpectralMetrics value.
-// This enables struct-level accumulation instead of 13 individual variables.
-func (s *IntervalSample) spectralFields() SpectralMetrics {
-	return SpectralMetrics{
-		Mean:     s.SpectralMean,
-		Variance: s.SpectralVariance,
-		Centroid: s.SpectralCentroid,
-		Spread:   s.SpectralSpread,
-		Skewness: s.SpectralSkewness,
-		Kurtosis: s.SpectralKurtosis,
-		Entropy:  s.SpectralEntropy,
-		Flatness: s.SpectralFlatness,
-		Crest:    s.SpectralCrest,
-		Flux:     s.SpectralFlux,
-		Slope:    s.SpectralSlope,
-		Decrease: s.SpectralDecrease,
-		Rolloff:  s.SpectralRolloff,
-		Found:    true,
+// SpectralAccumulator accumulates spectral measurements across frames and
+// averages only frames where aspectralstats metadata was found.
+type SpectralAccumulator struct {
+	sum   SpectralMetrics
+	count int
+}
+
+// Add accumulates a found spectral measurement and ignores frames without
+// aspectralstats metadata.
+func (a *SpectralAccumulator) Add(spectral SpectralMetrics) {
+	if !spectral.Found {
+		return
 	}
+	a.sum.add(spectral)
+	a.count++
+}
+
+// Average returns averaged spectral measurements, or the zero value when no
+// spectral metadata was accumulated.
+func (a SpectralAccumulator) Average() SpectralMetrics {
+	if !a.Found() {
+		return SpectralMetrics{}
+	}
+	average := a.sum.average(float64(a.count))
+	average.Found = true
+	return average
+}
+
+// Count returns the number of found spectral frames accumulated.
+func (a SpectralAccumulator) Count() int {
+	return a.count
+}
+
+// Found reports whether at least one spectral frame was accumulated.
+func (a SpectralAccumulator) Found() bool {
+	return a.count > 0
 }
 
 // add accumulates another SpectralMetrics into this one (element-wise sum).
@@ -656,23 +871,6 @@ func (m SpectralMetrics) average(n float64) SpectralMetrics {
 		Decrease: m.Decrease / n,
 		Rolloff:  m.Rolloff / n,
 	}
-}
-
-// writeSpectralTo maps all 13 spectral fields to the corresponding BaseMeasurements fields.
-func (m SpectralMetrics) writeSpectralTo(b *BaseMeasurements) {
-	b.SpectralMean = m.Mean
-	b.SpectralVariance = m.Variance
-	b.SpectralCentroid = m.Centroid
-	b.SpectralSpread = m.Spread
-	b.SpectralSkewness = m.Skewness
-	b.SpectralKurtosis = m.Kurtosis
-	b.SpectralEntropy = m.Entropy
-	b.SpectralFlatness = m.Flatness
-	b.SpectralCrest = m.Crest
-	b.SpectralFlux = m.Flux
-	b.SpectralSlope = m.Slope
-	b.SpectralDecrease = m.Decrease
-	b.SpectralRolloff = m.Rolloff
 }
 
 // extractSpectralMetrics extracts all 13 aspectralstats measurements from FFmpeg metadata.
@@ -746,19 +944,7 @@ func extractIntervalFrameMetrics(metadata *ffmpeg.AVDictionary, spectral Spectra
 	m.PeakLevel, _ = getFloatMetadata(metadata, metaKeyPeakLevel)
 
 	// aspectralstats metrics (valid per-window measurements, pre-extracted by caller)
-	m.SpectralMean = spectral.Mean
-	m.SpectralVariance = spectral.Variance
-	m.SpectralCentroid = spectral.Centroid
-	m.SpectralSpread = spectral.Spread
-	m.SpectralSkewness = spectral.Skewness
-	m.SpectralKurtosis = spectral.Kurtosis
-	m.SpectralEntropy = spectral.Entropy
-	m.SpectralFlatness = spectral.Flatness
-	m.SpectralCrest = spectral.Crest
-	m.SpectralFlux = spectral.Flux
-	m.SpectralSlope = spectral.Slope
-	m.SpectralDecrease = spectral.Decrease
-	m.SpectralRolloff = spectral.Rolloff
+	m.Spectral = spectral
 
 	// ebur128 windowed measurements
 	m.MomentaryLUFS, _ = getFloatMetadata(metadata, metaKeyEbur128M)
@@ -884,12 +1070,14 @@ func extractOutputFrameMetadata(metadata *ffmpeg.AVDictionary, acc *outputMetada
 // finalizeOutputMeasurements converts accumulated values to OutputMeasurements struct.
 // Returns nil if no measurements were captured.
 func finalizeOutputMeasurements(acc *outputMetadataAccumulators) *OutputMeasurements {
-	if !acc.ebur128Found && !acc.astatsFound && acc.spectralFrameCount == 0 {
+	if !acc.ebur128Found && !acc.astatsFound && !acc.spectral.Found() {
 		return nil // No measurements captured
 	}
 
 	m := &OutputMeasurements{
 		BaseMeasurements: BaseMeasurements{
+			Spectral: acc.finalizeSpectral(),
+
 			// ebur128 momentary/short-term loudness
 			MomentaryLoudness: acc.ebur128OutputM,
 			ShortTermLoudness: acc.ebur128OutputS,
@@ -931,9 +1119,6 @@ func finalizeOutputMeasurements(acc *outputMetadataAccumulators) *OutputMeasurem
 	if m.OutputThresh == 0.0 && m.OutputI != 0.0 {
 		m.OutputThresh = m.OutputI - 10.0
 	}
-
-	// Calculate average spectral statistics from aspectralstats
-	acc.finalizeSpectral().writeSpectralTo(&m.BaseMeasurements)
 
 	return m
 }

--- a/internal/processor/analyzer_metrics_test.go
+++ b/internal/processor/analyzer_metrics_test.go
@@ -2,10 +2,29 @@ package processor
 
 import (
 	"math"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
 
 const spectralTestEpsilon = 1e-9
+
+var staleSpectralPrimitiveFields = []string{
+	"SpectralMean",
+	"SpectralVariance",
+	"SpectralCentroid",
+	"SpectralSpread",
+	"SpectralSkewness",
+	"SpectralKurtosis",
+	"SpectralEntropy",
+	"SpectralFlatness",
+	"SpectralCrest",
+	"SpectralFlux",
+	"SpectralSlope",
+	"SpectralDecrease",
+	"SpectralRolloff",
+}
 
 func TestFinalizeSpectral_ZeroFrameCount(t *testing.T) {
 	acc := &baseMetadataAccumulators{}
@@ -17,22 +36,39 @@ func TestFinalizeSpectral_ZeroFrameCount(t *testing.T) {
 }
 
 func TestFinalizeSpectral_AveragesCorrectly(t *testing.T) {
-	acc := &baseMetadataAccumulators{
-		spectralMeanSum:     10.0,
-		spectralVarianceSum: 20.0,
-		spectralCentroidSum: 3000.0,
-		spectralSpreadSum:   600.0,
-		spectralSkewnessSum: 4.0,
-		spectralKurtosisSum: 8.0,
-		spectralEntropySum:  1.5,
-		spectralFlatnessSum: 0.5,
-		spectralCrestSum:    6.0,
-		spectralFluxSum:     2.0,
-		spectralSlopeSum:    -0.02,
-		spectralDecreaseSum: 0.4,
-		spectralRolloffSum:  8000.0,
-		spectralFrameCount:  2,
-	}
+	acc := &baseMetadataAccumulators{}
+	acc.accumulateSpectral(SpectralMetrics{
+		Mean:     2.0,
+		Variance: 4.0,
+		Centroid: 1000.0,
+		Spread:   200.0,
+		Skewness: 1.0,
+		Kurtosis: 2.0,
+		Entropy:  0.25,
+		Flatness: 0.10,
+		Crest:    1.0,
+		Flux:     0.5,
+		Slope:    -0.005,
+		Decrease: 0.1,
+		Rolloff:  2000.0,
+		Found:    true,
+	})
+	acc.accumulateSpectral(SpectralMetrics{
+		Mean:     8.0,
+		Variance: 16.0,
+		Centroid: 2000.0,
+		Spread:   400.0,
+		Skewness: 3.0,
+		Kurtosis: 6.0,
+		Entropy:  1.25,
+		Flatness: 0.40,
+		Crest:    5.0,
+		Flux:     1.5,
+		Slope:    -0.015,
+		Decrease: 0.3,
+		Rolloff:  6000.0,
+		Found:    true,
+	})
 
 	result := acc.finalizeSpectral()
 
@@ -62,44 +98,48 @@ func TestFinalizeSpectral_AveragesCorrectly(t *testing.T) {
 	}
 }
 
-func TestWriteSpectralTo_MapsAllFields(t *testing.T) {
-	sm := SpectralMetrics{
-		Mean:     1.0,
-		Variance: 2.0,
-		Centroid: 3.0,
-		Spread:   4.0,
-		Skewness: 5.0,
-		Kurtosis: 6.0,
-		Entropy:  7.0,
-		Flatness: 8.0,
-		Crest:    9.0,
-		Flux:     10.0,
-		Slope:    11.0,
-		Decrease: 12.0,
-		Rolloff:  13.0,
+func TestFinalizeSpectral_AssignsBaseSpectral(t *testing.T) {
+	acc := &baseMetadataAccumulators{}
+	for range 3 {
+		acc.accumulateSpectral(SpectralMetrics{
+			Mean:     10.0,
+			Variance: 20.0,
+			Centroid: 3000.0,
+			Spread:   500.0,
+			Skewness: 2.0,
+			Kurtosis: 4.0,
+			Entropy:  0.7,
+			Flatness: 0.3,
+			Crest:    5.0,
+			Flux:     1.0,
+			Slope:    -0.02,
+			Decrease: 0.4,
+			Rolloff:  8000.0,
+			Found:    true,
+		})
 	}
 
 	var bm BaseMeasurements
-	sm.writeSpectralTo(&bm)
+	bm.Spectral = acc.finalizeSpectral()
 
 	checks := []struct {
 		name string
 		got  float64
 		want float64
 	}{
-		{"SpectralMean", bm.SpectralMean, 1.0},
-		{"SpectralVariance", bm.SpectralVariance, 2.0},
-		{"SpectralCentroid", bm.SpectralCentroid, 3.0},
-		{"SpectralSpread", bm.SpectralSpread, 4.0},
-		{"SpectralSkewness", bm.SpectralSkewness, 5.0},
-		{"SpectralKurtosis", bm.SpectralKurtosis, 6.0},
-		{"SpectralEntropy", bm.SpectralEntropy, 7.0},
-		{"SpectralFlatness", bm.SpectralFlatness, 8.0},
-		{"SpectralCrest", bm.SpectralCrest, 9.0},
-		{"SpectralFlux", bm.SpectralFlux, 10.0},
-		{"SpectralSlope", bm.SpectralSlope, 11.0},
-		{"SpectralDecrease", bm.SpectralDecrease, 12.0},
-		{"SpectralRolloff", bm.SpectralRolloff, 13.0},
+		{"Mean", bm.Spectral.Mean, 10.0},
+		{"Variance", bm.Spectral.Variance, 20.0},
+		{"Centroid", bm.Spectral.Centroid, 3000.0},
+		{"Spread", bm.Spectral.Spread, 500.0},
+		{"Skewness", bm.Spectral.Skewness, 2.0},
+		{"Kurtosis", bm.Spectral.Kurtosis, 4.0},
+		{"Entropy", bm.Spectral.Entropy, 0.7},
+		{"Flatness", bm.Spectral.Flatness, 0.3},
+		{"Crest", bm.Spectral.Crest, 5.0},
+		{"Flux", bm.Spectral.Flux, 1.0},
+		{"Slope", bm.Spectral.Slope, -0.02},
+		{"Decrease", bm.Spectral.Decrease, 0.4},
+		{"Rolloff", bm.Spectral.Rolloff, 8000.0},
 	}
 	for _, c := range checks {
 		if math.Abs(c.got-c.want) > spectralTestEpsilon {
@@ -108,45 +148,250 @@ func TestWriteSpectralTo_MapsAllFields(t *testing.T) {
 	}
 }
 
-func TestFinalizeSpectral_WriteSpectralTo_Chained(t *testing.T) {
-	acc := &baseMetadataAccumulators{
-		spectralMeanSum:     30.0,
-		spectralVarianceSum: 60.0,
-		spectralCentroidSum: 9000.0,
-		spectralSpreadSum:   1500.0,
-		spectralSkewnessSum: 6.0,
-		spectralKurtosisSum: 12.0,
-		spectralEntropySum:  2.1,
-		spectralFlatnessSum: 0.9,
-		spectralCrestSum:    15.0,
-		spectralFluxSum:     3.0,
-		spectralSlopeSum:    -0.06,
-		spectralDecreaseSum: 1.2,
-		spectralRolloffSum:  24000.0,
-		spectralFrameCount:  3,
+func TestSpectralAccumulator_ZeroFrameCount(t *testing.T) {
+	var acc SpectralAccumulator
+
+	if acc.Found() {
+		t.Fatal("expected Found to be false before adding spectral metrics")
+	}
+	if got := acc.Count(); got != 0 {
+		t.Fatalf("Count() = %d, want 0", got)
+	}
+	if got := acc.Average(); got != (SpectralMetrics{}) {
+		t.Fatalf("Average() = %+v, want zero-value SpectralMetrics", got)
+	}
+}
+
+func TestSpectralAccumulator_MixedFoundAndUnfound(t *testing.T) {
+	var acc SpectralAccumulator
+
+	acc.Add(SpectralMetrics{
+		Mean:     100.0,
+		Variance: 200.0,
+		Found:    false,
+	})
+	acc.Add(SpectralMetrics{
+		Mean:     10.0,
+		Variance: 20.0,
+		Found:    true,
+	})
+
+	if !acc.Found() {
+		t.Fatal("expected Found to be true after adding found spectral metrics")
+	}
+	if got := acc.Count(); got != 1 {
+		t.Fatalf("Count() = %d, want 1", got)
 	}
 
-	var bm BaseMeasurements
-	acc.finalizeSpectral().writeSpectralTo(&bm)
+	average := acc.Average()
+	if !average.Found {
+		t.Fatal("expected averaged SpectralMetrics to preserve Found")
+	}
+	if average.Mean != 10.0 {
+		t.Errorf("Mean = %v, want 10.0", average.Mean)
+	}
+	if average.Variance != 20.0 {
+		t.Errorf("Variance = %v, want 20.0", average.Variance)
+	}
+}
+
+func TestSpectralAccumulator_AveragesAllFields(t *testing.T) {
+	var acc SpectralAccumulator
+	acc.Add(SpectralMetrics{
+		Mean:     2.0,
+		Variance: 4.0,
+		Centroid: 1000.0,
+		Spread:   200.0,
+		Skewness: 1.0,
+		Kurtosis: 2.0,
+		Entropy:  0.2,
+		Flatness: 0.4,
+		Crest:    6.0,
+		Flux:     0.02,
+		Slope:    -0.10,
+		Decrease: 0.06,
+		Rolloff:  5000.0,
+		Found:    true,
+	})
+	acc.Add(SpectralMetrics{
+		Mean:     6.0,
+		Variance: 12.0,
+		Centroid: 3000.0,
+		Spread:   600.0,
+		Skewness: 3.0,
+		Kurtosis: 6.0,
+		Entropy:  0.6,
+		Flatness: 0.8,
+		Crest:    10.0,
+		Flux:     0.06,
+		Slope:    -0.30,
+		Decrease: 0.18,
+		Rolloff:  9000.0,
+		Found:    true,
+	})
+
+	result := acc.Average()
 
 	checks := []struct {
 		name string
 		got  float64
 		want float64
 	}{
-		{"SpectralMean", bm.SpectralMean, 10.0},
-		{"SpectralVariance", bm.SpectralVariance, 20.0},
-		{"SpectralCentroid", bm.SpectralCentroid, 3000.0},
-		{"SpectralSpread", bm.SpectralSpread, 500.0},
-		{"SpectralSkewness", bm.SpectralSkewness, 2.0},
-		{"SpectralKurtosis", bm.SpectralKurtosis, 4.0},
-		{"SpectralEntropy", bm.SpectralEntropy, 0.7},
-		{"SpectralFlatness", bm.SpectralFlatness, 0.3},
-		{"SpectralCrest", bm.SpectralCrest, 5.0},
-		{"SpectralFlux", bm.SpectralFlux, 1.0},
-		{"SpectralSlope", bm.SpectralSlope, -0.02},
-		{"SpectralDecrease", bm.SpectralDecrease, 0.4},
-		{"SpectralRolloff", bm.SpectralRolloff, 8000.0},
+		{"Mean", result.Mean, 4.0},
+		{"Variance", result.Variance, 8.0},
+		{"Centroid", result.Centroid, 2000.0},
+		{"Spread", result.Spread, 400.0},
+		{"Skewness", result.Skewness, 2.0},
+		{"Kurtosis", result.Kurtosis, 4.0},
+		{"Entropy", result.Entropy, 0.4},
+		{"Flatness", result.Flatness, 0.6},
+		{"Crest", result.Crest, 8.0},
+		{"Flux", result.Flux, 0.04},
+		{"Slope", result.Slope, -0.20},
+		{"Decrease", result.Decrease, 0.12},
+		{"Rolloff", result.Rolloff, 7000.0},
+	}
+	for _, c := range checks {
+		if math.Abs(c.got-c.want) > spectralTestEpsilon {
+			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestBaseMetadataAccumulators_UsesSingleSpectralAccumulator(t *testing.T) {
+	accType := reflect.TypeFor[baseMetadataAccumulators]()
+	var spectralFields []reflect.StructField
+	for field := range accType.Fields() {
+		if strings.HasPrefix(field.Name, "spectral") {
+			spectralFields = append(spectralFields, field)
+		}
+	}
+
+	if len(spectralFields) != 1 {
+		t.Fatalf("baseMetadataAccumulators spectral field count = %d, want 1", len(spectralFields))
+	}
+	if spectralFields[0].Type != reflect.TypeFor[SpectralAccumulator]() {
+		t.Fatalf("spectral field type = %v, want SpectralAccumulator", spectralFields[0].Type)
+	}
+}
+
+func TestIntervalSample_UsesSingleSpectralMetricsField(t *testing.T) {
+	sampleType := reflect.TypeFor[IntervalSample]()
+	var spectralFields []reflect.StructField
+	for field := range sampleType.Fields() {
+		if strings.HasPrefix(field.Name, "Spectral") {
+			spectralFields = append(spectralFields, field)
+		}
+	}
+
+	if len(spectralFields) != 1 {
+		t.Fatalf("IntervalSample spectral field count = %d, want 1", len(spectralFields))
+	}
+	if spectralFields[0].Name != "Spectral" {
+		t.Fatalf("spectral field name = %s, want Spectral", spectralFields[0].Name)
+	}
+	if spectralFields[0].Type != reflect.TypeFor[SpectralMetrics]() {
+		t.Fatalf("spectral field type = %v, want SpectralMetrics", spectralFields[0].Type)
+	}
+}
+
+func TestIntervalSample_HasNoFlatSpectralPrimitiveFields(t *testing.T) {
+	assertNoStaleSpectralPrimitiveFields[IntervalSample](t)
+}
+
+func TestIntervalFrameMetrics_UsesSingleSpectralMetricsField(t *testing.T) {
+	metricsType := reflect.TypeFor[intervalFrameMetrics]()
+	var spectralFields []reflect.StructField
+	for field := range metricsType.Fields() {
+		if strings.HasPrefix(field.Name, "Spectral") {
+			spectralFields = append(spectralFields, field)
+		}
+	}
+
+	if len(spectralFields) != 1 {
+		t.Fatalf("intervalFrameMetrics spectral field count = %d, want 1", len(spectralFields))
+	}
+	if spectralFields[0].Name != "Spectral" {
+		t.Fatalf("spectral field name = %s, want Spectral", spectralFields[0].Name)
+	}
+	if spectralFields[0].Type != reflect.TypeFor[SpectralMetrics]() {
+		t.Fatalf("spectral field type = %v, want SpectralMetrics", spectralFields[0].Type)
+	}
+}
+
+func assertNoStaleSpectralPrimitiveFields[T any](t *testing.T) {
+	t.Helper()
+
+	targetType := reflect.TypeFor[T]()
+	for _, fieldName := range staleSpectralPrimitiveFields {
+		if field, ok := targetType.FieldByName(fieldName); ok {
+			t.Errorf("%s has stale flat spectral field %s with type %v", targetType.Name(), field.Name, field.Type)
+		}
+	}
+}
+
+func TestIntervalAccumulatorFinalize_WritesAveragedSpectralMetrics(t *testing.T) {
+	acc := &intervalAccumulator{}
+	acc.add(intervalFrameMetrics{
+		Spectral: SpectralMetrics{
+			Mean:     2.0,
+			Variance: 4.0,
+			Centroid: 1000.0,
+			Spread:   200.0,
+			Skewness: 1.0,
+			Kurtosis: 2.0,
+			Entropy:  0.2,
+			Flatness: 0.4,
+			Crest:    6.0,
+			Flux:     0.02,
+			Slope:    -0.10,
+			Decrease: 0.06,
+			Rolloff:  5000.0,
+			Found:    true,
+		},
+	})
+	acc.add(intervalFrameMetrics{
+		Spectral: SpectralMetrics{
+			Mean:     6.0,
+			Variance: 12.0,
+			Centroid: 3000.0,
+			Spread:   600.0,
+			Skewness: 3.0,
+			Kurtosis: 6.0,
+			Entropy:  0.6,
+			Flatness: 0.8,
+			Crest:    10.0,
+			Flux:     0.06,
+			Slope:    -0.30,
+			Decrease: 0.18,
+			Rolloff:  9000.0,
+			Found:    true,
+		},
+	})
+
+	result := acc.finalize(time.Second)
+
+	if !result.Spectral.Found {
+		t.Fatal("expected averaged interval spectral metrics to preserve Found")
+	}
+	checks := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"Mean", result.Spectral.Mean, 4.0},
+		{"Variance", result.Spectral.Variance, 8.0},
+		{"Centroid", result.Spectral.Centroid, 2000.0},
+		{"Spread", result.Spectral.Spread, 400.0},
+		{"Skewness", result.Spectral.Skewness, 2.0},
+		{"Kurtosis", result.Spectral.Kurtosis, 4.0},
+		{"Entropy", result.Spectral.Entropy, 0.4},
+		{"Flatness", result.Spectral.Flatness, 0.6},
+		{"Crest", result.Spectral.Crest, 8.0},
+		{"Flux", result.Spectral.Flux, 0.04},
+		{"Slope", result.Spectral.Slope, -0.20},
+		{"Decrease", result.Spectral.Decrease, 0.12},
+		{"Rolloff", result.Spectral.Rolloff, 7000.0},
 	}
 	for _, c := range checks {
 		if math.Abs(c.got-c.want) > spectralTestEpsilon {

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -61,6 +61,68 @@ func TestAudioMeasurementsJSON_PreservesFlatSpectralFields(t *testing.T) {
 	assertSpectralValues(t, decoded.Spectral)
 }
 
+func TestAudioMeasurementsJSON_PreservesInputFields(t *testing.T) {
+	measurements := AudioMeasurements{
+		BaseMeasurements: BaseMeasurements{
+			DynamicRange: 14.5,
+			Spectral:     flatSpectralMetricsFixture(),
+		},
+		InputI:                 -23.4,
+		InputTP:                -1.2,
+		InputLRA:               5.6,
+		InputThresh:            -34.0,
+		TargetOffset:           1.1,
+		NoiseFloor:             -62.0,
+		NoiseFloorSource:       "astats",
+		PreScanNoiseFloor:      -63.0,
+		SilenceDetectLevel:     -55.0,
+		SilenceRegions:         []SilenceRegion{{Start: time.Second, End: 2 * time.Second, Duration: time.Second}},
+		IntervalSamples:        []IntervalSample{{Timestamp: 250 * time.Millisecond, RMSLevel: -48.0, Spectral: flatSpectralMetricsFixture()}},
+		SpeechRegions:          []SpeechRegion{{Start: 3 * time.Second, End: 4 * time.Second, Duration: time.Second}},
+		SpeechProfile:          &SpeechCandidateMetrics{RMSLevel: -24.0, Spectral: flatSpectralMetricsFixture()},
+		VoiceActivated:         true,
+		NoiseProfile:           &NoiseProfile{Start: time.Second, Duration: time.Second, MeasuredNoiseFloor: -62.0},
+		SuggestedGateThreshold: 0.025,
+		NoiseReductionHeadroom: 12.5,
+	}
+
+	data, err := json.Marshal(measurements)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	assertJSONField(t, data, "input_i")
+	assertJSONField(t, data, "noise_floor_source")
+	assertJSONField(t, data, "interval_samples")
+	assertJSONField(t, data, "speech_profile")
+	assertJSONField(t, data, "noise_profile")
+
+	var decoded AudioMeasurements
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	if decoded.InputI != measurements.InputI {
+		t.Errorf("InputI = %v, want %v", decoded.InputI, measurements.InputI)
+	}
+	if decoded.NoiseFloorSource != measurements.NoiseFloorSource {
+		t.Errorf("NoiseFloorSource = %q, want %q", decoded.NoiseFloorSource, measurements.NoiseFloorSource)
+	}
+	if len(decoded.IntervalSamples) != 1 {
+		t.Fatalf("IntervalSamples length = %d, want 1", len(decoded.IntervalSamples))
+	}
+	if !decoded.IntervalSamples[0].Spectral.Found {
+		t.Fatal("expected interval sample spectral metrics to preserve Found")
+	}
+	if decoded.SpeechProfile == nil {
+		t.Fatal("expected SpeechProfile to round-trip")
+	}
+	if decoded.NoiseProfile == nil {
+		t.Fatal("expected NoiseProfile to round-trip")
+	}
+	if !decoded.VoiceActivated {
+		t.Fatal("expected VoiceActivated to round-trip")
+	}
+}
+
 func TestOutputMeasurementsJSON_PreservesFlatSpectralFields(t *testing.T) {
 	measurements := OutputMeasurements{}
 	measurements.Spectral = flatSpectralMetricsFixture()
@@ -76,6 +138,58 @@ func TestOutputMeasurementsJSON_PreservesFlatSpectralFields(t *testing.T) {
 		t.Fatalf("Unmarshal() failed: %v", err)
 	}
 	assertSpectralValues(t, decoded.Spectral)
+}
+
+func TestOutputMeasurementsJSON_PreservesOutputFields(t *testing.T) {
+	measurements := OutputMeasurements{
+		BaseMeasurements: BaseMeasurements{
+			DynamicRange: 10.5,
+			Spectral:     flatSpectralMetricsFixture(),
+		},
+		OutputI:              -16.0,
+		OutputTP:             -1.0,
+		OutputLRA:            4.0,
+		OutputThresh:         -26.0,
+		TargetOffset:         0.3,
+		LoudnormInputI:       -18.0,
+		LoudnormInputTP:      -1.5,
+		LoudnormInputLRA:     5.0,
+		LoudnormInputThresh:  -28.0,
+		LoudnormTargetOffset: 1.2,
+		LoudnormMeasured:     true,
+		SilenceSample:        &SilenceCandidateMetrics{RMSLevel: -58.0, Spectral: flatSpectralMetricsFixture()},
+		SpeechSample:         &SpeechCandidateMetrics{RMSLevel: -22.0, Spectral: flatSpectralMetricsFixture()},
+	}
+
+	data, err := json.Marshal(measurements)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	assertJSONField(t, data, "output_i")
+	assertJSONField(t, data, "loudnorm_input_i")
+	assertJSONField(t, data, "loudnorm_measured")
+	assertJSONField(t, data, "silence_sample")
+	assertJSONField(t, data, "speech_sample")
+
+	var decoded OutputMeasurements
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	if decoded.OutputI != measurements.OutputI {
+		t.Errorf("OutputI = %v, want %v", decoded.OutputI, measurements.OutputI)
+	}
+	if decoded.LoudnormInputI != measurements.LoudnormInputI {
+		t.Errorf("LoudnormInputI = %v, want %v", decoded.LoudnormInputI, measurements.LoudnormInputI)
+	}
+	if !decoded.LoudnormMeasured {
+		t.Fatal("expected LoudnormMeasured to round-trip")
+	}
+	if decoded.SilenceSample == nil {
+		t.Fatal("expected SilenceSample to round-trip")
+	}
+	if decoded.SpeechSample == nil {
+		t.Fatal("expected SpeechSample to round-trip")
+	}
 }
 
 func TestBaseMeasurements_HasNoFlatSpectralPrimitiveFields(t *testing.T) {
@@ -97,6 +211,18 @@ func assertFlatSpectralJSONKeys(t *testing.T, data []byte) {
 	}
 	if _, ok := object["spectral"]; ok {
 		t.Errorf("unexpected nested spectral JSON field in %s", string(data))
+	}
+}
+
+func assertJSONField(t *testing.T, data []byte, field string) {
+	t.Helper()
+
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	if _, ok := object[field]; !ok {
+		t.Errorf("missing JSON field %q in %s", field, string(data))
 	}
 }
 

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 	"time"
@@ -8,6 +9,163 @@ import (
 	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
+
+var flatSpectralJSONFields = []string{
+	"spectral_mean",
+	"spectral_variance",
+	"spectral_centroid",
+	"spectral_spread",
+	"spectral_skewness",
+	"spectral_kurtosis",
+	"spectral_entropy",
+	"spectral_flatness",
+	"spectral_crest",
+	"spectral_flux",
+	"spectral_slope",
+	"spectral_decrease",
+	"spectral_rolloff",
+}
+
+func TestIntervalSampleJSON_PreservesFlatSpectralFields(t *testing.T) {
+	sample := IntervalSample{
+		Spectral: flatSpectralMetricsFixture(),
+	}
+
+	data, err := json.Marshal(sample)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	assertFlatSpectralJSONKeys(t, data)
+
+	var decoded IntervalSample
+	if err := json.Unmarshal(flatSpectralJSONFixture(), &decoded); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	assertSpectralValues(t, decoded.Spectral)
+}
+
+func TestAudioMeasurementsJSON_PreservesFlatSpectralFields(t *testing.T) {
+	measurements := AudioMeasurements{}
+	measurements.Spectral = flatSpectralMetricsFixture()
+
+	data, err := json.Marshal(measurements)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	assertFlatSpectralJSONKeys(t, data)
+
+	var decoded AudioMeasurements
+	if err := json.Unmarshal(flatSpectralJSONFixture(), &decoded); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	assertSpectralValues(t, decoded.Spectral)
+}
+
+func TestOutputMeasurementsJSON_PreservesFlatSpectralFields(t *testing.T) {
+	measurements := OutputMeasurements{}
+	measurements.Spectral = flatSpectralMetricsFixture()
+
+	data, err := json.Marshal(measurements)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	assertFlatSpectralJSONKeys(t, data)
+
+	var decoded OutputMeasurements
+	if err := json.Unmarshal(flatSpectralJSONFixture(), &decoded); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	assertSpectralValues(t, decoded.Spectral)
+}
+
+func TestBaseMeasurements_HasNoFlatSpectralPrimitiveFields(t *testing.T) {
+	assertNoStaleSpectralPrimitiveFields[BaseMeasurements](t)
+}
+
+func assertFlatSpectralJSONKeys(t *testing.T, data []byte) {
+	t.Helper()
+
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+
+	for _, field := range flatSpectralJSONFields {
+		if _, ok := object[field]; !ok {
+			t.Errorf("missing flat spectral JSON field %q in %s", field, string(data))
+		}
+	}
+	if _, ok := object["spectral"]; ok {
+		t.Errorf("unexpected nested spectral JSON field in %s", string(data))
+	}
+}
+
+func flatSpectralJSONFixture() []byte {
+	return []byte(`{
+		"spectral_mean": 1,
+		"spectral_variance": 2,
+		"spectral_centroid": 3,
+		"spectral_spread": 4,
+		"spectral_skewness": 5,
+		"spectral_kurtosis": 6,
+		"spectral_entropy": 7,
+		"spectral_flatness": 8,
+		"spectral_crest": 9,
+		"spectral_flux": 10,
+		"spectral_slope": 11,
+		"spectral_decrease": 12,
+		"spectral_rolloff": 13
+	}`)
+}
+
+func flatSpectralMetricsFixture() SpectralMetrics {
+	return SpectralMetrics{
+		Mean:     1,
+		Variance: 2,
+		Centroid: 3,
+		Spread:   4,
+		Skewness: 5,
+		Kurtosis: 6,
+		Entropy:  7,
+		Flatness: 8,
+		Crest:    9,
+		Flux:     10,
+		Slope:    11,
+		Decrease: 12,
+		Rolloff:  13,
+		Found:    true,
+	}
+}
+
+func assertSpectralValues(t *testing.T, got SpectralMetrics) {
+	t.Helper()
+
+	want := flatSpectralMetricsFixture()
+	checks := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"Mean", got.Mean, want.Mean},
+		{"Variance", got.Variance, want.Variance},
+		{"Centroid", got.Centroid, want.Centroid},
+		{"Spread", got.Spread, want.Spread},
+		{"Skewness", got.Skewness, want.Skewness},
+		{"Kurtosis", got.Kurtosis, want.Kurtosis},
+		{"Entropy", got.Entropy, want.Entropy},
+		{"Flatness", got.Flatness, want.Flatness},
+		{"Crest", got.Crest, want.Crest},
+		{"Flux", got.Flux, want.Flux},
+		{"Slope", got.Slope, want.Slope},
+		{"Decrease", got.Decrease, want.Decrease},
+		{"Rolloff", got.Rolloff, want.Rolloff},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
 
 func TestAnalyzeAudio(t *testing.T) {
 	// Generate synthetic test audio: 5-second 440Hz tone at -23 LUFS with a 0.5s silence gap
@@ -517,13 +675,15 @@ func makeSilenceTestIntervals(start time.Duration, duration time.Duration, rms, 
 	intervals := make([]IntervalSample, count)
 	for i := range intervals {
 		intervals[i] = IntervalSample{
-			Timestamp:        start + time.Duration(i)*250*time.Millisecond,
-			RMSLevel:         rms,
-			PeakLevel:        peak,
-			SpectralCentroid: centroid,
-			SpectralFlatness: flatness,
-			SpectralKurtosis: kurtosis,
-			SpectralFlux:     flux,
+			Timestamp: start + time.Duration(i)*250*time.Millisecond,
+			RMSLevel:  rms,
+			PeakLevel: peak,
+			Spectral: SpectralMetrics{
+				Centroid: centroid,
+				Flatness: flatness,
+				Kurtosis: kurtosis,
+				Flux:     flux,
+			},
 		}
 	}
 	return intervals
@@ -787,10 +947,12 @@ func makeSpeechTestIntervals(count int, rms float64) []IntervalSample {
 	intervals := make([]IntervalSample, count)
 	for i := range intervals {
 		intervals[i] = IntervalSample{
-			Timestamp:        time.Duration(i) * 250 * time.Millisecond,
-			RMSLevel:         rms,
-			SpectralCentroid: defaultCentroid,
-			SpectralEntropy:  entropy,
+			Timestamp: time.Duration(i) * 250 * time.Millisecond,
+			RMSLevel:  rms,
+			Spectral: SpectralMetrics{
+				Centroid: defaultCentroid,
+				Entropy:  entropy,
+			},
 		}
 	}
 	return intervals
@@ -808,9 +970,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "typical speech",
 			interval: IntervalSample{
-				RMSLevel:         -18.0,
-				SpectralCentroid: 1500.0, // Voice range
-				SpectralEntropy:  0.5,
+				RMSLevel: -18.0,
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0, // Voice range
+					Entropy:  0.5,
+				},
 			},
 			rmsP50:       -20.0,
 			speechRMSMin: -40.0,
@@ -820,9 +984,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "silence (too quiet)",
 			interval: IntervalSample{
-				RMSLevel:         -50.0,
-				SpectralCentroid: 1500.0,
-				SpectralEntropy:  0.5,
+				RMSLevel: -50.0,
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0,
+					Entropy:  0.5,
+				},
 			},
 			rmsP50:       -20.0,
 			speechRMSMin: -40.0,
@@ -832,9 +998,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "noise (wrong centroid)",
 			interval: IntervalSample{
-				RMSLevel:         -18.0,
-				SpectralCentroid: 8000.0, // Outside voice range
-				SpectralEntropy:  0.9,    // High entropy
+				RMSLevel: -18.0,
+				Spectral: SpectralMetrics{
+					Centroid: 8000.0, // Outside voice range
+					Entropy:  0.9,    // High entropy
+				},
 			},
 			rmsP50:       -20.0,
 			speechRMSMin: -40.0,
@@ -844,9 +1012,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "at RMS minimum threshold",
 			interval: IntervalSample{
-				RMSLevel:         -40.0, // Exactly at speechRMSMinimum
-				SpectralCentroid: 1500.0,
-				SpectralEntropy:  0.5,
+				RMSLevel: -40.0, // Exactly at speechRMSMinimum
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0,
+					Entropy:  0.5,
+				},
 			},
 			rmsP50:       -45.0,
 			speechRMSMin: -40.0,
@@ -856,9 +1026,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "just below RMS minimum",
 			interval: IntervalSample{
-				RMSLevel:         -40.1, // Just below threshold
-				SpectralCentroid: 1500.0,
-				SpectralEntropy:  0.5,
+				RMSLevel: -40.1, // Just below threshold
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0,
+					Entropy:  0.5,
+				},
 			},
 			rmsP50:       -45.0,
 			speechRMSMin: -40.0,
@@ -868,9 +1040,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "low entropy structured speech",
 			interval: IntervalSample{
-				RMSLevel:         -18.0,
-				SpectralCentroid: 2000.0,
-				SpectralEntropy:  0.2, // Very structured
+				RMSLevel: -18.0,
+				Spectral: SpectralMetrics{
+					Centroid: 2000.0,
+					Entropy:  0.2, // Very structured
+				},
 			},
 			rmsP50:       -20.0,
 			speechRMSMin: -40.0,
@@ -880,9 +1054,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "adaptive threshold rejects quiet interval",
 			interval: IntervalSample{
-				RMSLevel:         -35.0,
-				SpectralCentroid: 1500.0,
-				SpectralEntropy:  0.5,
+				RMSLevel: -35.0,
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0,
+					Entropy:  0.5,
+				},
 			},
 			rmsP50:       -20.0,
 			speechRMSMin: -32.0, // Adaptive threshold above interval RMS
@@ -892,9 +1068,11 @@ func TestSpeechScore(t *testing.T) {
 		{
 			name: "default threshold admits same interval",
 			interval: IntervalSample{
-				RMSLevel:         -35.0,
-				SpectralCentroid: 1500.0,
-				SpectralEntropy:  0.5,
+				RMSLevel: -35.0,
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0,
+					Entropy:  0.5,
+				},
 			},
 			rmsP50:       -40.0,
 			speechRMSMin: -40.0, // Default threshold below interval RMS
@@ -991,10 +1169,12 @@ func TestFindSpeechCandidatesFromIntervals(t *testing.T) {
 				}
 			}
 			intervals[i] = IntervalSample{
-				Timestamp:        startTime + time.Duration(i)*250*time.Millisecond,
-				RMSLevel:         rms,
-				SpectralCentroid: 1500.0,
-				SpectralEntropy:  0.3, // Low entropy for better scores (~0.65 entropyScore)
+				Timestamp: startTime + time.Duration(i)*250*time.Millisecond,
+				RMSLevel:  rms,
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0,
+					Entropy:  0.3, // Low entropy for better scores (~0.65 entropyScore)
+				},
 			}
 		}
 		return intervals
@@ -1149,13 +1329,15 @@ func TestMeasureSpeechCandidateFromIntervals(t *testing.T) {
 		intervals := make([]IntervalSample, 40) // 10s of intervals
 		for i := range intervals {
 			intervals[i] = IntervalSample{
-				Timestamp:        time.Duration(i) * 250 * time.Millisecond,
-				RMSLevel:         -20.0,
-				PeakLevel:        -8.0,
-				SpectralCentroid: 1500.0,
-				SpectralFlatness: 0.3,
-				SpectralKurtosis: 5.0,
-				SpectralEntropy:  0.5,
+				Timestamp: time.Duration(i) * 250 * time.Millisecond,
+				RMSLevel:  -20.0,
+				PeakLevel: -8.0,
+				Spectral: SpectralMetrics{
+					Centroid: 1500.0,
+					Flatness: 0.3,
+					Kurtosis: 5.0,
+					Entropy:  0.5,
+				},
 			}
 		}
 		// Set one interval with higher peak
@@ -1262,13 +1444,15 @@ func TestFindBestSpeechRegion_AllBelowMinAcceptableScoreFallsBack(t *testing.T) 
 		intervals := make([]IntervalSample, count)
 		for i := range intervals {
 			intervals[i] = IntervalSample{
-				Timestamp:        start + time.Duration(i)*250*time.Millisecond,
-				RMSLevel:         -35.0,
-				PeakLevel:        -10.0,
-				SpectralKurtosis: 2.0,
-				SpectralCentroid: 8000.0,
-				SpectralRolloff:  rolloff,
-				SpectralFlux:     0.05,
+				Timestamp: start + time.Duration(i)*250*time.Millisecond,
+				RMSLevel:  -35.0,
+				PeakLevel: -10.0,
+				Spectral: SpectralMetrics{
+					Kurtosis: 2.0,
+					Centroid: 8000.0,
+					Rolloff:  rolloff,
+					Flux:     0.05,
+				},
 			}
 		}
 		return intervals
@@ -1375,13 +1559,15 @@ func makeSpeechIntervalsScorable(startTime time.Duration, count int, kurtosis, f
 	intervals := make([]IntervalSample, count)
 	for i := range intervals {
 		intervals[i] = IntervalSample{
-			Timestamp:        startTime + time.Duration(i)*250*time.Millisecond,
-			RMSLevel:         rms,
-			SpectralKurtosis: kurtosis,
-			SpectralFlatness: flatness,
-			SpectralCentroid: centroid,
-			SpectralRolloff:  6000.0, // Ideal range (4000-8000 Hz)
-			SpectralFlux:     0.003,  // Below stable threshold (0.004)
+			Timestamp: startTime + time.Duration(i)*250*time.Millisecond,
+			RMSLevel:  rms,
+			Spectral: SpectralMetrics{
+				Kurtosis: kurtosis,
+				Flatness: flatness,
+				Centroid: centroid,
+				Rolloff:  6000.0, // Ideal range (4000-8000 Hz)
+				Flux:     0.003,  // Below stable threshold (0.004)
+			},
 		}
 	}
 	return intervals
@@ -1415,23 +1601,27 @@ func TestScoreSpeechIntervalWindow(t *testing.T) {
 				for i := range intervals {
 					if i%2 == 0 {
 						intervals[i] = IntervalSample{
-							Timestamp:        time.Duration(i) * 250 * time.Millisecond,
-							RMSLevel:         -35.0,   // Quiet
-							SpectralKurtosis: 15.0,    // High
-							SpectralFlatness: 0.8,     // Noise-like
-							SpectralCentroid: 6000.0,  // Outside voice range
-							SpectralRolloff:  12000.0, // Above acceptable range (max 10000)
-							SpectralFlux:     0.05,    // High variation (transients)
+							Timestamp: time.Duration(i) * 250 * time.Millisecond,
+							RMSLevel:  -35.0, // Quiet
+							Spectral: SpectralMetrics{
+								Kurtosis: 15.0,    // High
+								Flatness: 0.8,     // Noise-like
+								Centroid: 6000.0,  // Outside voice range
+								Rolloff:  12000.0, // Above acceptable range (max 10000)
+								Flux:     0.05,    // High variation (transients)
+							},
 						}
 					} else {
 						intervals[i] = IntervalSample{
-							Timestamp:        time.Duration(i) * 250 * time.Millisecond,
-							RMSLevel:         -35.0,   // Quiet
-							SpectralKurtosis: 1.0,     // Low
-							SpectralFlatness: 0.8,     // Noise-like
-							SpectralCentroid: 6000.0,  // Outside voice range
-							SpectralRolloff:  12000.0, // Above acceptable range (max 10000)
-							SpectralFlux:     0.05,    // High variation (transients)
+							Timestamp: time.Duration(i) * 250 * time.Millisecond,
+							RMSLevel:  -35.0, // Quiet
+							Spectral: SpectralMetrics{
+								Kurtosis: 1.0,     // Low
+								Flatness: 0.8,     // Noise-like
+								Centroid: 6000.0,  // Outside voice range
+								Rolloff:  12000.0, // Above acceptable range (max 10000)
+								Flux:     0.05,    // High variation (transients)
+							},
 						}
 					}
 				}
@@ -2107,7 +2297,7 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "single interval returns neutral",
 			intervals: []IntervalSample{
-				{RMSLevel: -50.0, SpectralFlux: 0.0},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.0}},
 			},
 			wantMin: 0.5,
 			wantMax: 0.5,
@@ -2116,10 +2306,10 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "uniform intervals - perfect stability",
 			intervals: []IntervalSample{
-				{RMSLevel: -50.0, SpectralFlux: 0.0},
-				{RMSLevel: -50.0, SpectralFlux: 0.0},
-				{RMSLevel: -50.0, SpectralFlux: 0.0},
-				{RMSLevel: -50.0, SpectralFlux: 0.0},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.0}},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.0}},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.0}},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.0}},
 			},
 			wantMin: 0.99,
 			wantMax: 1.0,
@@ -2128,10 +2318,10 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "uniform RMS with low flux - high stability",
 			intervals: []IntervalSample{
-				{RMSLevel: -60.0, SpectralFlux: 0.001},
-				{RMSLevel: -60.0, SpectralFlux: 0.002},
-				{RMSLevel: -60.0, SpectralFlux: 0.001},
-				{RMSLevel: -60.0, SpectralFlux: 0.002},
+				{RMSLevel: -60.0, Spectral: SpectralMetrics{Flux: 0.001}},
+				{RMSLevel: -60.0, Spectral: SpectralMetrics{Flux: 0.002}},
+				{RMSLevel: -60.0, Spectral: SpectralMetrics{Flux: 0.001}},
+				{RMSLevel: -60.0, Spectral: SpectralMetrics{Flux: 0.002}},
 			},
 			wantMin: 0.90,
 			wantMax: 1.0,
@@ -2140,10 +2330,10 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "variable RMS - lower stability",
 			intervals: []IntervalSample{
-				{RMSLevel: -45.0, SpectralFlux: 0.0},
-				{RMSLevel: -55.0, SpectralFlux: 0.0},
-				{RMSLevel: -48.0, SpectralFlux: 0.0},
-				{RMSLevel: -52.0, SpectralFlux: 0.0},
+				{RMSLevel: -45.0, Spectral: SpectralMetrics{Flux: 0.0}},
+				{RMSLevel: -55.0, Spectral: SpectralMetrics{Flux: 0.0}},
+				{RMSLevel: -48.0, Spectral: SpectralMetrics{Flux: 0.0}},
+				{RMSLevel: -52.0, Spectral: SpectralMetrics{Flux: 0.0}},
 			},
 			wantMin: 0.35,
 			wantMax: 0.45,
@@ -2152,10 +2342,10 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "high spectral flux - lower stability",
 			intervals: []IntervalSample{
-				{RMSLevel: -50.0, SpectralFlux: 0.03},
-				{RMSLevel: -50.0, SpectralFlux: 0.04},
-				{RMSLevel: -50.0, SpectralFlux: 0.025},
-				{RMSLevel: -50.0, SpectralFlux: 0.035},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.03}},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.04}},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.025}},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.035}},
 			},
 			wantMin: 0.0,
 			wantMax: 0.65,
@@ -2164,10 +2354,10 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "variable RMS and high flux - poor stability",
 			intervals: []IntervalSample{
-				{RMSLevel: -45.0, SpectralFlux: 0.03},
-				{RMSLevel: -55.0, SpectralFlux: 0.04},
-				{RMSLevel: -48.0, SpectralFlux: 0.025},
-				{RMSLevel: -52.0, SpectralFlux: 0.035},
+				{RMSLevel: -45.0, Spectral: SpectralMetrics{Flux: 0.03}},
+				{RMSLevel: -55.0, Spectral: SpectralMetrics{Flux: 0.04}},
+				{RMSLevel: -48.0, Spectral: SpectralMetrics{Flux: 0.025}},
+				{RMSLevel: -52.0, Spectral: SpectralMetrics{Flux: 0.035}},
 			},
 			wantMin: 0.0,
 			wantMax: 0.5,
@@ -2176,10 +2366,10 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "extreme variance - near-zero stability",
 			intervals: []IntervalSample{
-				{RMSLevel: -30.0, SpectralFlux: 0.05},
-				{RMSLevel: -70.0, SpectralFlux: 0.08},
-				{RMSLevel: -35.0, SpectralFlux: 0.06},
-				{RMSLevel: -65.0, SpectralFlux: 0.07},
+				{RMSLevel: -30.0, Spectral: SpectralMetrics{Flux: 0.05}},
+				{RMSLevel: -70.0, Spectral: SpectralMetrics{Flux: 0.08}},
+				{RMSLevel: -35.0, Spectral: SpectralMetrics{Flux: 0.06}},
+				{RMSLevel: -65.0, Spectral: SpectralMetrics{Flux: 0.07}},
 			},
 			wantMin: 0.0,
 			wantMax: 0.2,
@@ -2188,8 +2378,8 @@ func TestCalculateStabilityScore(t *testing.T) {
 		{
 			name: "two intervals - minimum valid input",
 			intervals: []IntervalSample{
-				{RMSLevel: -50.0, SpectralFlux: 0.005},
-				{RMSLevel: -50.0, SpectralFlux: 0.005},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.005}},
+				{RMSLevel: -50.0, Spectral: SpectralMetrics{Flux: 0.005}},
 			},
 			wantMin: 0.85,
 			wantMax: 1.0,

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -396,14 +396,10 @@ func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
 	base.FilterOrder = []FilterID{FilterAnalysis, FilterDeesser}
 
 	first, firstDiagnostics := AdaptConfig(base, &AudioMeasurements{
-		BaseMeasurements: BaseMeasurements{
-			SpectralCentroid: 5000,
-		},
+		BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: 5000}},
 	})
 	second, secondDiagnostics := AdaptConfig(base, &AudioMeasurements{
-		BaseMeasurements: BaseMeasurements{
-			SpectralCentroid: 2000,
-		},
+		BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: 2000}},
 	})
 	if first == nil || second == nil {
 		t.Fatal("AdaptConfig returned nil")


### PR DESCRIPTION
- Move interval and measurement spectral values into nested SpectralMetrics
- Preserve flat spectral JSON fields for backward compatibility
- Update adaptive, logging, and candidate consumers to read nested values
- Add shared spectral report descriptors and stale-field guard tests