### PR TITLE
refactor(processor): replace flat filter config fields with structs

### DIFF
--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	// Create default filter configuration
 	config := processor.DefaultFilterConfig()
-	config.SilenceScanDuration = cliArgs.SilenceScanDuration
+	config.Analysis.SilenceScanDuration = cliArgs.SilenceScanDuration
 
 	// Open debug log file if --debug flag is set
 	debugLog, err := openDebugLog(cliArgs.Debug)

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -168,8 +168,8 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 		firstEffective,
 		secondEffective,
 	}
-	resultConfigs[0].DS201HPFreq = 60.0
-	resultConfigs[1].DS201HPFreq = 100.0
+	resultConfigs[0].DS201HighPass.Frequency = 60.0
+	resultConfigs[1].DS201HighPass.Frequency = 100.0
 	secondFilterOrder := append([]processor.FilterID(nil), resultConfigs[1].FilterOrder...)
 	resultDiagnostics := []*processor.AdaptiveDiagnostics{
 		{DS201LPReason: "first"},
@@ -243,7 +243,8 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	if !reflect.DeepEqual(resultConfigs[1].FilterOrder, secondFilterOrder) {
 		t.Fatalf("second result config FilterOrder = %v, want unaffected %v", resultConfigs[1].FilterOrder, secondFilterOrder)
 	}
-	if baseConfig.DS201HPFreq == resultConfigs[0].DS201HPFreq || baseConfig.DS201HPFreq == resultConfigs[1].DS201HPFreq {
+	if baseConfig.DS201HighPass.Frequency == resultConfigs[0].DS201HighPass.Frequency ||
+		baseConfig.DS201HighPass.Frequency == resultConfigs[1].DS201HighPass.Frequency {
 		t.Fatal("test setup failed: result configs should differ from the shared base seed")
 	}
 }

--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -129,10 +129,10 @@ func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMea
 	writeAnalysisSection(w, "FILTER ADAPTATION")
 	if config != nil {
 		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
-			{"Highpass", fmt.Sprintf("%.0f Hz (from spectral analysis)", config.DS201HPFreq)},
+			{"Highpass", fmt.Sprintf("%.0f Hz (from spectral analysis)", config.DS201HighPass.Frequency)},
 		})
-		if config.DS201LPEnabled {
-			lowpassValue := fmt.Sprintf("%.0f Hz", config.DS201LPFreq)
+		if config.DS201LowPass.Enabled {
+			lowpassValue := fmt.Sprintf("%.0f Hz", config.DS201LowPass.Frequency)
 			if diagnostics != nil && diagnostics.DS201LPReason != "" {
 				lowpassValue += fmt.Sprintf(" (%s)", diagnostics.DS201LPReason)
 			}
@@ -145,14 +145,14 @@ func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMea
 			})
 		}
 		if measurements.NoiseProfile != nil {
-			gateThresholdDB := processor.LinearToDb(config.DS201GateThreshold)
+			gateThresholdDB := processor.LinearToDb(config.DS201Gate.Threshold)
 			gateDesc := "(from noise floor)"
 			if measurements.SpeechProfile != nil {
 				gateDesc = "(with breath reduction)"
 			}
 			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
 				{"Gate Threshold", fmt.Sprintf("%.1f dB %s", gateThresholdDB, gateDesc)},
-				{"Gate Ratio", fmt.Sprintf("%.1f:1", config.DS201GateRatio)},
+				{"Gate Ratio", fmt.Sprintf("%.1f:1", config.DS201Gate.Ratio)},
 			})
 			if diagnostics != nil && diagnostics.DS201GateClampReason != "" && diagnostics.DS201GateClampReason != "none" {
 				writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
@@ -160,19 +160,19 @@ func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMea
 				})
 			}
 		}
-		if config.NoiseRemoveCompandEnabled {
+		if config.NoiseRemove.CompandEnabled {
 			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
-				{"NR Threshold", fmt.Sprintf("%.0f dB", config.NoiseRemoveCompandThreshold)},
-				{"NR Expansion", fmt.Sprintf("%.0f dB", config.NoiseRemoveCompandExpansion)},
+				{"NR Threshold", fmt.Sprintf("%.0f dB", config.NoiseRemove.CompandThreshold)},
+				{"NR Expansion", fmt.Sprintf("%.0f dB", config.NoiseRemove.CompandExpansion)},
 			})
 		} else {
 			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
 				{"NR Compander", "disabled"},
 			})
 		}
-		if config.DeessIntensity > 0 {
+		if config.Deesser.Intensity > 0 {
 			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
-				{"De-esser", fmt.Sprintf("%.0f%% intensity", config.DeessIntensity*100)},
+				{"De-esser", fmt.Sprintf("%.0f%% intensity", config.Deesser.Intensity*100)},
 			})
 		} else {
 			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
@@ -180,8 +180,8 @@ func writeAnalysisFilterAdaptation(w io.Writer, measurements *processor.AudioMea
 			})
 		}
 		writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{
-			{"LA-2A Thresh", fmt.Sprintf("%.0f dB", config.LA2AThreshold)},
-			{"LA-2A Ratio", fmt.Sprintf("%.1f:1", config.LA2ARatio)},
+			{"LA-2A Thresh", fmt.Sprintf("%.0f dB", config.LA2A.Threshold)},
+			{"LA-2A Ratio", fmt.Sprintf("%.1f:1", config.LA2A.Ratio)},
 		})
 		if diagnostics != nil && diagnostics.LA2AHighCrestActive {
 			writeAnalysisMetricRows(w, "  ", 15, []analysisMetricSpec{

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -155,15 +155,15 @@ func TestDisplayAnalysisResults_VoiceActivated_NoElectedCandidate(t *testing.T) 
 func TestDisplayAnalysisResults_FullOutputFixture(t *testing.T) {
 	m := makeFullAnalysisMeasurements()
 	config := processor.DefaultEffectiveFilterConfig()
-	config.NoiseRemoveCompandEnabled = true
-	config.NoiseRemoveCompandThreshold = -53
-	config.NoiseRemoveCompandExpansion = 7
-	config.DeessIntensity = 0.35
-	config.LA2AThreshold = -21
-	config.LA2ARatio = 2.5
-	config.DS201HPFreq = 85
-	config.DS201GateThreshold = processor.DbToLinear(-51.2)
-	config.DS201GateRatio = 3.0
+	config.NoiseRemove.CompandEnabled = true
+	config.NoiseRemove.CompandThreshold = -53
+	config.NoiseRemove.CompandExpansion = 7
+	config.Deesser.Intensity = 0.35
+	config.LA2A.Threshold = -21
+	config.LA2A.Ratio = 2.5
+	config.DS201HighPass.Frequency = 85
+	config.DS201Gate.Threshold = processor.DbToLinear(-51.2)
+	config.DS201Gate.Ratio = 3.0
 	timings := AnalysisTimings{
 		Analysis:     2*time.Minute + 3*time.Second,
 		Adaptation:   1500 * time.Millisecond,
@@ -277,12 +277,12 @@ ANALYSIS TIMINGS
 func TestDisplayAnalysisResultsWithDiagnostics_UsesEffectiveConfigAndDiagnostics(t *testing.T) {
 	m := makeFullAnalysisMeasurements()
 	config := processor.DefaultEffectiveFilterConfig()
-	config.DS201LPEnabled = false
-	config.DeessIntensity = 0.62
-	config.DS201GateThreshold = processor.DbToLinear(-48.2)
-	config.DS201GateRatio = 3.5
-	config.LA2AThreshold = -26
-	config.LA2ARatio = 4.2
+	config.DS201LowPass.Enabled = false
+	config.Deesser.Intensity = 0.62
+	config.DS201Gate.Threshold = processor.DbToLinear(-48.2)
+	config.DS201Gate.Ratio = 3.5
+	config.LA2A.Threshold = -26
+	config.LA2A.Ratio = 4.2
 	effective := config
 	diagnostics := &processor.AdaptiveDiagnostics{
 		DS201LPReason:               "rolloff/centroid gap",
@@ -368,7 +368,7 @@ func TestDisplayAnalysisResults_Normal_NoVoiceActivated(t *testing.T) {
 func TestDisplayAnalysisResults_CompanderDisabled(t *testing.T) {
 	m := makeMinimalMeasurements()
 	config := processor.DefaultEffectiveFilterConfig()
-	config.NoiseRemoveCompandEnabled = false
+	config.NoiseRemove.CompandEnabled = false
 
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)
@@ -388,9 +388,9 @@ func TestDisplayAnalysisResults_CompanderDisabled(t *testing.T) {
 func TestDisplayAnalysisResults_CompanderEnabled(t *testing.T) {
 	m := makeMinimalMeasurements()
 	config := processor.DefaultEffectiveFilterConfig()
-	config.NoiseRemoveCompandEnabled = true
-	config.NoiseRemoveCompandThreshold = -55
-	config.NoiseRemoveCompandExpansion = 6
+	config.NoiseRemove.CompandEnabled = true
+	config.NoiseRemove.CompandThreshold = -55
+	config.NoiseRemove.CompandExpansion = 6
 
 	var buf bytes.Buffer
 	DisplayAnalysisResults(&buf, "/tmp/test.wav", makeMinimalMetadata(), m, config)

--- a/internal/logging/recording_tips.go
+++ b/internal/logging/recording_tips.go
@@ -332,11 +332,11 @@ func tipProximityEffect(m *processor.AudioMeasurements, _ *processor.EffectiveFi
 
 // tipSibilance fires when the adaptive de-esser was set to high intensity,
 // confirmed by bright speech spectral characteristics.
-// Checks EffectiveFilterConfig.DeessIntensity > 0.5 (deessIntensityNormal in adaptive.go),
+// Checks EffectiveFilterConfig.Deesser.Intensity > 0.5 (deessIntensityNormal in adaptive.go),
 // speech centroid > 4000 Hz (centroidBright), and speech rolloff > 10000 Hz.
 // Prefers SpeechProfile metrics when available, falling back to full-file metrics.
 func tipSibilance(m *processor.AudioMeasurements, config *processor.EffectiveFilterConfig) *RecordingTip {
-	if config == nil || config.DeessIntensity <= 0.5 {
+	if config == nil || config.Deesser.Intensity <= 0.5 {
 		return nil
 	}
 

--- a/internal/logging/recording_tips_test.go
+++ b/internal/logging/recording_tips_test.go
@@ -593,21 +593,21 @@ func TestTipSibilance(t *testing.T) {
 	}{
 		{
 			name:     "high de-esser bright speech",
-			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.6}},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			wantTip:  true,
 		},
 		{
 			name:     "low de-esser",
-			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.3},
+			config:   &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.3}},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			wantTip:  false,
 		},
 		{
 			name:     "de-esser at boundary no tip",
-			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.5},
+			config:   &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.5}},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			wantTip:  false,
@@ -621,21 +621,21 @@ func TestTipSibilance(t *testing.T) {
 		},
 		{
 			name:     "dark voice no sibilance",
-			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.6}},
 			centroid: 3000.0,
 			rolloff:  11000.0,
 			wantTip:  false,
 		},
 		{
 			name:     "low rolloff no sibilance",
-			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.6}},
 			centroid: 4500.0,
 			rolloff:  9000.0,
 			wantTip:  false,
 		},
 		{
 			name:     "speech profile overrides full-file",
-			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.6}},
 			centroid: 3000.0,
 			rolloff:  9000.0,
 			speechProfile: &processor.SpeechCandidateMetrics{
@@ -645,7 +645,7 @@ func TestTipSibilance(t *testing.T) {
 		},
 		{
 			name:     "speech profile zero values use full-file",
-			config:   &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
+			config:   &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.6}},
 			centroid: 4500.0,
 			rolloff:  11000.0,
 			speechProfile: &processor.SpeechCandidateMetrics{
@@ -932,7 +932,7 @@ func TestGenerateRecordingTips(t *testing.T) {
 				m.Spectral.Rolloff = 11000.0
 				return m
 			}(),
-			config:      &processor.EffectiveFilterConfig{DeessIntensity: 0.6},
+			config:      &processor.EffectiveFilterConfig{Deesser: processor.DeesserConfig{Intensity: 0.6}},
 			wantRuleIDs: []string{"sibilance"},
 		},
 		{

--- a/internal/logging/report_diagnostics.go
+++ b/internal/logging/report_diagnostics.go
@@ -172,8 +172,8 @@ func writeDiagnosticPeakLimiter(f *os.File, result *processor.NormalisationResul
 		projectedTP := result.InputTP + result.LimiterGain
 		fmt.Fprintf(f, "Projected TP:    %.1f dBTP (gain %.1f dB applied to %.1f dBTP peaks)\n",
 			projectedTP, result.LimiterGain, result.InputTP)
-		fmt.Fprintf(f, "Target TP:       %.1f dBTP\n", config.LoudnormTargetTP)
-		fmt.Fprintf(f, "Headroom:        %.1f dB\n", config.LoudnormTargetTP-projectedTP)
+		fmt.Fprintf(f, "Target TP:       %.1f dBTP\n", config.Loudnorm.TargetTP)
+		fmt.Fprintf(f, "Headroom:        %.1f dB\n", config.Loudnorm.TargetTP-projectedTP)
 		fmt.Fprintln(f, "")
 		return
 	}
@@ -190,10 +190,10 @@ func writeDiagnosticPeakLimiter(f *os.File, result *processor.NormalisationResul
 	fmt.Fprintln(f, "Problem:")
 	fmt.Fprintf(f, "  Input TP:          %.1f dBTP (peaks from Pass 2 filtered audio)\n", result.InputTP)
 	fmt.Fprintf(f, "  Gain Required:     %+.1f dB (to reach %.1f LUFS from %.1f LUFS)\n",
-		result.LimiterGain, config.LoudnormTargetI, result.InputLUFS)
+		result.LimiterGain, config.Loudnorm.TargetI, result.InputLUFS)
 	fmt.Fprintf(f, "  Projected TP:      %.1f dBTP (would exceed %.1f dBTP target by %.1f dB)\n",
-		projectedTPWithoutLimiter, config.LoudnormTargetTP,
-		projectedTPWithoutLimiter-config.LoudnormTargetTP)
+		projectedTPWithoutLimiter, config.Loudnorm.TargetTP,
+		projectedTPWithoutLimiter-config.Loudnorm.TargetTP)
 	fmt.Fprintln(f, "")
 
 	fmt.Fprintln(f, "Solution (CBS Volumax-inspired peak limiting):")
@@ -241,7 +241,7 @@ func writeDiagnosticPeakLimiter(f *os.File, result *processor.NormalisationResul
 
 // writeDiagnosticLoudnorm outputs detailed loudnorm normalisation diagnostics.
 func writeDiagnosticLoudnorm(f *os.File, result *processor.NormalisationResult, config *processor.EffectiveFilterConfig) {
-	if result == nil || !config.LoudnormEnabled {
+	if result == nil || !config.Loudnorm.Enabled {
 		return
 	}
 
@@ -258,12 +258,12 @@ func writeDiagnosticLoudnorm(f *os.File, result *processor.NormalisationResult, 
 		fmt.Fprintf(f, "  Target I:   %.1f LUFS (adjusted from %.1f to preserve linear mode)\n",
 			result.EffectiveTargetI, result.RequestedTargetI)
 	} else {
-		fmt.Fprintf(f, "  Target I:   %.1f LUFS\n", config.LoudnormTargetI)
+		fmt.Fprintf(f, "  Target I:   %.1f LUFS\n", config.Loudnorm.TargetI)
 	}
-	fmt.Fprintf(f, "  Target TP:  %.1f dBTP\n", config.LoudnormTargetTP)
-	fmt.Fprintf(f, "  Target LRA: %.1f LU\n", config.LoudnormTargetLRA)
-	fmt.Fprintf(f, "  Mode:       %s\n", loudnormModeString(config.LoudnormLinear))
-	fmt.Fprintf(f, "  Dual mono:  %v\n", config.LoudnormDualMono)
+	fmt.Fprintf(f, "  Target TP:  %.1f dBTP\n", config.Loudnorm.TargetTP)
+	fmt.Fprintf(f, "  Target LRA: %.1f LU\n", config.Loudnorm.TargetLRA)
+	fmt.Fprintf(f, "  Mode:       %s\n", loudnormModeString(config.Loudnorm.Linear))
+	fmt.Fprintf(f, "  Dual mono:  %v\n", config.Loudnorm.DualMono)
 	fmt.Fprintf(f, "  Gain:       %+.2f dB\n", result.GainApplied)
 
 	// Display loudnorm filter's unique diagnostic info (I/TP/LRA values are in Loudness table)

--- a/internal/logging/report_filters.go
+++ b/internal/logging/report_filters.go
@@ -57,30 +57,31 @@ func formatFilter(f *os.File, filterID processor.FilterID, cfg *processor.Effect
 
 // formatDS201HighpassFilter outputs DS201-inspired highpass filter details
 func formatDS201HighpassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *processor.AudioMeasurements, prefix string) {
-	if !cfg.DS201HPEnabled {
+	highpass := cfg.DS201HighPass
+	if !highpass.Enabled {
 		fmt.Fprintf(f, "%sDS201 highpass: DISABLED\n", prefix)
 		return
 	}
 
 	// Show slope (6dB/oct for gentle, 12dB/oct for standard)
 	slope := "12dB/oct"
-	if cfg.DS201HPPoles == 1 {
+	if highpass.Poles == 1 {
 		slope = "6dB/oct"
 	}
 
 	// Build header with all relevant parameters
-	header := fmt.Sprintf("%sDS201 highpass: %.0f Hz cutoff (%s", prefix, cfg.DS201HPFreq, slope)
+	header := fmt.Sprintf("%sDS201 highpass: %.0f Hz cutoff (%s", prefix, highpass.Frequency, slope)
 
 	// Show Q if not default Butterworth
-	if cfg.DS201HPWidth > 0 && cfg.DS201HPWidth != 0.707 {
-		header += fmt.Sprintf(", Q=%.2f", cfg.DS201HPWidth)
+	if highpass.Width > 0 && highpass.Width != 0.707 {
+		header += fmt.Sprintf(", Q=%.2f", highpass.Width)
 	}
 
 	// Show transform if specified
-	if cfg.DS201HPTransform == "tdii" {
+	if highpass.Transform == "tdii" {
 		header += ", tdii"
-	} else if cfg.DS201HPTransform != "" {
-		header += ", " + cfg.DS201HPTransform
+	} else if highpass.Transform != "" {
+		header += ", " + highpass.Transform
 	}
 
 	header += ")"
@@ -97,23 +98,23 @@ func formatDS201HighpassFilter(f *os.File, cfg *processor.EffectiveFilterConfig,
 		fmt.Fprintf(f, "        Rationale: %s voice (centroid %.0f Hz)\n", voiceType, m.Spectral.Centroid)
 
 		// Show warm voice protection if applicable (using mix)
-		if cfg.DS201HPMix > 0 && cfg.DS201HPMix < 1.0 {
+		if highpass.Mix > 0 && highpass.Mix < 1.0 {
 			reason := "warm voice"
 			if m.Spectral.Decrease < -0.08 {
 				reason = "very warm voice"
 			} else if m.Spectral.Skewness > 1.0 {
 				reason = "LF emphasis"
 			}
-			fmt.Fprintf(f, "        Mix: %.0f%% (%s — blending filtered with dry signal)\n", cfg.DS201HPMix*100, reason)
+			fmt.Fprintf(f, "        Mix: %.0f%% (%s — blending filtered with dry signal)\n", highpass.Mix*100, reason)
 		}
 
 		// Show why low frequency was chosen for warm voices
-		if cfg.DS201HPFreq <= 40 {
-			fmt.Fprintf(f, "        Frequency: %.0f Hz (subsonic only — protecting bass foundation)\n", cfg.DS201HPFreq)
+		if highpass.Frequency <= 40 {
+			fmt.Fprintf(f, "        Frequency: %.0f Hz (subsonic only — protecting bass foundation)\n", highpass.Frequency)
 		}
 
 		// Show gentle slope explanation
-		if cfg.DS201HPPoles == 1 {
+		if highpass.Poles == 1 {
 			fmt.Fprintf(f, "        Slope: 6dB/oct (gentle rolloff — preserving warmth)\n")
 		}
 	}
@@ -121,7 +122,8 @@ func formatDS201HighpassFilter(f *os.File, cfg *processor.EffectiveFilterConfig,
 
 // formatDS201LowPassFilter outputs DS201-inspired low-pass filter details
 func formatDS201LowPassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements, prefix string) {
-	if !cfg.DS201LPEnabled {
+	lowpass := cfg.DS201LowPass
+	if !lowpass.Enabled {
 		// Show reason for being disabled (pass-through mode)
 		if diagnostics != nil && diagnostics.DS201LPReason != "" {
 			fmt.Fprintf(f, "%sDS201 lowpass: DISABLED (%s)\n", prefix, diagnostics.DS201LPReason)
@@ -133,28 +135,28 @@ func formatDS201LowPassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, 
 
 	// Show slope (6dB/oct for gentle, 12dB/oct for standard)
 	slope := "12dB/oct"
-	if cfg.DS201LPPoles == 1 {
+	if lowpass.Poles == 1 {
 		slope = "6dB/oct"
 	}
 
 	// Build header with all relevant parameters
-	header := fmt.Sprintf("%sDS201 lowpass: %.0f Hz cutoff (%s", prefix, cfg.DS201LPFreq, slope)
+	header := fmt.Sprintf("%sDS201 lowpass: %.0f Hz cutoff (%s", prefix, lowpass.Frequency, slope)
 
 	// Show Q if not default Butterworth
-	if cfg.DS201LPWidth > 0 && cfg.DS201LPWidth != 0.707 {
-		header += fmt.Sprintf(", Q=%.2f", cfg.DS201LPWidth)
+	if lowpass.Width > 0 && lowpass.Width != 0.707 {
+		header += fmt.Sprintf(", Q=%.2f", lowpass.Width)
 	}
 
 	// Show transform if specified
-	if cfg.DS201LPTransform == "tdii" {
+	if lowpass.Transform == "tdii" {
 		header += ", tdii"
-	} else if cfg.DS201LPTransform != "" {
-		header += ", " + cfg.DS201LPTransform
+	} else if lowpass.Transform != "" {
+		header += ", " + lowpass.Transform
 	}
 
 	// Show mix if not full wet
-	if cfg.DS201LPMix > 0 && cfg.DS201LPMix < 1.0 {
-		header += fmt.Sprintf(", mix %.0f%%", cfg.DS201LPMix*100)
+	if lowpass.Mix > 0 && lowpass.Mix < 1.0 {
+		header += fmt.Sprintf(", mix %.0f%%", lowpass.Mix*100)
 	}
 
 	header += ")"
@@ -197,7 +199,8 @@ func formatDS201LowPassFilter(f *os.File, cfg *processor.EffectiveFilterConfig, 
 // formatNoiseRemoveFilter outputs NoiseRemove (anlmdn + compand) filter details
 // Uses Non-Local Means denoiser followed by compand for residual suppression
 func formatNoiseRemoveFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *processor.AudioMeasurements, prefix string) {
-	if !cfg.NoiseRemoveEnabled {
+	noiseRemove := cfg.NoiseRemove
+	if !noiseRemove.Enabled {
 		fmt.Fprintf(f, "%snoiseremove: DISABLED\n", prefix)
 		return
 	}
@@ -207,40 +210,41 @@ func formatNoiseRemoveFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m
 
 	// anlmdn parameters (matrix spike defaults: r_min + m_strict at source rate)
 	fmt.Fprintf(f, "        anlmdn: s=%.5f, p=%.4fs, r=%.4fs, m=%.0f\n",
-		cfg.NoiseRemoveStrength,
-		cfg.NoiseRemovePatchSec,
-		cfg.NoiseRemoveResearchSec,
-		cfg.NoiseRemoveSmooth)
+		noiseRemove.Strength,
+		noiseRemove.PatchSec,
+		noiseRemove.ResearchSec,
+		noiseRemove.Smooth)
 
 	// compand parameters and rationale - show noise floor source
 	if m != nil && m.NoiseProfile != nil && m.NoiseProfile.MeasuredNoiseFloor < 0 {
 		fmt.Fprintf(f, "        noise floor: %.1f dBFS (from silence regions)\n",
 			m.NoiseProfile.MeasuredNoiseFloor)
 		fmt.Fprintf(f, "        compand: threshold %.0f dB (floor + 5dB), expansion %.0f dB\n",
-			cfg.NoiseRemoveCompandThreshold,
-			cfg.NoiseRemoveCompandExpansion)
+			noiseRemove.CompandThreshold,
+			noiseRemove.CompandExpansion)
 	} else {
 		fmt.Fprintf(f, "        compand: threshold %.0f dB, expansion %.0f dB (defaults - no noise profile)\n",
-			cfg.NoiseRemoveCompandThreshold,
-			cfg.NoiseRemoveCompandExpansion)
+			noiseRemove.CompandThreshold,
+			noiseRemove.CompandExpansion)
 	}
 	fmt.Fprintf(f, "        timing: attack %.0fms, decay %.0fms, knee %.0f dB\n",
-		cfg.NoiseRemoveCompandAttack*1000,
-		cfg.NoiseRemoveCompandDecay*1000,
-		cfg.NoiseRemoveCompandKnee)
+		noiseRemove.CompandAttack*1000,
+		noiseRemove.CompandDecay*1000,
+		noiseRemove.CompandKnee)
 }
 
 // formatDS201GateFilter outputs DS201-inspired gate filter details
 func formatDS201GateFilter(f *os.File, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements, prefix string) {
-	if !cfg.DS201GateEnabled {
+	gate := cfg.DS201Gate
+	if !gate.Enabled {
 		fmt.Fprintf(f, "%sDS201 gate: DISABLED\n", prefix)
 		return
 	}
 
-	thresholdDB := processor.LinearToDb(cfg.DS201GateThreshold)
-	rangeDB := processor.LinearToDb(cfg.DS201GateRange)
+	thresholdDB := processor.LinearToDb(gate.Threshold)
+	rangeDB := processor.LinearToDb(gate.Range)
 
-	detection := cfg.DS201GateDetection
+	detection := gate.Detection
 	if detection == "" {
 		detection = "rms"
 	}
@@ -251,9 +255,9 @@ func formatDS201GateFilter(f *os.File, cfg *processor.EffectiveFilterConfig, dia
 		modeNote = " [gentle mode]"
 	}
 
-	fmt.Fprintf(f, "%sDS201 gate: threshold %.1f dB, ratio %.1f:1, detection %s%s\n", prefix, thresholdDB, cfg.DS201GateRatio, detection, modeNote)
-	fmt.Fprintf(f, "        Timing: attack %.2fms, release %.0fms (soft expander)\n", cfg.DS201GateAttack, cfg.DS201GateRelease)
-	fmt.Fprintf(f, "        Range: %.1f dB reduction, knee %.1f\n", rangeDB, cfg.DS201GateKnee)
+	fmt.Fprintf(f, "%sDS201 gate: threshold %.1f dB, ratio %.1f:1, detection %s%s\n", prefix, thresholdDB, gate.Ratio, detection, modeNote)
+	fmt.Fprintf(f, "        Timing: attack %.2fms, release %.0fms (soft expander)\n", gate.Attack, gate.Release)
+	fmt.Fprintf(f, "        Range: %.1f dB reduction, knee %.1f\n", rangeDB, gate.Knee)
 
 	// Show rationale based on measurements
 	if m != nil {
@@ -261,7 +265,7 @@ func formatDS201GateFilter(f *os.File, cfg *processor.EffectiveFilterConfig, dia
 
 		// Threshold rationale - must match logic in calculateDS201GateThreshold
 		// Peak reference is used when: crest > 20 AND peak != 0 AND lufsGap < 25
-		lufsGap := cfg.TargetI - m.InputI
+		lufsGap := cfg.Loudnorm.TargetI - m.InputI
 		if lufsGap < 0 {
 			lufsGap = 0
 		}
@@ -333,14 +337,15 @@ func formatDS201GateFilter(f *os.File, cfg *processor.EffectiveFilterConfig, dia
 
 // formatLA2ACompressorFilter outputs LA-2A Compressor filter details
 func formatLA2ACompressorFilter(f *os.File, cfg *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, m *processor.AudioMeasurements, prefix string) {
-	if !cfg.LA2AEnabled {
+	la2a := cfg.LA2A
+	if !la2a.Enabled {
 		fmt.Fprintf(f, "%sLA-2A Compressor: DISABLED\n", prefix)
 		return
 	}
 
-	fmt.Fprintf(f, "%sLA-2A Compressor: threshold %.0f dB, ratio %.1f:1\n", prefix, cfg.LA2AThreshold, cfg.LA2ARatio)
-	fmt.Fprintf(f, "        Timing: attack %.0fms, release %.0fms\n", cfg.LA2AAttack, cfg.LA2ARelease)
-	fmt.Fprintf(f, "        Mix: %.0f%%, knee %.1f\n", cfg.LA2AMix*100, cfg.LA2AKnee)
+	fmt.Fprintf(f, "%sLA-2A Compressor: threshold %.0f dB, ratio %.1f:1\n", prefix, la2a.Threshold, la2a.Ratio)
+	fmt.Fprintf(f, "        Timing: attack %.0fms, release %.0fms\n", la2a.Attack, la2a.Release)
+	fmt.Fprintf(f, "        Mix: %.0f%%, knee %.1f\n", la2a.Mix*100, la2a.Knee)
 
 	// Show rationale with measurement sources
 	if m != nil && m.DynamicRange > 0 {
@@ -378,10 +383,10 @@ func formatLA2ACompressorFilter(f *os.File, cfg *processor.EffectiveFilterConfig
 		gainRequired := processor.NormTargetLUFS - m.InputI
 		fmt.Fprintf(f, "        Projected TP: %.1f dBTP (gain %.1f dB applied to %.1f dBTP peaks)\n",
 			diagnostics.LA2AHighCrestProjectedTP, gainRequired, m.InputTP)
-		idealCeiling := cfg.LoudnormTargetTP - gainRequired - 1.5
+		idealCeiling := cfg.Loudnorm.TargetTP - gainRequired - 1.5
 		fmt.Fprintf(f, "        Ideal ceiling: %.1f dBTP, alimiter minimum: -24.0 dBTP\n", idealCeiling)
 		fmt.Fprintf(f, "        Override targets: threshold <= %.0f dB, ratio >= %.1f:1\n",
-			cfg.LA2AThreshold, cfg.LA2ARatio)
+			la2a.Threshold, la2a.Ratio)
 	} else {
 		highCrestDeficit := 0.0
 		if diagnostics != nil {
@@ -394,11 +399,12 @@ func formatLA2ACompressorFilter(f *os.File, cfg *processor.EffectiveFilterConfig
 
 // formatDeesserFilter outputs deesser filter details
 func formatDeesserFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *processor.AudioMeasurements, prefix string) {
-	if !cfg.DeessEnabled {
+	deesser := cfg.Deesser
+	if !deesser.Enabled {
 		fmt.Fprintf(f, "%sdeesser: DISABLED\n", prefix)
 		return
 	}
-	if cfg.DeessIntensity == 0 {
+	if deesser.Intensity == 0 {
 		if m == nil || m.SpeechProfile == nil {
 			fmt.Fprintf(f, "%sdeesser: inactive: no speech profile (full-file metrics unreliable)\n", prefix)
 		} else {
@@ -408,7 +414,7 @@ func formatDeesserFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *pr
 	}
 
 	fmt.Fprintf(f, "%sdeesser: intensity %.0f%%, amount %.0f%%, freq %.0f%%\n",
-		prefix, cfg.DeessIntensity*100, cfg.DeessAmount*100, cfg.DeessFreq*100)
+		prefix, deesser.Intensity*100, deesser.Amount*100, deesser.Frequency*100)
 
 	// Show rationale with measurement source
 	if m != nil && m.Spectral.Centroid > 0 {
@@ -442,7 +448,7 @@ func formatDeesserFilter(f *os.File, cfg *processor.EffectiveFilterConfig, m *pr
 
 // formatDownmixFilter outputs downmix filter details
 func formatDownmixFilter(f *os.File, cfg *processor.EffectiveFilterConfig, prefix string) {
-	if !cfg.DownmixEnabled {
+	if !cfg.Downmix.Enabled {
 		fmt.Fprintf(f, "%sdownmix: DISABLED\n", prefix)
 		return
 	}
@@ -451,7 +457,7 @@ func formatDownmixFilter(f *os.File, cfg *processor.EffectiveFilterConfig, prefi
 
 // formatAnalysisFilter outputs analysis filter details
 func formatAnalysisFilter(f *os.File, cfg *processor.EffectiveFilterConfig, prefix string) {
-	if !cfg.AnalysisEnabled {
+	if !cfg.Analysis.Enabled {
 		fmt.Fprintf(f, "%sanalysis: DISABLED\n", prefix)
 		return
 	}
@@ -460,10 +466,11 @@ func formatAnalysisFilter(f *os.File, cfg *processor.EffectiveFilterConfig, pref
 
 // formatResampleFilter outputs resample filter details
 func formatResampleFilter(f *os.File, cfg *processor.EffectiveFilterConfig, prefix string) {
-	if !cfg.ResampleEnabled {
+	resample := cfg.Resample
+	if !resample.Enabled {
 		fmt.Fprintf(f, "%sresample: DISABLED\n", prefix)
 		return
 	}
 	fmt.Fprintf(f, "%sresample: %d Hz %s mono, %d samples/frame\n",
-		prefix, cfg.ResampleSampleRate, cfg.ResampleFormat, cfg.ResampleFrameSize)
+		prefix, resample.SampleRate, resample.Format, resample.FrameSize)
 }

--- a/internal/logging/report_test.go
+++ b/internal/logging/report_test.go
@@ -317,10 +317,10 @@ func TestGenerateReport_FilterChainUsesProcessingDiagnostics(t *testing.T) {
 
 func TestGenerateReport_FilterChainReportsDeesser(t *testing.T) {
 	data := makeReportData(t)
-	data.Result.Config.DeessEnabled = true
-	data.Result.Config.DeessIntensity = 0.42
-	data.Result.Config.DeessAmount = 0.55
-	data.Result.Config.DeessFreq = 0.65
+	data.Result.Config.Deesser.Enabled = true
+	data.Result.Config.Deesser.Intensity = 0.42
+	data.Result.Config.Deesser.Amount = 0.55
+	data.Result.Config.Deesser.Frequency = 0.65
 
 	output := generateReportText(t, data)
 
@@ -333,6 +333,10 @@ func TestGenerateReport_FilterChainReportsDeesser(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Errorf("report missing %q", want)
 		}
+	}
+
+	if strings.Contains(output, "99%") {
+		t.Error("report used stale flat deesser fields")
 	}
 }
 

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -121,28 +121,68 @@ func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) (*Ef
 	return effectiveConfig, diagnostics
 }
 
-// sanitizeConfig ensures no NaN or Inf values remain after adaptive tuning
+// sanitizeConfig ensures no NaN or Inf values remain after adaptive tuning.
 func sanitizeConfig(config *EffectiveFilterConfig) {
-	// DS201-inspired highpass filter
-	config.DS201HPFreq = sanitizeFloat(config.DS201HPFreq, ds201DefaultHPFreq)
-	config.DS201HPWidth = sanitizeFloat(config.DS201HPWidth, 0.707) // Butterworth default
-	config.DS201HPMix = sanitizeFloat(config.DS201HPMix, 1.0)       // Full wet default
+	sanitizeDS201HighPassConfig(&config.DS201HighPass)
+	sanitizeDS201LowPassConfig(&config.DS201LowPass)
+	sanitizeNoiseRemoveConfig(&config.NoiseRemove)
+	sanitizeDS201GateConfig(&config.DS201Gate)
+	sanitizeLA2AConfig(&config.LA2A)
+	sanitizeDeesserConfig(&config.Deesser)
+}
 
-	// DS201-inspired lowpass filter
-	config.DS201LPFreq = sanitizeFloat(config.DS201LPFreq, ds201LPDefaultFreq)
-	config.DS201LPWidth = sanitizeFloat(config.DS201LPWidth, 0.707) // Butterworth default
-	config.DS201LPMix = sanitizeFloat(config.DS201LPMix, 1.0)       // Full wet default
+func sanitizeDS201HighPassConfig(config *DS201HighPassConfig) {
+	config.Frequency = sanitizeFloat(config.Frequency, ds201DefaultHPFreq)
+	config.Width = sanitizeFloat(config.Width, 0.707)
+	config.Mix = sanitizeFloat(config.Mix, 1.0)
+}
 
-	// De-esser intensity
-	config.DeessIntensity = sanitizeFloat(config.DeessIntensity, defaultDeessIntensity)
+func sanitizeDS201LowPassConfig(config *DS201LowPassConfig) {
+	config.Frequency = sanitizeFloat(config.Frequency, ds201LPDefaultFreq)
+	config.Width = sanitizeFloat(config.Width, 0.707)
+	config.Mix = sanitizeFloat(config.Mix, 1.0)
+}
 
-	// LA-2A compressor
-	config.LA2ARatio = sanitizeFloat(config.LA2ARatio, defaultLA2ARatio)
-	config.LA2AThreshold = sanitizeFloat(config.LA2AThreshold, defaultLA2AThreshold)
-	// Note: LA2AMakeup not sanitised - always 0 (set in DefaultFilterConfig)
+func sanitizeNoiseRemoveConfig(config *NoiseRemoveConfig) {
+	defaults := defaultNoiseRemoveConfig()
+	config.Strength = sanitizeFloat(config.Strength, defaults.Strength)
+	config.PatchSec = sanitizeFloat(config.PatchSec, defaults.PatchSec)
+	config.ResearchSec = sanitizeFloat(config.ResearchSec, defaults.ResearchSec)
+	config.Smooth = sanitizeFloat(config.Smooth, defaults.Smooth)
+	config.CompandThreshold = sanitizeFloat(config.CompandThreshold, defaults.CompandThreshold)
+	config.CompandExpansion = sanitizeFloat(config.CompandExpansion, defaults.CompandExpansion)
+	config.CompandAttack = sanitizeFloat(config.CompandAttack, defaults.CompandAttack)
+	config.CompandDecay = sanitizeFloat(config.CompandDecay, defaults.CompandDecay)
+	config.CompandKnee = sanitizeFloat(config.CompandKnee, defaults.CompandKnee)
+}
 
-	// DS201-inspired gate threshold needs additional check for zero/negative
-	if math.IsNaN(config.DS201GateThreshold) || math.IsInf(config.DS201GateThreshold, 0) || config.DS201GateThreshold <= 0 {
-		config.DS201GateThreshold = ds201DefaultGateThreshold
+func sanitizeDS201GateConfig(config *DS201GateConfig) {
+	defaults := defaultDS201GateConfig()
+	if math.IsNaN(config.Threshold) || math.IsInf(config.Threshold, 0) || config.Threshold <= 0 {
+		config.Threshold = ds201DefaultGateThreshold
 	}
+	config.Ratio = sanitizeFloat(config.Ratio, defaults.Ratio)
+	config.Attack = sanitizeFloat(config.Attack, defaults.Attack)
+	config.Release = sanitizeFloat(config.Release, defaults.Release)
+	config.Range = sanitizeFloat(config.Range, defaults.Range)
+	config.Knee = sanitizeFloat(config.Knee, defaults.Knee)
+	config.Makeup = sanitizeFloat(config.Makeup, defaults.Makeup)
+}
+
+func sanitizeLA2AConfig(config *LA2AConfig) {
+	defaults := defaultLA2AConfig()
+	config.Ratio = sanitizeFloat(config.Ratio, defaultLA2ARatio)
+	config.Threshold = sanitizeFloat(config.Threshold, defaultLA2AThreshold)
+	config.Attack = sanitizeFloat(config.Attack, defaults.Attack)
+	config.Release = sanitizeFloat(config.Release, defaults.Release)
+	config.Makeup = sanitizeFloat(config.Makeup, defaults.Makeup)
+	config.Knee = sanitizeFloat(config.Knee, defaults.Knee)
+	config.Mix = sanitizeFloat(config.Mix, defaults.Mix)
+}
+
+func sanitizeDeesserConfig(config *DeesserConfig) {
+	defaults := defaultDeesserConfig()
+	config.Intensity = sanitizeFloat(config.Intensity, defaultDeessIntensity)
+	config.Amount = sanitizeFloat(config.Amount, defaults.Amount)
+	config.Frequency = sanitizeFloat(config.Frequency, defaults.Frequency)
 }

--- a/internal/processor/adaptive_deesser.go
+++ b/internal/processor/adaptive_deesser.go
@@ -34,7 +34,7 @@ func tuneDeesser(config *EffectiveFilterConfig, measurements *AudioMeasurements)
 	// Full-file spectral metrics are diluted by silence/noise regions
 	// and produce false positives for sibilance in speech-sparse recordings.
 	if measurements.SpeechProfile == nil {
-		config.DeessIntensity = 0.0
+		config.Deesser.Intensity = 0.0
 		return
 	}
 
@@ -78,22 +78,22 @@ func tuneDeesserFull(config *EffectiveFilterConfig, measurements *AudioMeasureme
 	switch {
 	case rolloff < rolloffNoSibilance:
 		// Very limited HF content - no sibilance expected
-		config.DeessIntensity = 0.0
+		config.Deesser.Intensity = 0.0
 
 	case rolloff < rolloffLimited:
 		// Limited HF extension - reduce intensity
-		config.DeessIntensity = baseIntensity * 0.7
-		if config.DeessIntensity < deessIntensityMin {
-			config.DeessIntensity = 0.0 // Skip if too low
+		config.Deesser.Intensity = baseIntensity * 0.7
+		if config.Deesser.Intensity < deessIntensityMin {
+			config.Deesser.Intensity = 0.0 // Skip if too low
 		}
 
 	case rolloff > rolloffExtensive:
 		// Extensive HF content - likely sibilance
-		config.DeessIntensity = math.Min(baseIntensity*1.2, deessIntensityMax)
+		config.Deesser.Intensity = math.Min(baseIntensity*1.2, deessIntensityMax)
 
 	default:
 		// Normal HF extension (8-12 kHz)
-		config.DeessIntensity = baseIntensity
+		config.Deesser.Intensity = baseIntensity
 	}
 }
 
@@ -108,10 +108,10 @@ func tuneDeesserCentroidOnly(config *EffectiveFilterConfig, measurements *AudioM
 
 	switch {
 	case centroid > centroidVeryBright:
-		config.DeessIntensity = deessIntensityBright
+		config.Deesser.Intensity = deessIntensityBright
 	case centroid > centroidBright:
-		config.DeessIntensity = deessIntensityNormal
+		config.Deesser.Intensity = deessIntensityNormal
 	default:
-		config.DeessIntensity = deessIntensityDark
+		config.Deesser.Intensity = deessIntensityDark
 	}
 }

--- a/internal/processor/adaptive_ds201_gate.go
+++ b/internal/processor/adaptive_ds201_gate.go
@@ -157,14 +157,14 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 	}
 
 	// Calculate LUFS gap for threshold decision
-	lufsGap := config.TargetI - measurements.InputI
+	lufsGap := config.Loudnorm.TargetI - measurements.InputI
 	if lufsGap < 0 {
 		lufsGap = 0
 	}
 
 	// 2. Ratio: based on LRA (loudness range) - soft expander approach
 	// Calculate ratio FIRST since threshold depends on it
-	config.DS201GateRatio = calculateDS201GateRatio(measurements.InputLRA)
+	config.DS201Gate.Ratio = calculateDS201GateRatio(measurements.InputLRA)
 
 	// Extract speech measurements (zero values if no profile)
 	var speechRMS, speechCrest float64
@@ -175,11 +175,11 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 
 	// 1. Threshold: sits above noise/bleed peaks, below quiet speech
 	// Gap is derived from ratio to achieve target reduction
-	config.DS201GateThreshold = calculateDS201GateThreshold(
+	config.DS201Gate.Threshold = calculateDS201GateThreshold(
 		measurements.NoiseFloor,
 		silencePeak,
 		silenceCrest,
-		config.DS201GateRatio,
+		config.DS201Gate.Ratio,
 		lufsGap,
 		measurements.InputLRA,
 		speechRMS,
@@ -201,7 +201,7 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 		// Determine clamp reason
 		noiseFloorLimit := measurements.NoiseFloor + ds201GateThresholdNoiseMargin
 		speechRMSLimit := measurements.SpeechProfile.RMSLevel - ds201GateThresholdSpeechMargin
-		actualThreshold := LinearToDb(config.DS201GateThreshold)
+		actualThreshold := LinearAmplitude(config.DS201Gate.Threshold).Decibels().Float64()
 
 		var clampReason string
 		switch {
@@ -224,7 +224,7 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 
 	// 3. Attack: based on MaxDifference, SpectralFlux, and SpectralCrest
 	// DS201-inspired: supports sub-millisecond attack for transient preservation
-	config.DS201GateAttack = calculateDS201GateAttack(
+	config.DS201Gate.Attack = calculateDS201GateAttack(
 		measurements.MaxDifference,
 		measurements.Spectral.Flux,
 		measurements.Spectral.Crest,
@@ -234,7 +234,7 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 	// Includes +50ms compensation for lack of Hold parameter
 	// Higher entropy = more broadband noise = faster release to cut noise quickly
 	// Low LRA = narrow dynamics = extend release to prevent pumping
-	config.DS201GateRelease = calculateDS201GateRelease(
+	config.DS201Gate.Release = calculateDS201GateRelease(
 		measurements.Spectral.Flux,
 		measurements.ZeroCrossingsRate,
 		silenceEntropy,
@@ -246,13 +246,13 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 
 	// Clamp range and convert to linear
 	rangeDB = clamp(rangeDB, float64(ds201GateRangeMinDB), float64(ds201GateRangeMaxDB))
-	config.DS201GateRange = DbToLinear(rangeDB)
+	config.DS201Gate.Range = Decibels(rangeDB).LinearAmplitude().Float64()
 
 	// 6. Knee: based on spectral crest - soft knee for natural transitions
-	config.DS201GateKnee = calculateDS201GateKnee(measurements.Spectral.Crest)
+	config.DS201Gate.Knee = calculateDS201GateKnee(measurements.Spectral.Crest)
 
 	// 7. Detection: RMS for bleed, peak for clean
-	config.DS201GateDetection = calculateDS201GateDetection(silenceEntropy, silenceCrest)
+	config.DS201Gate.Detection = calculateDS201GateDetection(silenceEntropy, silenceCrest)
 
 	// Note: Makeup gain left at default (1.0 unity) - loudnorm handles all level adjustment
 
@@ -261,8 +261,8 @@ func tuneDS201Gate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnosti
 	// to apply varying gain reduction across similar speech levels, creating
 	// volume modulation ("hunting"). Override to gentler parameters.
 	if lufsGap >= lufsGapExtreme && measurements.InputLRA < ds201GateGentleLRAThreshold {
-		config.DS201GateRatio = ds201GateGentleRatio
-		config.DS201GateKnee = ds201GateGentleKnee
+		config.DS201Gate.Ratio = ds201GateGentleRatio
+		config.DS201Gate.Knee = ds201GateGentleKnee
 		if diagnostics != nil {
 			diagnostics.DS201GateGentleMode = true
 		}
@@ -329,7 +329,7 @@ func calculateDS201GateThresholdLegacy(
 
 	thresholdDB = clamp(thresholdDB, ds201GateThresholdMinDB, ds201GateThresholdMaxDB)
 
-	return DbToLinear(thresholdDB)
+	return Decibels(thresholdDB).LinearAmplitude().Float64()
 }
 
 // calculateDS201GateThreshold determines threshold ensuring sufficient gap above noise
@@ -381,7 +381,7 @@ func calculateDS201GateThreshold(
 		// Additional safety: respect global limits
 		thresholdDB = clamp(thresholdDB, ds201GateThresholdMinDB, ds201GateThresholdMaxDB)
 
-		return DbToLinear(thresholdDB)
+		return Decibels(thresholdDB).LinearAmplitude().Float64()
 	}
 
 	// Fallback: legacy noise-floor-based approach (no SpeechProfile)

--- a/internal/processor/adaptive_ds201_highpass.go
+++ b/internal/processor/adaptive_ds201_highpass.go
@@ -64,10 +64,10 @@ const (
 // - High entropy indicates broadband noise → skip notch filter
 // - Voice-aware: reduces harmonics for warm voices to protect vocal fundamentals
 func tuneDS201HighPass(config *EffectiveFilterConfig, measurements *AudioMeasurements) {
-	config.DS201HPPoles = ds201HPDefaultPoles
-	config.DS201HPWidth = ds201HPDefaultWidth
-	config.DS201HPMix = ds201HPDefaultMix
-	config.DS201HPTransform = ds201HPDefaultTransform
+	config.DS201HighPass.Poles = ds201HPDefaultPoles
+	config.DS201HighPass.Width = ds201HPDefaultWidth
+	config.DS201HighPass.Mix = ds201HPDefaultMix
+	config.DS201HighPass.Transform = ds201HPDefaultTransform
 
 	if measurements.Spectral.Centroid <= 0 {
 		// No spectral analysis available - keep default
@@ -134,13 +134,13 @@ func tuneDS201HighPass(config *EffectiveFilterConfig, measurements *AudioMeasure
 
 	// Apply boost if warranted by noise characteristics (only for non-warm voices)
 	if shouldBoost {
-		config.DS201HPFreq = baseFreq + boostAmount
+		config.DS201HighPass.Frequency = baseFreq + boostAmount
 	} else {
-		config.DS201HPFreq = baseFreq
+		config.DS201HighPass.Frequency = baseFreq
 	}
 
 	// Set TDII transform for all highpass (best floating-point accuracy)
-	config.DS201HPTransform = ds201HPDefaultTransform
+	config.DS201HighPass.Transform = ds201HPDefaultTransform
 
 	// Protect warm voices with significant LF body
 	// Instead of disabling highpass, we use gentler settings:
@@ -153,27 +153,27 @@ func tuneDS201HighPass(config *EffectiveFilterConfig, measurements *AudioMeasure
 	case decrease < spectralDecreaseVeryWarm:
 		// Very warm voice
 		// Use minimal settings: 60Hz cutoff, gentle Q, 80% mix
-		config.DS201HPFreq = ds201HPVeryWarmFreq
-		config.DS201HPWidth = ds201HPVeryWarmWidth
-		config.DS201HPMix = ds201HPVeryWarmMix
-		config.DS201HPPoles = 1 // Gentle 6dB/oct slope
+		config.DS201HighPass.Frequency = ds201HPVeryWarmFreq
+		config.DS201HighPass.Width = ds201HPVeryWarmWidth
+		config.DS201HighPass.Mix = ds201HPVeryWarmMix
+		config.DS201HighPass.Poles = 1 // Gentle 6dB/oct slope
 	case skewness > spectralSkewnessLFEmphasis:
 		// Significant LF emphasis
 		// Use warm settings: 70Hz cutoff, gentle Q, 90% mix
-		config.DS201HPFreq = ds201HPWarmFreq
-		config.DS201HPWidth = ds201HPWarmWidth
-		config.DS201HPMix = ds201HPWarmMix
-		config.DS201HPPoles = 1 // Gentle 6dB/oct slope
+		config.DS201HighPass.Frequency = ds201HPWarmFreq
+		config.DS201HighPass.Width = ds201HPWarmWidth
+		config.DS201HighPass.Mix = ds201HPWarmMix
+		config.DS201HighPass.Poles = 1 // Gentle 6dB/oct slope
 	case decrease < spectralDecreaseWarm:
 		// Warm voice - cap at default with gentle slope to preserve body
-		if config.DS201HPFreq > ds201HPDefaultFreq {
-			config.DS201HPFreq = ds201HPDefaultFreq
+		if config.DS201HighPass.Frequency > ds201HPDefaultFreq {
+			config.DS201HighPass.Frequency = ds201HPDefaultFreq
 		}
-		config.DS201HPPoles = 1 // Gentle 6dB/oct slope
+		config.DS201HighPass.Poles = 1 // Gentle 6dB/oct slope
 	}
 
 	// Final cap at maximum to avoid affecting voice fundamentals
-	if config.DS201HPFreq > ds201HPMaxFreq {
-		config.DS201HPFreq = ds201HPMaxFreq
+	if config.DS201HighPass.Frequency > ds201HPMaxFreq {
+		config.DS201HighPass.Frequency = ds201HPMaxFreq
 	}
 }

--- a/internal/processor/adaptive_ds201_lowpass.go
+++ b/internal/processor/adaptive_ds201_lowpass.go
@@ -48,8 +48,8 @@ const (
 // to avoid audible HF loss.
 func tuneDS201LowPass(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
 	// Start disabled - only enable when we detect clear benefit
-	config.DS201LPEnabled = false
-	config.DS201LPFreq = ds201LPDefaultFreq
+	config.DS201LowPass.Enabled = false
+	config.DS201LowPass.Frequency = ds201LPDefaultFreq
 	if diagnostics == nil {
 		diagnostics = &AdaptiveDiagnostics{}
 	}
@@ -102,10 +102,10 @@ func tuneDS201LowPass(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagno
 //   - Conservative approach — preserves natural voice character
 func tuneDS201LowPassForSpeech(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, m *AudioMeasurements) {
 	// Default: DISABLED per spec — only activate when measurements indicate benefit
-	config.DS201LPEnabled = false
-	config.DS201LPFreq = ds201LPDefaultFreq
-	config.DS201LPPoles = 1 // 6dB/oct - gentle
-	config.DS201LPMix = 1.0
+	config.DS201LowPass.Enabled = false
+	config.DS201LowPass.Frequency = ds201LPDefaultFreq
+	config.DS201LowPass.Poles = 1 // 6dB/oct - gentle
+	config.DS201LowPass.Mix = 1.0
 	diagnostics.DS201LPReason = "no HF issues detected"
 
 	// Prefer speech-specific spectral metrics when available.
@@ -132,10 +132,10 @@ func tuneDS201LowPassForSpeech(config *EffectiveFilterConfig, diagnostics *Adapt
 		if cutoff > 20000 {
 			cutoff = 20000
 		}
-		config.DS201LPEnabled = true
-		config.DS201LPFreq = cutoff
-		config.DS201LPPoles = 1 // 6dB/oct - very gentle for ultrasonic cleanup
-		config.DS201LPMix = 1.0
+		config.DS201LowPass.Enabled = true
+		config.DS201LowPass.Frequency = cutoff
+		config.DS201LowPass.Poles = 1 // 6dB/oct - very gentle for ultrasonic cleanup
+		config.DS201LowPass.Mix = 1.0
 		diagnostics.DS201LPReason = "ultrasonic cleanup (rolloff > 14kHz)"
 		return
 	}
@@ -143,10 +143,10 @@ func tuneDS201LowPassForSpeech(config *EffectiveFilterConfig, diagnostics *Adapt
 	// Condition 3: High ZCR with low centroid (HF noise, not sibilance)
 	// Sibilance has high ZCR AND high centroid; noise has high ZCR with low centroid
 	if m.ZeroCrossingsRate > lpZCRHigh && centroid < lpZCRCentroidThreshold {
-		config.DS201LPEnabled = true
-		config.DS201LPFreq = lpZCRCutoff
-		config.DS201LPPoles = 1 // 6dB/oct - gentle
-		config.DS201LPMix = 0.8 // Blend with dry for transparency
+		config.DS201LowPass.Enabled = true
+		config.DS201LowPass.Frequency = lpZCRCutoff
+		config.DS201LowPass.Poles = 1 // 6dB/oct - gentle
+		config.DS201LowPass.Mix = 0.8 // Blend with dry for transparency
 		diagnostics.DS201LPReason = "high ZCR with low centroid (HF noise)"
 		return
 	}

--- a/internal/processor/adaptive_la2a.go
+++ b/internal/processor/adaptive_la2a.go
@@ -146,7 +146,7 @@ func applyHighCrestOverrides(config *EffectiveFilterConfig, diagnostics *Adaptiv
 	// Deficit calculation
 	gainRequired := NormTargetLUFS - measurements.InputI
 	projectedTP := measurements.InputTP + gainRequired
-	idealCeiling := config.LoudnormTargetTP - gainRequired - safetyMarginDB
+	idealCeiling := config.Loudnorm.TargetTP - gainRequired - safetyMarginDB
 	deficit := minLimiterCeilingDB - idealCeiling
 
 	if diagnostics != nil {
@@ -197,7 +197,7 @@ func tuneLA2AAttack(config *EffectiveFilterConfig, measurements *AudioMeasuremen
 		}
 	}
 
-	config.LA2AAttack = attack
+	config.LA2A.Attack = attack
 }
 
 // tuneLA2ARelease sets release time to approximate LA-2A's two-stage behaviour.
@@ -267,7 +267,7 @@ func tuneLA2ARelease(config *EffectiveFilterConfig, measurements *AudioMeasureme
 		release = math.Max(release, overrides.ReleaseFloor)
 	}
 
-	config.LA2ARelease = release
+	config.LA2A.Release = release
 }
 
 // tuneLA2ARatio sets compression ratio to emulate T4 optical cell behaviour.
@@ -325,7 +325,7 @@ func tuneLA2ARatio(config *EffectiveFilterConfig, measurements *AudioMeasurement
 		ratio = clamp(ratio, 2.0, 5.0)
 	}
 
-	config.LA2ARatio = ratio
+	config.LA2A.Ratio = ratio
 }
 
 // tuneLA2AThreshold sets threshold relative to RMS level.
@@ -333,7 +333,7 @@ func tuneLA2ARatio(config *EffectiveFilterConfig, measurements *AudioMeasurement
 // We calculate threshold as peak level minus headroom, where headroom determines depth.
 func tuneLA2AThreshold(config *EffectiveFilterConfig, measurements *AudioMeasurements, overrides la2aOverrides) {
 	if math.IsNaN(measurements.PeakLevel) || math.IsInf(measurements.PeakLevel, 0) {
-		config.LA2AThreshold = defaultLA2AThreshold
+		config.LA2A.Threshold = defaultLA2AThreshold
 		return
 	}
 
@@ -376,7 +376,7 @@ func tuneLA2AThreshold(config *EffectiveFilterConfig, measurements *AudioMeasure
 		threshold = math.Min(threshold, overrides.ThresholdFloor)
 	}
 
-	config.LA2AThreshold = threshold
+	config.LA2A.Threshold = threshold
 }
 
 // tuneLA2AKnee sets knee softness to emulate T4 optical cell.
@@ -425,7 +425,7 @@ func tuneLA2AKnee(config *EffectiveFilterConfig, measurements *AudioMeasurements
 		knee = clamp(knee, 1.0, 8.0)
 	}
 
-	config.LA2AKnee = knee
+	config.LA2A.Knee = knee
 }
 
 // tuneLA2AMix sets wet/dry mix.
@@ -445,5 +445,5 @@ func tuneLA2AMix(config *EffectiveFilterConfig, measurements *AudioMeasurements)
 		mix = la2aMixModerate
 	}
 
-	config.LA2AMix = mix
+	config.LA2A.Mix = mix
 }

--- a/internal/processor/adaptive_noise.go
+++ b/internal/processor/adaptive_noise.go
@@ -14,7 +14,7 @@ package processor
 // - research: production default (search window)
 // - smooth: 11 (weight smoothing)
 func tuneNoiseRemove(config *EffectiveFilterConfig, m *AudioMeasurements) {
-	if !config.NoiseRemoveEnabled {
+	if !config.NoiseRemove.Enabled {
 		return
 	}
 
@@ -23,12 +23,12 @@ func tuneNoiseRemove(config *EffectiveFilterConfig, m *AudioMeasurements) {
 	// without a reference profile. Disable the compand to avoid the
 	// blind fallback risking attenuation of quiet speech.
 	if m.NoiseProfile == nil || m.NoiseProfile.MeasuredNoiseFloor >= 0 {
-		config.NoiseRemoveCompandEnabled = false
+		config.NoiseRemove.CompandEnabled = false
 		return
 	}
 
 	// Re-enable compand (may have been disabled by a previous file in the same run)
-	config.NoiseRemoveCompandEnabled = true
+	config.NoiseRemove.CompandEnabled = true
 
 	noiseFloor := m.NoiseProfile.MeasuredNoiseFloor
 
@@ -40,8 +40,8 @@ func tuneNoiseRemove(config *EffectiveFilterConfig, m *AudioMeasurements) {
 	// Expansion: scale with noise severity
 	expansion := scaleExpansion(noiseFloor)
 
-	config.NoiseRemoveCompandThreshold = threshold
-	config.NoiseRemoveCompandExpansion = expansion
+	config.NoiseRemove.CompandThreshold = threshold
+	config.NoiseRemove.CompandExpansion = expansion
 
 	// attack, decay, knee stay constant (validated in spike testing)
 }

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -25,9 +25,9 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 
 	base := newTestBaseConfig()
 	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
-	base.DS201HPEnabled = true
-	base.DS201HPFreq = 95.0
-	base.TargetI = -18.0
+	base.DS201HighPass.Enabled = true
+	base.DS201HighPass.Frequency = 95.0
+	base.Loudnorm.TargetI = -18.0
 
 	effective, diagnostics := AdaptConfig(base, measurements)
 	if effective == nil {
@@ -41,11 +41,11 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) {
 		t.Errorf("base FilterOrder = %v, want unchanged custom order", base.FilterOrder)
 	}
-	if base.DS201HPFreq != 95.0 {
-		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", base.DS201HPFreq)
+	if base.DS201HighPass.Frequency != 95.0 {
+		t.Errorf("base DS201HighPass.Frequency = %.1f, want unchanged 95.0", base.DS201HighPass.Frequency)
 	}
-	if base.TargetI != -18.0 {
-		t.Errorf("base TargetI = %.1f, want unchanged -18.0", base.TargetI)
+	if base.Loudnorm.TargetI != -18.0 {
+		t.Errorf("base Loudnorm.TargetI = %.1f, want unchanged -18.0", base.Loudnorm.TargetI)
 	}
 
 	if !reflect.DeepEqual(effective.FilterOrder, base.FilterOrder) {
@@ -55,8 +55,8 @@ func TestAdaptConfigReturnsEffectiveConfig(t *testing.T) {
 	if base.FilterOrder[0] == FilterDownmix {
 		t.Fatal("effective FilterOrder mutation changed base FilterOrder")
 	}
-	if effective.DS201HPFreq == 95.0 {
-		t.Fatal("effective DS201HPFreq did not adapt from base seed value")
+	if effective.DS201HighPass.Frequency == 95.0 {
+		t.Fatal("effective DS201HighPass.Frequency did not adapt from base seed value")
 	}
 	if diagnostics.DS201LPContentType != ContentMusic {
 		t.Errorf("diagnostics DS201LPContentType = %v, want %v", diagnostics.DS201LPContentType, ContentMusic)
@@ -82,7 +82,7 @@ func TestAdaptConfigOrderIndependence(t *testing.T) {
 	if !firstDiagnostics.DS201GateGentleMode {
 		t.Fatal("file A setup failed: expected gentle gate mode")
 	}
-	if firstEffective.NoiseRemoveCompandEnabled {
+	if firstEffective.NoiseRemove.CompandEnabled {
 		t.Fatal("file A setup failed: expected compand disabled without a noise profile")
 	}
 	if !firstDiagnostics.LA2AHighCrestActive {
@@ -101,7 +101,7 @@ func TestAdaptConfigOrderIndependence(t *testing.T) {
 	assertOrderIndependentAdaptiveFields(t, afterA, alone)
 	assertOrderIndependentAdaptiveDiagnostics(t, afterADiagnostics, aloneDiagnostics)
 
-	if !sharedSeed.NoiseRemoveCompandEnabled {
+	if !sharedSeed.NoiseRemove.CompandEnabled {
 		t.Fatal("shared seed retained file A compand disabled state")
 	}
 }
@@ -162,12 +162,12 @@ func TestAdaptConfigSeedParameterOwnershipBoundary(t *testing.T) {
 
 func newOrderIndependenceSeed() *BaseFilterConfig {
 	config := newTestBaseConfig()
-	config.DS201HPEnabled = true
-	config.DS201LPEnabled = true
-	config.NoiseRemoveEnabled = true
-	config.DS201GateEnabled = true
-	config.LA2AEnabled = true
-	config.LoudnormTargetTP = -2.0
+	config.DS201HighPass.Enabled = true
+	config.DS201LowPass.Enabled = true
+	config.NoiseRemove.Enabled = true
+	config.DS201Gate.Enabled = true
+	config.LA2A.Enabled = true
+	config.Loudnorm.TargetTP = -2.0
 	return config
 }
 
@@ -224,20 +224,20 @@ func assertOrderIndependentAdaptiveFields(t *testing.T, got, want *EffectiveFilt
 		got  any
 		want any
 	}{
-		{"DS201HPFreq", got.DS201HPFreq, want.DS201HPFreq},
-		{"DS201HPPoles", got.DS201HPPoles, want.DS201HPPoles},
-		{"DS201HPWidth", got.DS201HPWidth, want.DS201HPWidth},
-		{"DS201HPMix", got.DS201HPMix, want.DS201HPMix},
-		{"DS201HPTransform", got.DS201HPTransform, want.DS201HPTransform},
-		{"NoiseRemoveCompandEnabled", got.NoiseRemoveCompandEnabled, want.NoiseRemoveCompandEnabled},
-		{"NoiseRemoveCompandThreshold", got.NoiseRemoveCompandThreshold, want.NoiseRemoveCompandThreshold},
-		{"NoiseRemoveCompandExpansion", got.NoiseRemoveCompandExpansion, want.NoiseRemoveCompandExpansion},
-		{"DS201LPEnabled", got.DS201LPEnabled, want.DS201LPEnabled},
-		{"DS201LPFreq", got.DS201LPFreq, want.DS201LPFreq},
-		{"LA2AThreshold", got.LA2AThreshold, want.LA2AThreshold},
-		{"LA2ARatio", got.LA2ARatio, want.LA2ARatio},
-		{"LA2ARelease", got.LA2ARelease, want.LA2ARelease},
-		{"LA2AKnee", got.LA2AKnee, want.LA2AKnee},
+		{"DS201HighPass.Frequency", got.DS201HighPass.Frequency, want.DS201HighPass.Frequency},
+		{"DS201HighPass.Poles", got.DS201HighPass.Poles, want.DS201HighPass.Poles},
+		{"DS201HighPass.Width", got.DS201HighPass.Width, want.DS201HighPass.Width},
+		{"DS201HighPass.Mix", got.DS201HighPass.Mix, want.DS201HighPass.Mix},
+		{"DS201HighPass.Transform", got.DS201HighPass.Transform, want.DS201HighPass.Transform},
+		{"NoiseRemove.CompandEnabled", got.NoiseRemove.CompandEnabled, want.NoiseRemove.CompandEnabled},
+		{"NoiseRemove.CompandThreshold", got.NoiseRemove.CompandThreshold, want.NoiseRemove.CompandThreshold},
+		{"NoiseRemove.CompandExpansion", got.NoiseRemove.CompandExpansion, want.NoiseRemove.CompandExpansion},
+		{"DS201LowPass.Enabled", got.DS201LowPass.Enabled, want.DS201LowPass.Enabled},
+		{"DS201LowPass.Frequency", got.DS201LowPass.Frequency, want.DS201LowPass.Frequency},
+		{"LA2A.Threshold", got.LA2A.Threshold, want.LA2A.Threshold},
+		{"LA2A.Ratio", got.LA2A.Ratio, want.LA2A.Ratio},
+		{"LA2A.Release", got.LA2A.Release, want.LA2A.Release},
+		{"LA2A.Knee", got.LA2A.Knee, want.LA2A.Knee},
 	}
 
 	for _, tt := range tests {
@@ -478,7 +478,7 @@ func TestTuneDS201HighPass(t *testing.T) {
 			centroid:         0, // triggers early return
 			spectralDecrease: 0.0,
 			noiseProfile:     makeNoiseProfile(-50.0, 0.8),
-			wantFreqMin:      80, // DefaultFilterConfig().DS201HPFreq
+			wantFreqMin:      80, // DefaultFilterConfig().DS201HighPass.Frequency
 			wantFreqMax:      80,
 		},
 		{
@@ -528,7 +528,7 @@ func TestTuneDS201HighPass(t *testing.T) {
 			// Setup: create test config and measurements
 			config := newTestConfig()
 			// Start with highpass enabled to test tuning behavior
-			config.DS201HPEnabled = true
+			config.DS201HighPass.Enabled = true
 			measurements := &AudioMeasurements{
 				BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: tt.centroid, Decrease: tt.spectralDecrease, Skewness: tt.spectralSkewness}},
 				NoiseProfile:     tt.noiseProfile,
@@ -539,72 +539,72 @@ func TestTuneDS201HighPass(t *testing.T) {
 
 			// Verify disabled state (legacy - now rarely used)
 			if tt.wantDisabled {
-				if config.DS201HPEnabled {
-					t.Errorf("DS201HPEnabled = true, want false")
+				if config.DS201HighPass.Enabled {
+					t.Errorf("DS201HighPass.Enabled = true, want false")
 				}
 				return // no further checks needed for disabled
 			}
 
 			// Verify enabled (warm voices now use gentle settings instead of disabling)
-			if !config.DS201HPEnabled {
-				t.Errorf("DS201HPEnabled = false, want true")
+			if !config.DS201HighPass.Enabled {
+				t.Errorf("DS201HighPass.Enabled = false, want true")
 			}
 
 			// Verify frequency
-			if config.DS201HPFreq < tt.wantFreqMin || config.DS201HPFreq > tt.wantFreqMax {
-				t.Errorf("DS201HPFreq = %.1f Hz, want [%.1f, %.1f] Hz",
-					config.DS201HPFreq, tt.wantFreqMin, tt.wantFreqMax)
+			if config.DS201HighPass.Frequency < tt.wantFreqMin || config.DS201HighPass.Frequency > tt.wantFreqMax {
+				t.Errorf("DS201HighPass.Frequency = %.1f Hz, want [%.1f, %.1f] Hz",
+					config.DS201HighPass.Frequency, tt.wantFreqMin, tt.wantFreqMax)
 			}
 
 			// Verify poles (slope) if specified
-			if tt.wantPoles > 0 && config.DS201HPPoles != tt.wantPoles {
-				t.Errorf("DS201HPPoles = %d, want %d", config.DS201HPPoles, tt.wantPoles)
+			if tt.wantPoles > 0 && config.DS201HighPass.Poles != tt.wantPoles {
+				t.Errorf("DS201HighPass.Poles = %d, want %d", config.DS201HighPass.Poles, tt.wantPoles)
 			}
 
 			// Verify width (Q) if specified
-			if tt.wantWidth > 0 && config.DS201HPWidth != tt.wantWidth {
-				t.Errorf("DS201HPWidth = %.3f, want %.3f", config.DS201HPWidth, tt.wantWidth)
+			if tt.wantWidth > 0 && config.DS201HighPass.Width != tt.wantWidth {
+				t.Errorf("DS201HighPass.Width = %.3f, want %.3f", config.DS201HighPass.Width, tt.wantWidth)
 			}
 
 			// Verify mix if specified
-			if tt.wantMix > 0 && config.DS201HPMix != tt.wantMix {
-				t.Errorf("DS201HPMix = %.2f, want %.2f", config.DS201HPMix, tt.wantMix)
+			if tt.wantMix > 0 && config.DS201HighPass.Mix != tt.wantMix {
+				t.Errorf("DS201HighPass.Mix = %.2f, want %.2f", config.DS201HighPass.Mix, tt.wantMix)
 			}
 		})
 	}
 
 	t.Run("resets adaptive baseline after warm tuning", func(t *testing.T) {
 		config := newTestConfig()
-		config.DS201HPEnabled = true
+		config.DS201HighPass.Enabled = true
 
 		tuneDS201HighPass(config, &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: 5000, Decrease: -0.12}},
 			NoiseProfile:     makeNoiseProfile(-50.0, 0.8),
 		})
 
-		if config.DS201HPPoles != 1 || config.DS201HPWidth != ds201HPVeryWarmWidth || config.DS201HPMix != ds201HPVeryWarmMix {
+		if config.DS201HighPass.Poles != 1 || config.DS201HighPass.Width != ds201HPVeryWarmWidth || config.DS201HighPass.Mix != ds201HPVeryWarmMix {
 			t.Fatalf("warm tuning did not enter gentle baseline: poles=%d width=%.3f mix=%.2f",
-				config.DS201HPPoles, config.DS201HPWidth, config.DS201HPMix)
+				config.DS201HighPass.Poles, config.DS201HighPass.Width, config.DS201HighPass.Mix)
 		}
 
 		tuneDS201HighPass(config, &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: 5000}},
 		})
 
-		if config.DS201HPFreq != ds201HPBrightFreq {
-			t.Errorf("DS201HPFreq = %.1f, want %.1f", config.DS201HPFreq, ds201HPBrightFreq)
+		if config.DS201HighPass.Frequency != ds201HPBrightFreq {
+			t.Errorf("DS201HighPass.Frequency = %.1f, want %.1f", config.DS201HighPass.Frequency, ds201HPBrightFreq)
 		}
-		if config.DS201HPPoles != ds201HPDefaultPoles {
-			t.Errorf("DS201HPPoles = %d, want %d", config.DS201HPPoles, ds201HPDefaultPoles)
+		if config.DS201HighPass.Poles != ds201HPDefaultPoles {
+			t.Errorf("DS201HighPass.Poles = %d, want %d", config.DS201HighPass.Poles, ds201HPDefaultPoles)
 		}
-		if config.DS201HPWidth != ds201HPDefaultWidth {
-			t.Errorf("DS201HPWidth = %.3f, want %.3f", config.DS201HPWidth, ds201HPDefaultWidth)
+		if config.DS201HighPass.Width != ds201HPDefaultWidth {
+			t.Errorf("DS201HighPass.Width = %.3f, want %.3f", config.DS201HighPass.Width, ds201HPDefaultWidth)
 		}
-		if config.DS201HPMix != ds201HPDefaultMix {
-			t.Errorf("DS201HPMix = %.2f, want %.2f", config.DS201HPMix, ds201HPDefaultMix)
+		if config.DS201HighPass.Mix != ds201HPDefaultMix {
+			t.Errorf("DS201HighPass.Mix = %.2f, want %.2f", config.DS201HighPass.Mix, ds201HPDefaultMix)
 		}
-		if config.DS201HPTransform != ds201HPDefaultTransform {
-			t.Errorf("DS201HPTransform = %q, want %q", config.DS201HPTransform, ds201HPDefaultTransform)
+		if config.DS201HighPass.Transform != ds201HPDefaultTransform {
+			t.Errorf("DS201HighPass.Transform = %q, want %q", config.DS201HighPass.Transform, ds201HPDefaultTransform)
 		}
 	})
 }
@@ -870,9 +870,9 @@ func TestTuneDS201LowPass(t *testing.T) {
 
 			tuneDS201LowPass(config, diagnostics, m)
 
-			if config.DS201LPEnabled != tt.wantEnabled {
-				t.Errorf("DS201LPEnabled = %v, want %v [%s]",
-					config.DS201LPEnabled, tt.wantEnabled, tt.desc)
+			if config.DS201LowPass.Enabled != tt.wantEnabled {
+				t.Errorf("DS201LowPass.Enabled = %v, want %v [%s]",
+					config.DS201LowPass.Enabled, tt.wantEnabled, tt.desc)
 			}
 
 			if diagnostics.DS201LPContentType != tt.wantContentType {
@@ -888,9 +888,9 @@ func TestTuneDS201LowPass(t *testing.T) {
 			assertNoStaleEffectiveConfigFields(t)
 
 			if tt.wantEnabled && tt.wantFreqMin > 0 {
-				if config.DS201LPFreq < tt.wantFreqMin || config.DS201LPFreq > tt.wantFreqMax {
-					t.Errorf("DS201LPFreq = %.0f Hz, want %.0f-%.0f Hz [%s]",
-						config.DS201LPFreq, tt.wantFreqMin, tt.wantFreqMax, tt.desc)
+				if config.DS201LowPass.Frequency < tt.wantFreqMin || config.DS201LowPass.Frequency > tt.wantFreqMax {
+					t.Errorf("DS201LowPass.Frequency = %.0f Hz, want %.0f-%.0f Hz [%s]",
+						config.DS201LowPass.Frequency, tt.wantFreqMin, tt.wantFreqMax, tt.desc)
 				}
 			}
 		})
@@ -1112,7 +1112,7 @@ func TestTuneDeesser(t *testing.T) {
 			// Setup
 			config := newTestConfig()
 			// Start with deesser disabled - tuneDeesser should set intensity based on spectral data
-			config.DeessIntensity = 0.0
+			config.Deesser.Intensity = 0.0
 			measurements := &AudioMeasurements{
 				BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: tt.centroid, Rolloff: tt.rolloff}},
 				SpeechProfile:    tt.speechProfile,
@@ -1122,13 +1122,13 @@ func TestTuneDeesser(t *testing.T) {
 			tuneDeesser(config, measurements)
 
 			// Verify
-			diff := config.DeessIntensity - tt.wantIntensity
+			diff := config.Deesser.Intensity - tt.wantIntensity
 			if diff < 0 {
 				diff = -diff
 			}
 			if diff > tt.tolerance {
-				t.Errorf("DeessIntensity = %.3f, want %.3f (±%.3f) [centroid=%.0f, rolloff=%.0f]",
-					config.DeessIntensity, tt.wantIntensity, tt.tolerance, tt.centroid, tt.rolloff)
+				t.Errorf("Deesser.Intensity = %.3f, want %.3f (±%.3f) [centroid=%.0f, rolloff=%.0f]",
+					config.Deesser.Intensity, tt.wantIntensity, tt.tolerance, tt.centroid, tt.rolloff)
 			}
 		})
 	}
@@ -1229,13 +1229,13 @@ func TestTuneDS201Gate(t *testing.T) {
 
 				tuneDS201GateForTest(config, measurements)
 
-				actualDB := linearToDB(config.DS201GateThreshold)
+				actualDB := linearToDB(config.DS201Gate.Threshold)
 				diff := actualDB - tt.wantThresholdDB
 				if diff < 0 {
 					diff = -diff
 				}
 				if diff > tt.tolerance {
-					t.Errorf("DS201GateThreshold = %.1f dB, want %.1f dB ±%.1f [%s]",
+					t.Errorf("DS201Gate.Threshold = %.1f dB, want %.1f dB ±%.1f [%s]",
 						actualDB, tt.wantThresholdDB, tt.tolerance, tt.desc)
 				}
 			})
@@ -1266,8 +1266,8 @@ func TestTuneDS201Gate(t *testing.T) {
 
 				tuneDS201GateForTest(config, measurements)
 
-				if config.DS201GateRatio != tt.wantRatio {
-					t.Errorf("DS201GateRatio = %.1f, want %.1f [%s]", config.DS201GateRatio, tt.wantRatio, tt.desc)
+				if config.DS201Gate.Ratio != tt.wantRatio {
+					t.Errorf("DS201Gate.Ratio = %.1f, want %.1f [%s]", config.DS201Gate.Ratio, tt.wantRatio, tt.desc)
 				}
 			})
 		}
@@ -1300,13 +1300,13 @@ func TestTuneDS201Gate(t *testing.T) {
 
 				tuneDS201GateForTest(config, measurements)
 
-				diff := config.DS201GateAttack - tt.wantAttackMS
+				diff := config.DS201Gate.Attack - tt.wantAttackMS
 				if diff < 0 {
 					diff = -diff
 				}
 				if diff > tt.tolerance {
-					t.Errorf("DS201GateAttack = %.1f ms, want %.1f ms ±%.1f [%s]",
-						config.DS201GateAttack, tt.wantAttackMS, tt.tolerance, tt.desc)
+					t.Errorf("DS201Gate.Attack = %.1f ms, want %.1f ms ±%.1f [%s]",
+						config.DS201Gate.Attack, tt.wantAttackMS, tt.tolerance, tt.desc)
 				}
 			})
 		}
@@ -1343,9 +1343,9 @@ func TestTuneDS201Gate(t *testing.T) {
 
 				tuneDS201GateForTest(config, measurements)
 
-				if config.DS201GateDetection != tt.wantDetection {
-					t.Errorf("DS201GateDetection = %q, want %q [%s]",
-						config.DS201GateDetection, tt.wantDetection, tt.desc)
+				if config.DS201Gate.Detection != tt.wantDetection {
+					t.Errorf("DS201Gate.Detection = %q, want %q [%s]",
+						config.DS201Gate.Detection, tt.wantDetection, tt.desc)
 				}
 			})
 		}
@@ -1381,13 +1381,13 @@ func TestTuneDS201Gate(t *testing.T) {
 
 				tuneDS201GateForTest(config, measurements)
 
-				actualDB := linearToDB(config.DS201GateRange)
+				actualDB := linearToDB(config.DS201Gate.Range)
 				diff := actualDB - tt.wantRangeDB
 				if diff < 0 {
 					diff = -diff
 				}
 				if diff > tt.tolerance {
-					t.Errorf("DS201GateRange = %.1f dB, want %.1f dB ±%.1f [%s]",
+					t.Errorf("DS201Gate.Range = %.1f dB, want %.1f dB ±%.1f [%s]",
 						actualDB, tt.wantRangeDB, tt.tolerance, tt.desc)
 				}
 			})
@@ -1406,14 +1406,14 @@ func TestTuneDS201Gate(t *testing.T) {
 		tuneDS201GateForTest(config, measurements)
 
 		// Should still calculate threshold from noise floor
-		thresholdDB := linearToDB(config.DS201GateThreshold)
+		thresholdDB := linearToDB(config.DS201Gate.Threshold)
 		if thresholdDB < -70 || thresholdDB > -25 {
-			t.Errorf("DS201GateThreshold = %.1f dB, want within bounds [-70, -25]", thresholdDB)
+			t.Errorf("DS201Gate.Threshold = %.1f dB, want within bounds [-70, -25]", thresholdDB)
 		}
 
 		// Detection should default to RMS when no profile
-		if config.DS201GateDetection != "rms" {
-			t.Errorf("DS201GateDetection = %q, want 'rms' (default for missing profile)", config.DS201GateDetection)
+		if config.DS201Gate.Detection != "rms" {
+			t.Errorf("DS201Gate.Detection = %q, want 'rms' (default for missing profile)", config.DS201Gate.Detection)
 		}
 	})
 
@@ -1494,9 +1494,9 @@ func TestTuneDS201Gate(t *testing.T) {
 
 				tuneDS201GateForTest(config, measurements)
 
-				if config.DS201GateRelease < tt.wantReleaseMin || config.DS201GateRelease > tt.wantReleaseMax {
-					t.Errorf("DS201GateRelease = %.1f ms, want %.1f-%.1f ms [%s]",
-						config.DS201GateRelease, tt.wantReleaseMin, tt.wantReleaseMax, tt.desc)
+				if config.DS201Gate.Release < tt.wantReleaseMin || config.DS201Gate.Release > tt.wantReleaseMax {
+					t.Errorf("DS201Gate.Release = %.1f ms, want %.1f-%.1f ms [%s]",
+						config.DS201Gate.Release, tt.wantReleaseMin, tt.wantReleaseMax, tt.desc)
 				}
 			})
 		}
@@ -1567,9 +1567,9 @@ func TestTuneDS201Gate(t *testing.T) {
 
 				tuneDS201GateForTest(config, measurements)
 
-				if config.DS201GateRelease < tt.wantReleaseMin || config.DS201GateRelease > tt.wantReleaseMax {
-					t.Errorf("DS201GateRelease = %.1f ms (LRA=%.1f LU), want %.1f-%.1f ms [%s]",
-						config.DS201GateRelease, tt.lra, tt.wantReleaseMin, tt.wantReleaseMax, tt.desc)
+				if config.DS201Gate.Release < tt.wantReleaseMin || config.DS201Gate.Release > tt.wantReleaseMax {
+					t.Errorf("DS201Gate.Release = %.1f ms (LRA=%.1f LU), want %.1f-%.1f ms [%s]",
+						config.DS201Gate.Release, tt.lra, tt.wantReleaseMin, tt.wantReleaseMax, tt.desc)
 				}
 			})
 		}
@@ -1604,9 +1604,9 @@ func TestTuneDS201Gate(t *testing.T) {
 			diagnostics.DS201GateClampReason == "" {
 			t.Fatalf("expected tuning to populate gate diagnostics: %+v", diagnostics)
 		}
-		if config.DS201GateRatio != ds201GateGentleRatio || config.DS201GateKnee != ds201GateGentleKnee {
+		if config.DS201Gate.Ratio != ds201GateGentleRatio || config.DS201Gate.Knee != ds201GateGentleKnee {
 			t.Fatalf("expected gentle mode to tune builder values, ratio=%.1f knee=%.1f",
-				config.DS201GateRatio, config.DS201GateKnee)
+				config.DS201Gate.Ratio, config.DS201Gate.Knee)
 		}
 		assertNoStaleEffectiveConfigFields(t)
 	})
@@ -1800,301 +1800,162 @@ func TestSanitizeFloat(t *testing.T) {
 }
 
 func TestSanitizeConfig(t *testing.T) {
-	// Tests for sanitizeConfig which sanitizes all tunable parameters in EffectiveFilterConfig
-	// Uses defaults from adaptive.go:
-	// defaultHighpassFreq   = 80.0
-	// defaultDeessIntensity = 0.0
-	// defaultLA2ARatio      = 3.0
-	// defaultLA2AThreshold  = -18.0
-	// defaultGateThreshold  = 0.01 (linear, ~-40dBFS)
-	// Note: LA2AMakeup not sanitised - always 0 (set in DefaultFilterConfig)
+	t.Run("valid typed config passes through unchanged", func(t *testing.T) {
+		config := EffectiveFilterConfig{
+			DS201HighPass: DS201HighPassConfig{Frequency: 100.0, Width: 0.5, Mix: 0.8},
+			DS201LowPass:  DS201LowPassConfig{Frequency: 14000.0, Width: 0.7, Mix: 0.9},
+			NoiseRemove: NoiseRemoveConfig{
+				Strength:         0.00001,
+				PatchSec:         0.006,
+				ResearchSec:      0.0058,
+				Smooth:           11.0,
+				CompandThreshold: -50.0,
+				CompandExpansion: 10.0,
+				CompandAttack:    0.005,
+				CompandDecay:     0.100,
+				CompandKnee:      6.0,
+			},
+			DS201Gate: DS201GateConfig{
+				Threshold: 0.02,
+				Ratio:     2.0,
+				Attack:    12,
+				Release:   250,
+				Range:     0.0625,
+				Knee:      3.0,
+				Makeup:    1.0,
+			},
+			LA2A:    LA2AConfig{Threshold: -24.0, Ratio: 3.0, Attack: 10, Release: 200, Makeup: 0, Knee: 4.0, Mix: 1.0},
+			Deesser: DeesserConfig{Intensity: 0.3, Amount: 0.5, Frequency: 0.5},
+		}
+		want := config
 
-	tests := []struct {
-		name   string
-		config EffectiveFilterConfig // input config
-		want   EffectiveFilterConfig // expected after sanitization
-	}{
-		// Clean config should pass through unchanged
-		{
-			name: "valid config passes through unchanged",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-		},
+		sanitizeConfig(&config)
 
-		// NaN in each field
-		{
-			name: "NaN HighpassFreq gets default",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        math.NaN(),
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        80.0, // defaultHighpassFreq
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-		},
-		{
-			name: "NaN DeessIntensity gets default",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     math.NaN(),
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.0, // defaultDeessIntensity
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-		},
-		{
-			name: "NaN LA2ARatio gets default",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          math.NaN(),
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0, // defaultLA2ARatio (LA-2A inspired)
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.02,
-			},
-		},
-		{
-			name: "NaN LA2AThreshold gets default",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      math.NaN(),
-				DS201GateThreshold: 0.02,
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -18.0, // defaultLA2AThreshold (LA-2A inspired)
-				DS201GateThreshold: 0.02,
-			},
-		},
-		{
-			name: "NaN GateThreshold gets default",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: math.NaN(),
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.01, // defaultGateThreshold
-			},
-		},
+		if !reflect.DeepEqual(config, want) {
+			t.Errorf("sanitizeConfig changed valid typed config:\ngot  %+v\nwant %+v", config, want)
+		}
+	})
 
-		// Inf cases
-		{
-			name: "positive Inf values get defaults",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        math.Inf(1),
-				DeessIntensity:     math.Inf(1),
-				LA2ARatio:          math.Inf(1),
-				LA2AThreshold:      math.Inf(1),
-				DS201GateThreshold: math.Inf(1),
+	t.Run("typed family non-finite values get defaults", func(t *testing.T) {
+		config := EffectiveFilterConfig{
+			DS201HighPass: DS201HighPassConfig{Frequency: math.NaN(), Width: math.Inf(1), Mix: math.Inf(-1)},
+			DS201LowPass:  DS201LowPassConfig{Frequency: math.Inf(1), Width: math.NaN(), Mix: math.Inf(-1)},
+			NoiseRemove: NoiseRemoveConfig{
+				Strength:         math.NaN(),
+				PatchSec:         math.Inf(1),
+				ResearchSec:      math.Inf(-1),
+				Smooth:           math.NaN(),
+				CompandThreshold: math.Inf(1),
+				CompandExpansion: math.Inf(-1),
+				CompandAttack:    math.NaN(),
+				CompandDecay:     math.Inf(1),
+				CompandKnee:      math.Inf(-1),
 			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        80.0,
-				DeessIntensity:     0.0,
-				LA2ARatio:          3.0,   // LA-2A inspired
-				LA2AThreshold:      -18.0, // LA-2A inspired
-				DS201GateThreshold: 0.01,
+			DS201Gate: DS201GateConfig{
+				Threshold: math.NaN(),
+				Ratio:     math.Inf(1),
+				Attack:    math.Inf(-1),
+				Release:   math.NaN(),
+				Range:     math.Inf(1),
+				Knee:      math.Inf(-1),
+				Makeup:    math.NaN(),
 			},
-		},
-		{
-			name: "negative Inf values get defaults",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        math.Inf(-1),
-				DeessIntensity:     math.Inf(-1),
-				LA2ARatio:          math.Inf(-1),
-				LA2AThreshold:      math.Inf(-1),
-				DS201GateThreshold: math.Inf(-1),
+			LA2A: LA2AConfig{
+				Threshold: math.NaN(),
+				Ratio:     math.Inf(1),
+				Attack:    math.Inf(-1),
+				Release:   math.NaN(),
+				Makeup:    math.Inf(1),
+				Knee:      math.Inf(-1),
+				Mix:       math.NaN(),
 			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        80.0,
-				DeessIntensity:     0.0,
-				LA2ARatio:          3.0,   // LA-2A inspired
-				LA2AThreshold:      -18.0, // LA-2A inspired
-				DS201GateThreshold: 0.01,
-			},
-		},
+			Deesser: DeesserConfig{Intensity: math.NaN(), Amount: math.Inf(1), Frequency: math.Inf(-1)},
+		}
 
-		// GateThreshold special cases: zero and negative get default
-		// (other fields allow zero/negative values)
-		{
-			name: "zero GateThreshold gets default",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.0, // zero is valid for DeessIntensity
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.0, // zero is NOT valid for GateThreshold
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.0,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.01, // defaultGateThreshold
-			},
-		},
-		{
-			name: "negative GateThreshold gets default",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: -0.5, // negative is NOT valid for GateThreshold
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 0.01, // defaultGateThreshold
-			},
-		},
+		sanitizeConfig(&config)
 
-		// Zero values for other fields pass through
-		// (sanitizeFloat doesn't treat zero specially)
-		{
-			name: "zero values for non-GateThreshold fields pass through",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        0.0, // passes through (edge case: probably invalid, but sanitize doesn't clamp)
-				DeessIntensity:     0.0, // valid: de-essing disabled
-				LA2ARatio:          0.0, // passes through (edge case: probably invalid)
-				LA2AThreshold:      0.0, // passes through (0 dB threshold)
-				DS201GateThreshold: 0.02,
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        0.0,
-				DeessIntensity:     0.0,
-				LA2ARatio:          0.0,
-				LA2AThreshold:      0.0,
-				DS201GateThreshold: 0.02,
-			},
-		},
+		if config.DS201HighPass.Frequency != ds201DefaultHPFreq || config.DS201HighPass.Width != 0.707 || config.DS201HighPass.Mix != 1.0 {
+			t.Errorf("DS201HighPass sanitised to %+v, want frequency %.1f width 0.707 mix 1.0", config.DS201HighPass, ds201DefaultHPFreq)
+		}
+		if config.DS201LowPass.Frequency != ds201LPDefaultFreq || config.DS201LowPass.Width != 0.707 || config.DS201LowPass.Mix != 1.0 {
+			t.Errorf("DS201LowPass sanitised to %+v, want frequency %.1f width 0.707 mix 1.0", config.DS201LowPass, ds201LPDefaultFreq)
+		}
 
-		// Negative values for fields that legitimately use them
-		{
-			name: "negative LA2AThreshold passes through (valid dB value)",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -40.0, // very aggressive threshold
-				DS201GateThreshold: 0.02,
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -40.0,
-				DS201GateThreshold: 0.02,
-			},
-		},
+		defaultNoise := defaultNoiseRemoveConfig()
+		defaultNoise.Enabled = false
+		defaultNoise.CompandEnabled = false
+		if config.NoiseRemove != defaultNoise {
+			t.Errorf("NoiseRemove sanitised to %+v, want %+v", config.NoiseRemove, defaultNoise)
+		}
 
-		// All fields NaN - complete fallback to defaults
-		{
-			name: "all NaN values get all defaults",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        math.NaN(),
-				DeessIntensity:     math.NaN(),
-				LA2ARatio:          math.NaN(),
-				LA2AThreshold:      math.NaN(),
-				DS201GateThreshold: math.NaN(),
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        80.0,
-				DeessIntensity:     0.0,
-				LA2ARatio:          3.0,   // LA-2A inspired
-				LA2AThreshold:      -18.0, // LA-2A inspired
-				DS201GateThreshold: 0.01,
-			},
-		},
+		defaultGate := defaultDS201GateConfig()
+		defaultGate.Enabled = false
+		defaultGate.Detection = ""
+		if config.DS201Gate != defaultGate {
+			t.Errorf("DS201Gate sanitised to %+v, want %+v", config.DS201Gate, defaultGate)
+		}
 
-		// Very small positive GateThreshold passes through
-		{
-			name: "very small positive GateThreshold passes through",
-			config: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 1e-10, // very small but positive
-			},
-			want: EffectiveFilterConfig{
-				DS201HPFreq:        100.0,
-				DeessIntensity:     0.3,
-				LA2ARatio:          3.0,
-				LA2AThreshold:      -24.0,
-				DS201GateThreshold: 1e-10,
-			},
-		},
-	}
+		defaultLA2A := defaultLA2AConfig()
+		defaultLA2A.Enabled = false
+		if config.LA2A != defaultLA2A {
+			t.Errorf("LA2A sanitised to %+v, want %+v", config.LA2A, defaultLA2A)
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Make a copy to avoid mutating test data
-			config := tt.config
+		defaultDeesser := defaultDeesserConfig()
+		defaultDeesser.Enabled = false
+		if config.Deesser != defaultDeesser {
+			t.Errorf("Deesser sanitised to %+v, want %+v", config.Deesser, defaultDeesser)
+		}
+	})
+
+	t.Run("gate threshold keeps existing zero and negative clamp behaviour", func(t *testing.T) {
+		for _, threshold := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), 0.0, -0.5} {
+			config := EffectiveFilterConfig{DS201Gate: DS201GateConfig{Threshold: threshold}}
+
 			sanitizeConfig(&config)
 
-			// Check each field
-			if config.DS201HPFreq != tt.want.DS201HPFreq {
-				t.Errorf("DS201HPFreq = %v, want %v", config.DS201HPFreq, tt.want.DS201HPFreq)
+			if config.DS201Gate.Threshold != ds201DefaultGateThreshold {
+				t.Errorf("DS201Gate.Threshold for input %v = %v, want %v", threshold, config.DS201Gate.Threshold, ds201DefaultGateThreshold)
 			}
-			if config.DeessIntensity != tt.want.DeessIntensity {
-				t.Errorf("DeessIntensity = %v, want %v", config.DeessIntensity, tt.want.DeessIntensity)
-			}
-			if config.LA2ARatio != tt.want.LA2ARatio {
-				t.Errorf("LA2ARatio = %v, want %v", config.LA2ARatio, tt.want.LA2ARatio)
-			}
-			if config.LA2AThreshold != tt.want.LA2AThreshold {
-				t.Errorf("LA2AThreshold = %v, want %v", config.LA2AThreshold, tt.want.LA2AThreshold)
-			}
-			if config.DS201GateThreshold != tt.want.DS201GateThreshold {
-				t.Errorf("DS201GateThreshold = %v, want %v", config.DS201GateThreshold, tt.want.DS201GateThreshold)
-			}
-		})
-	}
+		}
+	})
+
+	t.Run("zero values for non-gate typed fields pass through", func(t *testing.T) {
+		config := EffectiveFilterConfig{
+			DS201HighPass: DS201HighPassConfig{Frequency: 0.0, Width: 0.0, Mix: 0.0},
+			Deesser:       DeesserConfig{Intensity: 0.0},
+			LA2A:          LA2AConfig{Ratio: 0.0, Threshold: 0.0},
+			DS201Gate:     DS201GateConfig{Threshold: 1e-10},
+		}
+
+		sanitizeConfig(&config)
+
+		if config.DS201HighPass.Frequency != 0.0 || config.DS201HighPass.Width != 0.0 || config.DS201HighPass.Mix != 0.0 {
+			t.Errorf("DS201HighPass zero values changed: %+v", config.DS201HighPass)
+		}
+		if config.Deesser.Intensity != 0.0 {
+			t.Errorf("Deesser.Intensity = %v, want 0.0", config.Deesser.Intensity)
+		}
+		if config.LA2A.Ratio != 0.0 || config.LA2A.Threshold != 0.0 {
+			t.Errorf("LA2A zero values changed: %+v", config.LA2A)
+		}
+		if config.DS201Gate.Threshold != 1e-10 {
+			t.Errorf("DS201Gate.Threshold = %v, want 1e-10", config.DS201Gate.Threshold)
+		}
+	})
+
+	t.Run("negative LA2A threshold passes through", func(t *testing.T) {
+		config := EffectiveFilterConfig{
+			LA2A:      LA2AConfig{Threshold: -40.0, Ratio: 3.0},
+			DS201Gate: DS201GateConfig{Threshold: 0.02},
+		}
+
+		sanitizeConfig(&config)
+
+		if config.LA2A.Threshold != -40.0 {
+			t.Errorf("LA2A.Threshold = %v, want -40.0", config.LA2A.Threshold)
+		}
+	})
 }
 
 func TestTuneLA2AThresholdAcceptsZeroDBPeak(t *testing.T) {
@@ -2109,8 +1970,8 @@ func TestTuneLA2AThresholdAcceptsZeroDBPeak(t *testing.T) {
 
 	tuneLA2AThreshold(config, measurements, la2aOverrides{})
 
-	if math.Abs(config.LA2AThreshold-(-20.0)) > 0.001 {
-		t.Errorf("LA2AThreshold = %.3f, want -20.000", config.LA2AThreshold)
+	if math.Abs(config.LA2A.Threshold-(-20.0)) > 0.001 {
+		t.Errorf("LA2A.Threshold = %.3f, want -20.000", config.LA2A.Threshold)
 	}
 }
 
@@ -2126,8 +1987,8 @@ func TestTuneLA2AThresholdFallsBackForInvalidPeak(t *testing.T) {
 
 	tuneLA2AThreshold(config, measurements, la2aOverrides{})
 
-	if math.Abs(config.LA2AThreshold-defaultLA2AThreshold) > 0.001 {
-		t.Errorf("LA2AThreshold = %.3f, want %.3f", config.LA2AThreshold, defaultLA2AThreshold)
+	if math.Abs(config.LA2A.Threshold-defaultLA2AThreshold) > 0.001 {
+		t.Errorf("LA2A.Threshold = %.3f, want %.3f", config.LA2A.Threshold, defaultLA2AThreshold)
 	}
 }
 
@@ -2275,8 +2136,8 @@ func TestClamp(t *testing.T) {
 		{
 			name: "deess intensity clamping - below min",
 			val:  -0.1,
-			min:  0.0, // minDeessIntensity
-			max:  0.6, // maxDeessIntensity
+			min:  0.0, // minDeesser.Intensity
+			max:  0.6, // maxDeesser.Intensity
 			want: 0.0,
 		},
 		{
@@ -2308,8 +2169,8 @@ func TestTuneNoiseRemove(t *testing.T) {
 
 	t.Run("disabled filter returns early", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = false
-		originalThreshold := config.NoiseRemoveCompandThreshold
+		config.NoiseRemove.Enabled = false
+		originalThreshold := config.NoiseRemove.CompandThreshold
 
 		measurements := &AudioMeasurements{
 			NoiseProfile: &NoiseProfile{
@@ -2321,15 +2182,15 @@ func TestTuneNoiseRemove(t *testing.T) {
 		tuneNoiseRemove(config, measurements)
 
 		// Should not modify config when disabled
-		if config.NoiseRemoveCompandThreshold != originalThreshold {
+		if config.NoiseRemove.CompandThreshold != originalThreshold {
 			t.Errorf("tuneNoiseRemove should not modify disabled config")
 		}
 	})
 
 	t.Run("missing NoiseProfile disables compand", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveCompandEnabled = true
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.CompandEnabled = true
 
 		measurements := &AudioMeasurements{
 			NoiseProfile: nil,
@@ -2338,19 +2199,19 @@ func TestTuneNoiseRemove(t *testing.T) {
 		tuneNoiseRemove(config, measurements)
 
 		// anlmdn should remain enabled
-		if !config.NoiseRemoveEnabled {
+		if !config.NoiseRemove.Enabled {
 			t.Errorf("tuneNoiseRemove should keep filter enabled")
 		}
 		// Compand should be disabled (no calibration data)
-		if config.NoiseRemoveCompandEnabled {
-			t.Errorf("NoiseRemoveCompandEnabled should be false when NoiseProfile is nil")
+		if config.NoiseRemove.CompandEnabled {
+			t.Errorf("NoiseRemove.CompandEnabled should be false when NoiseProfile is nil")
 		}
 	})
 
 	t.Run("positive noise floor disables compand", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveCompandEnabled = true
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.CompandEnabled = true
 
 		measurements := &AudioMeasurements{
 			NoiseProfile: &NoiseProfile{
@@ -2362,15 +2223,15 @@ func TestTuneNoiseRemove(t *testing.T) {
 		tuneNoiseRemove(config, measurements)
 
 		// Compand should be disabled when noise floor is invalid
-		if config.NoiseRemoveCompandEnabled {
-			t.Errorf("NoiseRemoveCompandEnabled should be false when noise floor is non-negative")
+		if config.NoiseRemove.CompandEnabled {
+			t.Errorf("NoiseRemove.CompandEnabled should be false when noise floor is non-negative")
 		}
 	})
 
 	t.Run("valid NoiseProfile keeps compand enabled", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveCompandEnabled = true
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.CompandEnabled = true
 
 		measurements := &AudioMeasurements{
 			NoiseProfile: &NoiseProfile{
@@ -2381,20 +2242,20 @@ func TestTuneNoiseRemove(t *testing.T) {
 
 		tuneNoiseRemove(config, measurements)
 
-		if !config.NoiseRemoveCompandEnabled {
-			t.Errorf("NoiseRemoveCompandEnabled should remain true when NoiseProfile is valid")
+		if !config.NoiseRemove.CompandEnabled {
+			t.Errorf("NoiseRemove.CompandEnabled should remain true when NoiseProfile is valid")
 		}
 	})
 
 	t.Run("valid profile re-enables compand after previous disable", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
+		config.NoiseRemove.Enabled = true
 
 		// Simulate first file with no noise profile (disables compand)
-		config.NoiseRemoveCompandEnabled = true
+		config.NoiseRemove.CompandEnabled = true
 		tuneNoiseRemove(config, &AudioMeasurements{NoiseProfile: nil})
-		if config.NoiseRemoveCompandEnabled {
-			t.Fatalf("NoiseRemoveCompandEnabled should be false after nil NoiseProfile")
+		if config.NoiseRemove.CompandEnabled {
+			t.Fatalf("NoiseRemove.CompandEnabled should be false after nil NoiseProfile")
 		}
 
 		// Simulate second file with valid noise profile (should re-enable)
@@ -2404,8 +2265,8 @@ func TestTuneNoiseRemove(t *testing.T) {
 				MeasuredNoiseFloor: -55.0,
 			},
 		})
-		if !config.NoiseRemoveCompandEnabled {
-			t.Errorf("NoiseRemoveCompandEnabled should be re-enabled for valid NoiseProfile after previous disable")
+		if !config.NoiseRemove.CompandEnabled {
+			t.Errorf("NoiseRemove.CompandEnabled should be re-enabled for valid NoiseProfile after previous disable")
 		}
 	})
 
@@ -2430,7 +2291,7 @@ func TestTuneNoiseRemove(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
-				config.NoiseRemoveEnabled = true
+				config.NoiseRemove.Enabled = true
 
 				measurements := &AudioMeasurements{
 					NoiseProfile: &NoiseProfile{
@@ -2442,15 +2303,15 @@ func TestTuneNoiseRemove(t *testing.T) {
 				tuneNoiseRemove(config, measurements)
 
 				// Check threshold is noise floor + 5dB (clamped)
-				if config.NoiseRemoveCompandThreshold != tt.expectedThreshold {
-					t.Errorf("NoiseRemoveCompandThreshold = %.1f, want %.1f (floor %.1f + 5dB, clamped)",
-						config.NoiseRemoveCompandThreshold, tt.expectedThreshold, tt.noiseFloor)
+				if config.NoiseRemove.CompandThreshold != tt.expectedThreshold {
+					t.Errorf("NoiseRemove.CompandThreshold = %.1f, want %.1f (floor %.1f + 5dB, clamped)",
+						config.NoiseRemove.CompandThreshold, tt.expectedThreshold, tt.noiseFloor)
 				}
 
 				// Check expansion scales with noise severity
-				if config.NoiseRemoveCompandExpansion != tt.expectedExpansion {
-					t.Errorf("NoiseRemoveCompandExpansion = %.1f, want %.1f",
-						config.NoiseRemoveCompandExpansion, tt.expectedExpansion)
+				if config.NoiseRemove.CompandExpansion != tt.expectedExpansion {
+					t.Errorf("NoiseRemove.CompandExpansion = %.1f, want %.1f",
+						config.NoiseRemove.CompandExpansion, tt.expectedExpansion)
 				}
 			})
 		}
@@ -2458,12 +2319,12 @@ func TestTuneNoiseRemove(t *testing.T) {
 
 	t.Run("anlmdn parameters unchanged", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
+		config.NoiseRemove.Enabled = true
 		// Record original anlmdn values
-		originalStrength := config.NoiseRemoveStrength
-		originalPatch := config.NoiseRemovePatchSec
-		originalResearch := config.NoiseRemoveResearchSec
-		originalSmooth := config.NoiseRemoveSmooth
+		originalStrength := config.NoiseRemove.Strength
+		originalPatch := config.NoiseRemove.PatchSec
+		originalResearch := config.NoiseRemove.ResearchSec
+		originalSmooth := config.NoiseRemove.Smooth
 
 		measurements := &AudioMeasurements{
 			NoiseProfile: &NoiseProfile{
@@ -2475,26 +2336,26 @@ func TestTuneNoiseRemove(t *testing.T) {
 		tuneNoiseRemove(config, measurements)
 
 		// anlmdn parameters should remain constant
-		if config.NoiseRemoveStrength != originalStrength {
-			t.Errorf("NoiseRemoveStrength changed from %v to %v", originalStrength, config.NoiseRemoveStrength)
+		if config.NoiseRemove.Strength != originalStrength {
+			t.Errorf("NoiseRemove.Strength changed from %v to %v", originalStrength, config.NoiseRemove.Strength)
 		}
-		if config.NoiseRemovePatchSec != originalPatch {
-			t.Errorf("NoiseRemovePatchSec changed from %v to %v", originalPatch, config.NoiseRemovePatchSec)
+		if config.NoiseRemove.PatchSec != originalPatch {
+			t.Errorf("NoiseRemove.PatchSec changed from %v to %v", originalPatch, config.NoiseRemove.PatchSec)
 		}
-		if config.NoiseRemoveResearchSec != originalResearch {
-			t.Errorf("NoiseRemoveResearchSec changed from %v to %v", originalResearch, config.NoiseRemoveResearchSec)
+		if config.NoiseRemove.ResearchSec != originalResearch {
+			t.Errorf("NoiseRemove.ResearchSec changed from %v to %v", originalResearch, config.NoiseRemove.ResearchSec)
 		}
-		if config.NoiseRemoveSmooth != originalSmooth {
-			t.Errorf("NoiseRemoveSmooth changed from %v to %v", originalSmooth, config.NoiseRemoveSmooth)
+		if config.NoiseRemove.Smooth != originalSmooth {
+			t.Errorf("NoiseRemove.Smooth changed from %v to %v", originalSmooth, config.NoiseRemove.Smooth)
 		}
 	})
 
 	t.Run("attack/decay/knee unchanged", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		originalAttack := config.NoiseRemoveCompandAttack
-		originalDecay := config.NoiseRemoveCompandDecay
-		originalKnee := config.NoiseRemoveCompandKnee
+		config.NoiseRemove.Enabled = true
+		originalAttack := config.NoiseRemove.CompandAttack
+		originalDecay := config.NoiseRemove.CompandDecay
+		originalKnee := config.NoiseRemove.CompandKnee
 
 		measurements := &AudioMeasurements{
 			NoiseProfile: &NoiseProfile{
@@ -2505,14 +2366,14 @@ func TestTuneNoiseRemove(t *testing.T) {
 
 		tuneNoiseRemove(config, measurements)
 
-		if config.NoiseRemoveCompandAttack != originalAttack {
-			t.Errorf("NoiseRemoveCompandAttack changed from %v to %v", originalAttack, config.NoiseRemoveCompandAttack)
+		if config.NoiseRemove.CompandAttack != originalAttack {
+			t.Errorf("NoiseRemove.CompandAttack changed from %v to %v", originalAttack, config.NoiseRemove.CompandAttack)
 		}
-		if config.NoiseRemoveCompandDecay != originalDecay {
-			t.Errorf("NoiseRemoveCompandDecay changed from %v to %v", originalDecay, config.NoiseRemoveCompandDecay)
+		if config.NoiseRemove.CompandDecay != originalDecay {
+			t.Errorf("NoiseRemove.CompandDecay changed from %v to %v", originalDecay, config.NoiseRemove.CompandDecay)
 		}
-		if config.NoiseRemoveCompandKnee != originalKnee {
-			t.Errorf("NoiseRemoveCompandKnee changed from %v to %v", originalKnee, config.NoiseRemoveCompandKnee)
+		if config.NoiseRemove.CompandKnee != originalKnee {
+			t.Errorf("NoiseRemove.CompandKnee changed from %v to %v", originalKnee, config.NoiseRemove.CompandKnee)
 		}
 	})
 }
@@ -2643,7 +2504,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
 				// Use DefaultFilterConfig target TP (-2.0) to match proposal calculations
-				config.LoudnormTargetTP = -2.0
+				config.Loudnorm.TargetTP = -2.0
 				diagnostics := &AdaptiveDiagnostics{}
 				measurements := &AudioMeasurements{
 					InputI:        tt.inputI,
@@ -2714,7 +2575,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
-				config.LoudnormTargetTP = -2.0
+				config.Loudnorm.TargetTP = -2.0
 				diagnostics := &AdaptiveDiagnostics{}
 				measurements := &AudioMeasurements{
 					InputI:        tt.inputI,
@@ -2735,7 +2596,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 
 	t.Run("severity scales linearly with deficit", func(t *testing.T) {
 		// Acceptance criterion 5: severity is linear from 0 to 1 over deficit 0 to 6
-		// With LoudnormTargetTP=-2.0, deficit=0 when gainRequired=20.5, i.e. InputI=-36.5
+		// With Loudnorm.TargetTP=-2.0, deficit=0 when gainRequired=20.5, i.e. InputI=-36.5
 		// Each 1.0 dB decrease in InputI adds 1.0 dB to deficit
 		deficits := []struct {
 			inputI       float64
@@ -2754,7 +2615,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 
 		for _, tt := range deficits {
 			config := newTestConfig()
-			config.LoudnormTargetTP = -2.0
+			config.Loudnorm.TargetTP = -2.0
 			diagnostics := &AdaptiveDiagnostics{}
 			measurements := &AudioMeasurements{
 				InputI:        tt.inputI,
@@ -2773,7 +2634,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 	t.Run("diagnostic fields populated for all recordings", func(t *testing.T) {
 		// Acceptance criterion 6: fields populated even when inactive
 		config := newTestConfig()
-		config.LoudnormTargetTP = -2.0
+		config.Loudnorm.TargetTP = -2.0
 		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			InputI:        -20.2,
@@ -2820,7 +2681,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		// Anna-like: InputI=-39.1, InputTP=-4.9 -> deficit ~2.6, severity ~0.433
 		// Acceptance criterion 1: ratio pushed toward ~3.87, threshold toward ~-27.5
 		config := newTestConfig()
-		config.LoudnormTargetTP = -2.0
+		config.Loudnorm.TargetTP = -2.0
 		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
@@ -2847,22 +2708,22 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 
 		// Override floors: ratio >= 3.8, threshold <= -27.0
 		// Sub-tuners may push further, but not back above the floor.
-		if config.LA2ARatio < 3.8 {
-			t.Errorf("LA2ARatio = %.2f, want >= 3.8 (override floor ~3.87)", config.LA2ARatio)
+		if config.LA2A.Ratio < 3.8 {
+			t.Errorf("LA2A.Ratio = %.2f, want >= 3.8 (override floor ~3.87)", config.LA2A.Ratio)
 		}
-		if config.LA2AThreshold > -27.0 {
-			t.Errorf("LA2AThreshold = %.2f, want <= -27.0 (override floor ~-27.53)", config.LA2AThreshold)
+		if config.LA2A.Threshold > -27.0 {
+			t.Errorf("LA2A.Threshold = %.2f, want <= -27.0 (override floor ~-27.53)", config.LA2A.Threshold)
 		}
-		if config.LA2ARelease < 264.0 {
-			t.Errorf("LA2ARelease = %.2f, want >= 264.0 (override floor ~265.0)", config.LA2ARelease)
+		if config.LA2A.Release < 264.0 {
+			t.Errorf("LA2A.Release = %.2f, want >= 264.0 (override floor ~265.0)", config.LA2A.Release)
 		}
-		if config.LA2AKnee < 4.8 {
-			t.Errorf("LA2AKnee = %.2f, want >= 4.8 (override floor ~4.87)", config.LA2AKnee)
+		if config.LA2A.Knee < 4.8 {
+			t.Errorf("LA2A.Knee = %.2f, want >= 4.8 (override floor ~4.87)", config.LA2A.Knee)
 		}
 
 		// Ratio must respect existing 5.0 ceiling (acceptance criterion 4)
-		if config.LA2ARatio > 5.0 {
-			t.Errorf("LA2ARatio = %.2f, must not exceed 5.0 ceiling", config.LA2ARatio)
+		if config.LA2A.Ratio > 5.0 {
+			t.Errorf("LA2A.Ratio = %.2f, must not exceed 5.0 ceiling", config.LA2A.Ratio)
 		}
 	})
 
@@ -2870,7 +2731,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		// Marius-like: InputI=-20.2, InputTP=-2.5 -> deficit <= 0, no overrides
 		// Acceptance criterion 2: identical output to before high-crest logic
 		config := newTestConfig()
-		config.LoudnormTargetTP = -2.0
+		config.Loudnorm.TargetTP = -2.0
 		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
@@ -2894,23 +2755,23 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		assertNoStaleEffectiveConfigFields(t)
 
 		// Capture the values
-		ratioWithOverrides := config.LA2ARatio
-		thresholdWithOverrides := config.LA2AThreshold
-		releaseWithOverrides := config.LA2ARelease
-		kneeWithOverrides := config.LA2AKnee
+		ratioWithOverrides := config.LA2A.Ratio
+		thresholdWithOverrides := config.LA2A.Threshold
+		releaseWithOverrides := config.LA2A.Release
+		kneeWithOverrides := config.LA2A.Knee
 
 		// Run again on a fresh config to compare (both should be identical
 		// since overrides are zero-valued)
 		config2 := newTestConfig()
-		config2.LoudnormTargetTP = -2.0
+		config2.Loudnorm.TargetTP = -2.0
 		diagnostics2 := &AdaptiveDiagnostics{}
 		tuneLA2ACompressor(config2, diagnostics2, measurements)
 		assertNoStaleEffectiveConfigFields(t)
 
-		assertClose(t, "ratio", ratioWithOverrides, config2.LA2ARatio, 0.001)
-		assertClose(t, "threshold", thresholdWithOverrides, config2.LA2AThreshold, 0.001)
-		assertClose(t, "release", releaseWithOverrides, config2.LA2ARelease, 0.001)
-		assertClose(t, "knee", kneeWithOverrides, config2.LA2AKnee, 0.001)
+		assertClose(t, "ratio", ratioWithOverrides, config2.LA2A.Ratio, 0.001)
+		assertClose(t, "threshold", thresholdWithOverrides, config2.LA2A.Threshold, 0.001)
+		assertClose(t, "release", releaseWithOverrides, config2.LA2A.Release, 0.001)
+		assertClose(t, "knee", kneeWithOverrides, config2.LA2A.Knee, 0.001)
 	})
 
 	t.Run("hot-input and deficit cannot co-occur", func(t *testing.T) {
@@ -2931,7 +2792,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		for _, tt := range hotInputCases {
 			t.Run(tt.name, func(t *testing.T) {
 				config := newTestConfig()
-				config.LoudnormTargetTP = -2.0
+				config.Loudnorm.TargetTP = -2.0
 				diagnostics := &AdaptiveDiagnostics{}
 				measurements := &AudioMeasurements{
 					BaseMeasurements: BaseMeasurements{
@@ -2960,7 +2821,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 	t.Run("maximum severity produces aggressive but bounded parameters", func(t *testing.T) {
 		// Deficit >= 4.0 -> severity 1.0 -> maximum override floors
 		config := newTestConfig()
-		config.LoudnormTargetTP = -2.0
+		config.Loudnorm.TargetTP = -2.0
 		diagnostics := &AdaptiveDiagnostics{}
 		measurements := &AudioMeasurements{
 			BaseMeasurements: BaseMeasurements{
@@ -2985,20 +2846,20 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 
 		// At severity 1.0, floors are: threshold=-40, ratio=5.0, release=350, knee=6.0
 		// Sub-tuners may push further but not below the floor.
-		if config.LA2ARatio < 5.0 {
-			t.Errorf("LA2ARatio = %.2f, want >= 5.0 at maximum severity", config.LA2ARatio)
+		if config.LA2A.Ratio < 5.0 {
+			t.Errorf("LA2A.Ratio = %.2f, want >= 5.0 at maximum severity", config.LA2A.Ratio)
 		}
-		if config.LA2ARatio > 5.0 {
-			t.Errorf("LA2ARatio = %.2f, must not exceed 5.0 ceiling", config.LA2ARatio)
+		if config.LA2A.Ratio > 5.0 {
+			t.Errorf("LA2A.Ratio = %.2f, must not exceed 5.0 ceiling", config.LA2A.Ratio)
 		}
-		if config.LA2AThreshold > -40.0 {
-			t.Errorf("LA2AThreshold = %.2f, want <= -40.0 at maximum severity", config.LA2AThreshold)
+		if config.LA2A.Threshold > -40.0 {
+			t.Errorf("LA2A.Threshold = %.2f, want <= -40.0 at maximum severity", config.LA2A.Threshold)
 		}
-		if config.LA2ARelease < 350.0 {
-			t.Errorf("LA2ARelease = %.2f, want >= 350.0 at maximum severity", config.LA2ARelease)
+		if config.LA2A.Release < 350.0 {
+			t.Errorf("LA2A.Release = %.2f, want >= 350.0 at maximum severity", config.LA2A.Release)
 		}
-		if config.LA2AKnee < 6.0 {
-			t.Errorf("LA2AKnee = %.2f, want >= 6.0 at maximum severity", config.LA2AKnee)
+		if config.LA2A.Knee < 6.0 {
+			t.Errorf("LA2A.Knee = %.2f, want >= 6.0 at maximum severity", config.LA2A.Knee)
 		}
 	})
 }

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -383,7 +383,7 @@ func buildInputMeasurements(filename string, collection *analysisFrameCollection
 	measurements.InputTP = acc.ebur128InputTP
 	measurements.InputLRA = acc.ebur128InputLRA
 	measurements.InputThresh = acc.ebur128InputI - 10.0
-	measurements.TargetOffset = config.TargetI - acc.ebur128InputI
+	measurements.TargetOffset = config.Loudnorm.TargetI - acc.ebur128InputI
 	measurements.MomentaryLoudness = acc.ebur128InputM
 	measurements.ShortTermLoudness = acc.ebur128InputS
 	measurements.SamplePeak = acc.ebur128InputSP
@@ -547,7 +547,7 @@ func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *P
 			if inputFrameTime-intervalStartTime >= intervalDuration {
 				finalised := intervalAcc.finalize(intervalStartTime)
 				intervals = append(intervals, finalised)
-				if config.SilenceScanDuration > 0 && intervalStartTime < config.SilenceScanDuration {
+				if config.Analysis.SilenceScanDuration > 0 && intervalStartTime < config.Analysis.SilenceScanDuration {
 					silenceIntervals = append(silenceIntervals, finalised)
 				}
 				intervalStartTime = inputFrameTime
@@ -579,12 +579,12 @@ func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *P
 	if intervalAcc.rawSampleCount > 0 {
 		finalised := intervalAcc.finalize(intervalStartTime)
 		intervals = append(intervals, finalised)
-		if config.SilenceScanDuration > 0 && intervalStartTime < config.SilenceScanDuration {
+		if config.Analysis.SilenceScanDuration > 0 && intervalStartTime < config.Analysis.SilenceScanDuration {
 			silenceIntervals = append(silenceIntervals, finalised)
 		}
 	}
 
-	if config.SilenceScanDuration == 0 {
+	if config.Analysis.SilenceScanDuration == 0 {
 		silenceIntervals = intervals
 	}
 

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -314,7 +314,7 @@ func TestAnalyzeAudio(t *testing.T) {
 
 	// Use test config with podcast standard targets
 	config := newTestBaseConfig()
-	config.AnalysisEnabled = true
+	config.Analysis.Enabled = true
 
 	t.Run("synthetic_tone_with_silence", func(t *testing.T) {
 		// Progress callback to show analysis progress
@@ -368,9 +368,9 @@ func TestAnalyzeAudio(t *testing.T) {
 
 		// The offset should bring us close to target (-16 LUFS)
 		expectedOutput := measurements.InputI + measurements.TargetOffset
-		if expectedOutput < config.TargetI-2 || expectedOutput > config.TargetI+2 {
+		if expectedOutput < config.Loudnorm.TargetI-2 || expectedOutput > config.Loudnorm.TargetI+2 {
 			t.Logf("Warning: Target offset might not achieve target (expected ~%.1f, got %.2f)",
-				config.TargetI, expectedOutput)
+				config.Loudnorm.TargetI, expectedOutput)
 		}
 	})
 }
@@ -387,10 +387,10 @@ func TestAnalyzeAudioDoesNotMutateCallerConfig(t *testing.T) {
 
 	config := DefaultFilterConfig()
 	config.FilterOrder = []FilterID{FilterNoiseRemove, FilterAnalysis}
-	config.SilenceScanDuration = 250 * time.Millisecond
+	config.Analysis.SilenceScanDuration = 250 * time.Millisecond
 
 	originalOrder := append([]FilterID(nil), config.FilterOrder...)
-	originalSilenceScanDuration := config.SilenceScanDuration
+	originalSilenceScanDuration := config.Analysis.SilenceScanDuration
 
 	if _, err := AnalyzeAudio(testFile, config, nil); err != nil {
 		t.Fatalf("AnalyzeAudio failed: %v", err)
@@ -404,8 +404,8 @@ func TestAnalyzeAudioDoesNotMutateCallerConfig(t *testing.T) {
 			t.Errorf("FilterOrder[%d] = %q, want %q", i, config.FilterOrder[i], originalOrder[i])
 		}
 	}
-	if config.SilenceScanDuration != originalSilenceScanDuration {
-		t.Errorf("SilenceScanDuration = %v, want %v", config.SilenceScanDuration, originalSilenceScanDuration)
+	if config.Analysis.SilenceScanDuration != originalSilenceScanDuration {
+		t.Errorf("Analysis.SilenceScanDuration = %v, want %v", config.Analysis.SilenceScanDuration, originalSilenceScanDuration)
 	}
 }
 
@@ -2859,7 +2859,7 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 	const loudnessTolerance = 0.01
 
 	baselineConfig := newTestBaseConfig()
-	baselineConfig.AnalysisEnabled = true
+	baselineConfig.Analysis.Enabled = true
 
 	baseline, err := AnalyzeAudio(testFile, baselineConfig, nil)
 	if err != nil {
@@ -2900,8 +2900,8 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 	t.Run("zero_matches_baseline", func(t *testing.T) {
 		// AC1 / AC5: explicit zero is identical to flag absent (no cap).
 		config := newTestBaseConfig()
-		config.AnalysisEnabled = true
-		config.SilenceScanDuration = 0
+		config.Analysis.Enabled = true
+		config.Analysis.SilenceScanDuration = 0
 
 		got, err := AnalyzeAudio(testFile, config, nil)
 		if err != nil {
@@ -2929,8 +2929,8 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 		// pipeline's view, so no candidates are formed and no profile is extracted.
 		// 2 s lands cleanly between the 1.75 s and 2.0 s interval start times.
 		config := newTestBaseConfig()
-		config.AnalysisEnabled = true
-		config.SilenceScanDuration = 2 * time.Second
+		config.Analysis.Enabled = true
+		config.Analysis.SilenceScanDuration = 2 * time.Second
 
 		got, err := AnalyzeAudio(testFile, config, nil)
 		if err != nil {
@@ -2951,8 +2951,8 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 		// silence pipeline elects the same region as the uncapped run and
 		// produces the same NoiseProfile placement.
 		config := newTestBaseConfig()
-		config.AnalysisEnabled = true
-		config.SilenceScanDuration = 60 * time.Second
+		config.Analysis.Enabled = true
+		config.Analysis.SilenceScanDuration = 60 * time.Second
 
 		got, err := AnalyzeAudio(testFile, config, nil)
 		if err != nil {
@@ -2979,8 +2979,8 @@ func TestAnalyzeAudio_SilenceScanDuration(t *testing.T) {
 		// LRA, speech regions, interval samples) match the uncapped run because
 		// only the silence pipeline reads the capped slice.
 		config := newTestBaseConfig()
-		config.AnalysisEnabled = true
-		config.SilenceScanDuration = 60 * time.Second
+		config.Analysis.Enabled = true
+		config.Analysis.SilenceScanDuration = 60 * time.Second
 
 		got, err := AnalyzeAudio(testFile, config, nil)
 		if err != nil {

--- a/internal/processor/benchmark_test.go
+++ b/internal/processor/benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkAnalyzeAudioSynthetic5m(b *testing.B) {
 	b.ResetTimer()
 	for range b.N {
 		config := newTestBaseConfig()
-		config.AnalysisEnabled = true
+		config.Analysis.Enabled = true
 		if _, err := AnalyzeAudio(inputPath, config, nil); err != nil {
 			b.Fatalf("AnalyzeAudio failed: %v", err)
 		}

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -257,7 +257,7 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 			ExtractMeasurements: false,
 			BuildSpec: func(config *EffectiveFilterConfig) string {
 				ablated := *config
-				ablated.AnalysisEnabled = false
+				ablated.Analysis.Enabled = false
 				return ablated.BuildFilterSpec()
 			},
 		},
@@ -271,7 +271,7 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 			ExtractMeasurements: true,
 			BuildSpec: func(config *EffectiveFilterConfig) string {
 				ablated := *config
-				ablated.NoiseRemoveCompandEnabled = false
+				ablated.NoiseRemove.CompandEnabled = false
 				return ablated.BuildFilterSpec()
 			},
 		},
@@ -280,8 +280,8 @@ func fullbenchPass2AblationVariants() []fullbenchPass2AblationVariant {
 			ExtractMeasurements: true,
 			BuildSpec: func(config *EffectiveFilterConfig) string {
 				ablated := *config
-				ablated.DS201GateEnabled = false
-				ablated.LA2AEnabled = false
+				ablated.DS201Gate.Enabled = false
+				ablated.LA2A.Enabled = false
 				return ablated.BuildFilterSpec()
 			},
 		},
@@ -298,7 +298,7 @@ func buildFullbenchPass2WithoutAnlmdnSpec(config *EffectiveFilterConfig) string 
 	filters := make([]string, 0, len(order))
 	for _, id := range order {
 		if id == FilterNoiseRemove {
-			if ablated.NoiseRemoveEnabled && ablated.NoiseRemoveCompandEnabled {
+			if ablated.NoiseRemove.Enabled && ablated.NoiseRemove.CompandEnabled {
 				filters = append(filters, ablated.buildNoiseRemoveCompandFilter())
 			}
 			continue
@@ -392,13 +392,13 @@ func buildFullbenchPass4OutputAnalysisFilters(config *EffectiveFilterConfig, mea
 
 func buildFullbenchPass4ResampleFilter(config *EffectiveFilterConfig) string {
 	resampleConfig := *config
-	resampleConfig.ResampleEnabled = true
+	resampleConfig.Resample.Enabled = true
 	return resampleConfig.buildResampleFilter()
 }
 
 func buildFullbenchProductionPass4SpecWithoutAdeclick(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	pass4Config := *config
-	pass4Config.AdeclickEnabled = false
+	pass4Config.Adeclick.Enabled = false
 	return buildLoudnormFilterSpec(&pass4Config, measurement, 0, 0, false)
 }
 
@@ -414,17 +414,17 @@ func extractFullbenchFilterClause(spec, prefix string) string {
 
 func TestFullbenchPass2AblationSpecs(t *testing.T) {
 	config := newFullbenchEffectiveTestConfig()
-	config.DownmixEnabled = true
-	config.DS201HPEnabled = true
-	config.DS201LPEnabled = true
-	config.NoiseRemoveEnabled = true
-	config.NoiseRemoveCompandEnabled = true
-	config.DS201GateEnabled = true
-	config.LA2AEnabled = true
-	config.DeessEnabled = true
-	config.DeessIntensity = 0.5
-	config.AnalysisEnabled = true
-	config.ResampleEnabled = true
+	config.Downmix.Enabled = true
+	config.DS201HighPass.Enabled = true
+	config.DS201LowPass.Enabled = true
+	config.NoiseRemove.Enabled = true
+	config.NoiseRemove.CompandEnabled = true
+	config.DS201Gate.Enabled = true
+	config.LA2A.Enabled = true
+	config.Deesser.Enabled = true
+	config.Deesser.Intensity = 0.5
+	config.Analysis.Enabled = true
+	config.Resample.Enabled = true
 	config.FilterOrder = Pass2FilterOrder
 
 	variantByName := make(map[string]fullbenchPass2AblationVariant)
@@ -503,17 +503,17 @@ func TestFullbenchPass2AblationSpecs(t *testing.T) {
 
 func TestFullbenchPass2WithoutAnlmdnPreservesOrder(t *testing.T) {
 	config := newFullbenchEffectiveTestConfig()
-	config.DownmixEnabled = true
-	config.DS201HPEnabled = true
-	config.DS201LPEnabled = true
-	config.NoiseRemoveEnabled = true
-	config.NoiseRemoveCompandEnabled = true
-	config.DS201GateEnabled = true
-	config.LA2AEnabled = true
-	config.DeessEnabled = true
-	config.DeessIntensity = 0.5
-	config.AnalysisEnabled = true
-	config.ResampleEnabled = true
+	config.Downmix.Enabled = true
+	config.DS201HighPass.Enabled = true
+	config.DS201LowPass.Enabled = true
+	config.NoiseRemove.Enabled = true
+	config.NoiseRemove.CompandEnabled = true
+	config.DS201Gate.Enabled = true
+	config.LA2A.Enabled = true
+	config.Deesser.Enabled = true
+	config.Deesser.Intensity = 0.5
+	config.Analysis.Enabled = true
+	config.Resample.Enabled = true
 	config.FilterOrder = Pass2FilterOrder
 
 	spec := buildFullbenchPass2WithoutAnlmdnSpec(config)
@@ -538,10 +538,10 @@ func TestFullbenchPass2WithoutAnlmdnPreservesOrder(t *testing.T) {
 
 func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 	config := newFullbenchEffectiveTestConfig()
-	config.AdeclickEnabled = true
-	config.LoudnormTargetI = -17.25
-	config.LoudnormTargetTP = -2.25
-	config.LoudnormTargetLRA = 9.0
+	config.Adeclick.Enabled = true
+	config.Loudnorm.TargetI = -17.25
+	config.Loudnorm.TargetTP = -2.25
+	config.Loudnorm.TargetLRA = 9.0
 
 	measurement := &LoudnormMeasurement{
 		InputI:       -23.25,
@@ -552,7 +552,7 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 	}
 
 	productionConfig := *config
-	productionConfig.AdeclickEnabled = false
+	productionConfig.Adeclick.Enabled = false
 	productionClause := extractFullbenchFilterClause(
 		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false),
 		"loudnorm=",
@@ -582,8 +582,8 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 
 func TestFullbenchPass4AblationSpecs(t *testing.T) {
 	config := newFullbenchEffectiveTestConfig()
-	config.AdeclickEnabled = true
-	config.ResampleEnabled = false
+	config.Adeclick.Enabled = true
+	config.Resample.Enabled = false
 	measurement := &LoudnormMeasurement{
 		InputI:       -24.0,
 		InputTP:      -6.0,
@@ -751,8 +751,8 @@ func TestRunFullbenchFilterSpecSyntheticSmoke(t *testing.T) {
 	defer cleanupTestAudio(t, inputPath)
 
 	config := newFullbenchEffectiveTestConfig()
-	config.AnalysisEnabled = true
-	config.ResampleEnabled = true
+	config.Analysis.Enabled = true
+	config.Resample.Enabled = true
 	config.FilterOrder = Pass2FilterOrder
 	filterSpec := config.BuildFilterSpec()
 
@@ -935,7 +935,7 @@ func setupFullbenchPass2Seed(tb testing.TB, inputPath string, adapted *fullbench
 
 	config := *adapted.Config
 	config.FilterOrder = append([]FilterID(nil), Pass2FilterOrder...)
-	config.AnalysisEnabled = true
+	config.Analysis.Enabled = true
 
 	outputPath := filepath.Join(tb.TempDir(), "fullbench-pass2-seed.flac")
 	inputMetadata, outputMeasurements := runFullbenchFilterSpec(
@@ -969,13 +969,13 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 	limiterCeiling, limiterNeeded, limiterClamped := calculateLimiterCeiling(
 		seed.OutputMeasurements.OutputI,
 		seed.OutputMeasurements.OutputTP,
-		config.LoudnormTargetI,
-		config.LoudnormTargetTP,
+		config.Loudnorm.TargetI,
+		config.Loudnorm.TargetTP,
 	)
 	preGainDB, reDerivedCeiling := calculatePreGain(
 		seed.OutputMeasurements.OutputI,
-		config.LoudnormTargetI,
-		config.LoudnormTargetTP,
+		config.Loudnorm.TargetI,
+		config.Loudnorm.TargetTP,
 	)
 	if limiterClamped {
 		limiterCeiling = reDerivedCeiling
@@ -997,11 +997,11 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 	effectiveTargetI, _, linearPossible := calculateLinearModeTarget(
 		measurement.InputI,
 		measurement.InputTP,
-		config.LoudnormTargetI,
-		config.LoudnormTargetTP,
+		config.Loudnorm.TargetI,
+		config.Loudnorm.TargetTP,
 	)
 	effectiveConfig := config
-	effectiveConfig.LoudnormTargetI = effectiveTargetI
+	effectiveConfig.Loudnorm.TargetI = effectiveTargetI
 
 	return &fullbenchLoudnormSetup{
 		Measurement:       measurement,
@@ -1070,11 +1070,11 @@ func TestFullbenchSetupHelpersSyntheticSmoke(t *testing.T) {
 	effectiveTargetI, _, linearPossible := calculateLinearModeTarget(
 		loudnorm.Measurement.InputI,
 		loudnorm.Measurement.InputTP,
-		pass2Seed.Config.LoudnormTargetI,
-		pass2Seed.Config.LoudnormTargetTP,
+		pass2Seed.Config.Loudnorm.TargetI,
+		pass2Seed.Config.Loudnorm.TargetTP,
 	)
-	if math.Abs(loudnorm.EffectiveConfig.LoudnormTargetI-effectiveTargetI) > 0.01 {
-		t.Fatalf("effective target mismatch: got %.2f, want %.2f", loudnorm.EffectiveConfig.LoudnormTargetI, effectiveTargetI)
+	if math.Abs(loudnorm.EffectiveConfig.Loudnorm.TargetI-effectiveTargetI) > 0.01 {
+		t.Fatalf("effective target mismatch: got %.2f, want %.2f", loudnorm.EffectiveConfig.Loudnorm.TargetI, effectiveTargetI)
 	}
 	if loudnorm.LinearModeForced != !linearPossible {
 		t.Fatalf("linear mode forced mismatch: got %v, want %v", loudnorm.LinearModeForced, !linearPossible)

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -104,121 +104,136 @@ const (
 )
 
 type filterConfigDefaults struct {
-	// Downmix (pan) - stereo to mono conversion
-	// Applied first to ensure all downstream filters work with mono
-	DownmixEnabled bool
-
-	// Analysis (ebur128 + astats + aspectralstats) - audio measurement collection
-	// Captures loudness, dynamics, spectral characteristics
-	AnalysisEnabled bool
-
-	// SilenceScanDuration caps how much of the input is examined when collecting
-	// silence candidates for room-tone election. Zero is the sentinel meaning
-	// "scan whole file" (current behaviour); a positive value restricts silence
-	// candidate collection to intervals before this input time. Loudness, true
-	// peak, LRA, spectral statistics, and speech detection always remain
-	// whole-file regardless of this cap.
-	SilenceScanDuration time.Duration
-
-	// Resample (aformat) - output format standardisation
-	// Pass 2 only - ensures consistent output format
-	ResampleEnabled    bool
-	ResampleSampleRate int    // Output sample rate (default: 44100)
-	ResampleFormat     string // Output sample format (default: s16)
-	ResampleFrameSize  int    // Samples per frame (default: 4096)
-
-	// DS201-Inspired High-Pass Filter (highpass) - removes subsonic rumble
-	// Part of the DS201 side-chain composite: removes rumble before gate detection
-	DS201HPEnabled   bool    // Enable DS201 high-pass filter
-	DS201HPFreq      float64 // Hz, cutoff frequency (removes frequencies below this)
-	DS201HPPoles     int     // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
-	DS201HPWidth     float64 // Q factor: 0.707=Butterworth (default), lower=gentler rolloff
-	DS201HPMix       float64 // Wet/dry mix (0-1, 1=full filter, 0.7=subtle for warm voices)
-	DS201HPTransform string  // Filter transform: "tdii" (best accuracy), "zdf", etc.
-
-	// DS201-Inspired Low-Pass Filter (lowpass) - removes ultrasonic noise
-	// Part of the DS201 side-chain composite: prevents HF noise from triggering gate
-	// Enabled adaptively based on content type and HF noise indicators
-	DS201LPEnabled   bool    // Enable DS201 low-pass filter
-	DS201LPFreq      float64 // Hz, cutoff frequency (removes frequencies above this)
-	DS201LPPoles     int     // Filter poles: 1=6dB/oct (gentle), 2=12dB/oct (standard)
-	DS201LPWidth     float64 // Q factor: 0.707=Butterworth (default)
-	DS201LPMix       float64 // Wet/dry mix (0-1, 1=full filter)
-	DS201LPTransform string  // Filter transform: "tdii" (best accuracy), "zdf", etc.
-
-	// NoiseRemove - anlmdn + compand noise reduction
-	// Non-Local Means denoiser (anlmdn) with a compand for residual suppression.
-	// Production runs anlmdn at the source sample rate with r=0.0020 and m=3,
-	// validated by the matrix spike at .bench/anlmdn-matrix-spike.
-	NoiseRemoveEnabled          bool    // Enable anlmdn+compand noise reduction
-	NoiseRemoveCompandEnabled   bool    // Enable compand residual suppression (false = anlmdn-only)
-	NoiseRemoveStrength         float64 // anlmdn strength (0.00001 = minimum, kept constant)
-	NoiseRemovePatchSec         float64 // Patch size in seconds (context window for similarity)
-	NoiseRemoveResearchSec      float64 // Research radius in seconds (search window for matching)
-	NoiseRemoveSmooth           float64 // Smoothing factor for weights (1-1000)
-	NoiseRemoveCompandThreshold float64 // Expansion threshold (dB) - set to measured noise floor
-	NoiseRemoveCompandExpansion float64 // Expansion depth (dB) - gap between input floor and target floor
-	NoiseRemoveCompandAttack    float64 // Attack time (seconds) - fixed at 5ms for speech
-	NoiseRemoveCompandDecay     float64 // Decay time (seconds) - fixed at 100ms for speech
-	NoiseRemoveCompandKnee      float64 // Soft knee (dB) - fixed at 6dB for transparency
-
-	// DS201-Inspired Gate (agate) - Drawmer DS201 style soft expander
-	// Uses gentle ratio (2:1-4:1) rather than DS201's hard gate for natural speech transitions.
-	// Minimum 10ms attack prevents click artifacts from rapid gain changes.
-	DS201GateEnabled   bool    // Enable DS201-style gate
-	DS201GateThreshold float64 // Activation threshold (0.0-1.0, linear)
-	DS201GateRatio     float64 // Reduction ratio - soft expander (2:1-4:1), not hard gate
-	DS201GateAttack    float64 // Attack time (ms) - minimum 10ms to avoid click artifacts
-	DS201GateRelease   float64 // Release time (ms) - includes +50ms to compensate for no Hold param
-	DS201GateRange     float64 // Level of gain reduction below threshold (0.0-1.0)
-	DS201GateKnee      float64 // Knee curve softness (1.0-8.0) - soft knee for natural transitions
-	DS201GateMakeup    float64 // Makeup gain after gating (1.0-64.0)
-	DS201GateDetection string  // Level detection mode: "rms" (default, smoother) or "peak" (tighter)
-
-	// LA-2A Compressor - Teletronix LA-2A style optical compression
-	// The LA-2A is legendary for its gentle, program-dependent character from the T4 optical cell.
-	LA2AEnabled   bool    // Enable LA-2A compressor
-	LA2AThreshold float64 // dB, compression threshold (stored in dB, converted to linear)
-	LA2ARatio     float64 // Compression ratio (1.0-20.0)
-	LA2AAttack    float64 // Attack time (ms) - LA-2A has fixed ~10ms attack
-	LA2ARelease   float64 // Release time (ms) - LA-2A has program-dependent two-stage release
-	LA2AMakeup    float64 // dB, makeup gain (stored in dB, converted to linear)
-	LA2AKnee      float64 // Knee curve softness (1.0-8.0) - T4 cell provides inherent soft knee
-	LA2AMix       float64 // Wet/dry mix (0.0-1.0, 1.0 = 100% compressed)
-
-	// De-esser (deesser) - removes harsh sibilance automatically
-	DeessEnabled   bool    // Enable deesser filter
-	DeessIntensity float64 // 0.0-1.0, intensity for triggering de-essing (0=off, 1=max)
-	DeessAmount    float64 // 0.0-1.0, amount of ducking on treble (how much to reduce)
-	DeessFreq      float64 // 0.0-1.0, how much original frequency content to keep
-
-	// Target values (for reference only)
-	TargetI   float64 // LUFS target reference (podcast standard: -16)
-	TargetTP  float64 // dBTP, true peak ceiling reference
-	TargetLRA float64 // LU, loudness range reference
+	Downmix       DownmixConfig
+	Analysis      AnalysisConfig
+	Resample      ResampleConfig
+	DS201HighPass DS201HighPassConfig
+	DS201LowPass  DS201LowPassConfig
+	NoiseRemove   NoiseRemoveConfig
+	DS201Gate     DS201GateConfig
+	LA2A          LA2AConfig
+	Deesser       DeesserConfig
+	Adeclick      AdeclickConfig
+	Loudnorm      LoudnormConfig
 
 	// Filter chain order - controls the sequence of filters in the processing chain
 	// Use Pass2FilterOrder or customise for experimentation
 	FilterOrder []FilterID
+}
 
-	// Adeclick - Click/pop repair filter (Pass 4)
-	// Detects and repairs waveform discontinuities through interpolation
-	// Applied after loudnorm to catch clicks from limiter and gain changes
-	AdeclickEnabled   bool    // Enable adeclick filter (default: true in Pass 4)
-	AdeclickThreshold float64 // Detection sensitivity (0.1-8.0, lower=more sensitive)
-	AdeclickWindow    float64 // Analysis window in ms (10-100)
-	AdeclickOverlap   float64 // Window overlap percentage (50-95)
-	AdeclickMethod    string  // Interpolation method ("" = default "a" = average; "s" = spline)
+type DownmixConfig struct {
+	Enabled bool
+}
 
-	// Loudnorm (Pass 3) - EBU R128 dynamic loudness normalisation
-	// Replaces simple volume gain + limiting with integrated dynamic normalisation
-	// Uses two-pass mode with measurements from Pass 2 for optimal transparency
-	LoudnormEnabled   bool    // Enable loudnorm in Pass 3 (default: true)
-	LoudnormTargetI   float64 // Target integrated loudness (LUFS), default: -16.0
-	LoudnormTargetTP  float64 // Target true peak (dBTP), default: -1.5
-	LoudnormTargetLRA float64 // Target loudness range (LU), default: 11.0
-	LoudnormDualMono  bool    // Treat mono as dual-mono (CRITICAL for mono files)
-	LoudnormLinear    bool    // Prefer linear mode (falls back to dynamic if needed)
+type AnalysisConfig struct {
+	Enabled             bool
+	SilenceScanDuration time.Duration
+}
+
+type ResampleConfig struct {
+	Enabled    bool
+	SampleRate int
+	Format     string
+	FrameSize  int
+}
+
+type DS201HighPassConfig struct {
+	Enabled   bool
+	Frequency float64
+	Poles     int
+	Width     float64
+	Mix       float64
+	Transform string
+}
+
+type DS201LowPassConfig struct {
+	Enabled   bool
+	Frequency float64
+	Poles     int
+	Width     float64
+	Mix       float64
+	Transform string
+}
+
+type NoiseRemoveConfig struct {
+	Enabled          bool
+	CompandEnabled   bool
+	Strength         float64
+	PatchSec         float64
+	ResearchSec      float64
+	Smooth           float64
+	CompandThreshold float64
+	CompandExpansion float64
+	CompandAttack    float64
+	CompandDecay     float64
+	CompandKnee      float64
+}
+
+type DS201GateConfig struct {
+	Enabled   bool
+	Threshold float64
+	Ratio     float64
+	Attack    float64
+	Release   float64
+	Range     float64
+	Knee      float64
+	Makeup    float64
+	Detection string
+}
+
+type LA2AConfig struct {
+	Enabled   bool
+	Threshold float64
+	Ratio     float64
+	Attack    float64
+	Release   float64
+	Makeup    float64
+	Knee      float64
+	Mix       float64
+}
+
+type DeesserConfig struct {
+	Enabled   bool
+	Intensity float64
+	Amount    float64
+	Frequency float64
+}
+
+type AdeclickConfig struct {
+	Enabled   bool
+	Threshold float64
+	Window    float64
+	Overlap   float64
+	Method    string
+}
+
+type LoudnormConfig struct {
+	Enabled   bool
+	TargetI   float64
+	TargetTP  float64
+	TargetLRA float64
+	DualMono  bool
+	Linear    bool
+}
+
+type Decibels float64
+
+func (db Decibels) LinearAmplitude() LinearAmplitude {
+	return LinearAmplitude(DbToLinear(float64(db)))
+}
+
+func (db Decibels) Float64() float64 {
+	return float64(db)
+}
+
+type LinearAmplitude float64
+
+func (linear LinearAmplitude) Decibels() Decibels {
+	return Decibels(LinearToDb(float64(linear)))
+}
+
+func (linear LinearAmplitude) Float64() float64 {
+	return float64(linear)
 }
 
 // BaseFilterConfig holds caller-owned defaults and user-facing options only.
@@ -294,106 +309,165 @@ type EffectiveFilterConfig filterConfigDefaults
 // DefaultFilterConfig returns the scientifically-tuned caller-owned defaults for
 // podcast spoken word audio processing.
 func DefaultFilterConfig() *BaseFilterConfig {
-	return &BaseFilterConfig{filterConfigDefaults: filterConfigDefaults{
-		// Downmix - always enabled to ensure mono processing
-		DownmixEnabled: true,
+	return &BaseFilterConfig{filterConfigDefaults: defaultFilterConfigDefaults()}
+}
 
-		// Analysis - always enabled to collect measurements
-		AnalysisEnabled: true,
+func defaultFilterConfigDefaults() filterConfigDefaults {
+	return assembleFilterDefaults(
+		defaultDownmixConfig(),
+		defaultAnalysisConfig(),
+		defaultResampleConfig(),
+		defaultDS201HighPassConfig(),
+		defaultDS201LowPassConfig(),
+		defaultNoiseRemoveConfig(),
+		defaultDS201GateConfig(),
+		defaultLA2AConfig(),
+		defaultDeesserConfig(),
+		defaultAdeclickConfig(),
+		defaultLoudnormConfig(),
+	)
+}
 
-		// Resample - enabled by default (Pass 2 only via filter order)
-		ResampleEnabled:    true,
-		ResampleSampleRate: 44100,
-		ResampleFormat:     "s16",
-		ResampleFrameSize:  4096,
+func assembleFilterDefaults(
+	downmix DownmixConfig,
+	analysis AnalysisConfig,
+	resample ResampleConfig,
+	ds201HighPass DS201HighPassConfig,
+	ds201LowPass DS201LowPassConfig,
+	noiseRemove NoiseRemoveConfig,
+	ds201Gate DS201GateConfig,
+	la2a LA2AConfig,
+	deesser DeesserConfig,
+	adeclick AdeclickConfig,
+	loudnorm LoudnormConfig,
+) filterConfigDefaults {
+	return filterConfigDefaults{
+		Downmix:       downmix,
+		Analysis:      analysis,
+		Resample:      resample,
+		DS201HighPass: ds201HighPass,
+		DS201LowPass:  ds201LowPass,
+		NoiseRemove:   noiseRemove,
+		DS201Gate:     ds201Gate,
+		LA2A:          la2a,
+		Deesser:       deesser,
+		Adeclick:      adeclick,
+		Loudnorm:      loudnorm,
 
-		// DS201-Inspired High-pass - remove subsonic rumble (part of DS201 side-chain)
-		DS201HPEnabled:   true,
-		DS201HPFreq:      80.0,                    // 80Hz cutoff
-		DS201HPPoles:     ds201HPDefaultPoles,     // 12dB/oct standard slope (1=gentle 6dB/oct for warm voices)
-		DS201HPWidth:     ds201HPDefaultWidth,     // Butterworth Q (maximally flat passband)
-		DS201HPMix:       ds201HPDefaultMix,       // Full wet signal (reduce for warm voice protection)
-		DS201HPTransform: ds201HPDefaultTransform, // Transposed Direct Form II - best floating-point accuracy
-
-		// DS201-Inspired Low-pass Filter - removes ultrasonic noise (part of DS201 side-chain)
-		DS201LPEnabled:   true,
-		DS201LPFreq:      16000.0, // 16kHz cutoff (conservative default, preserves all audible content)
-		DS201LPPoles:     2,       // 12dB/oct standard slope
-		DS201LPWidth:     0.707,   // Butterworth Q (maximally flat passband)
-		DS201LPMix:       1.0,     // Full wet signal
-		DS201LPTransform: "tdii",  // Transposed Direct Form II - best floating-point accuracy
-
-		// NoiseRemove - anlmdn + compand at source sample rate (matrix spike defaults)
-		NoiseRemoveEnabled:          true,                             // Primary noise reduction filter
-		NoiseRemoveCompandEnabled:   true,                             // Compand enabled when noise profile available
-		NoiseRemoveStrength:         noiseRemoveProductionStrength,    // Minimum strength (fixed from spike validation)
-		NoiseRemovePatchSec:         noiseRemoveProductionPatchSec,    // 6ms patch
-		NoiseRemoveResearchSec:      noiseRemoveProductionResearchSec, // 2.0ms research (r_min)
-		NoiseRemoveSmooth:           noiseRemoveProductionSmooth,      // 3.0 smoothing (m_strict)
-		NoiseRemoveCompandThreshold: -55.0,                            // Overridden by adaptive tuning
-		NoiseRemoveCompandExpansion: 6.0,                              // Overridden by adaptive tuning
-		NoiseRemoveCompandAttack:    0.005,                            // 5ms - fixed, empirically validated for speech
-		NoiseRemoveCompandDecay:     0.100,                            // 100ms - fixed, empirically validated for speech
-		NoiseRemoveCompandKnee:      6.0,                              // 6dB - fixed, soft knee for transparency
-
-		// DS201-Inspired Gate - soft expander for natural speech transitions
-		// All parameters set adaptively based on Pass 1 measurements
-		DS201GateEnabled:   true,
-		DS201GateThreshold: 0.01,   // -40dBFS default (adaptive: based on silence peak + headroom)
-		DS201GateRatio:     2.0,    // 2:1 ratio - soft expander (adaptive: based on LRA)
-		DS201GateAttack:    12,     // 12ms attack (adaptive: 10-25ms based on MaxDifference/Crest)
-		DS201GateRelease:   350,    // 350ms release (adaptive: based on flux/ZCR, +50ms hold compensation)
-		DS201GateRange:     0.0625, // -24dB reduction (adaptive: based on silence entropy)
-		DS201GateKnee:      3.0,    // Soft knee (adaptive: based on spectral crest)
-		DS201GateMakeup:    1.0,    // Unity gain (loudnorm handles all level adjustment)
-		DS201GateDetection: "rms",  // RMS detection (adaptive: rms for bleed, peak for clean)
-
-		// LA-2A Compressor - Teletronix LA-2A style optical compressor emulation
-		// The Teletronix LA-2A is renowned for its gentle, program-dependent character:
-		// - Fixed 10ms attack preserves transients
-		// - Two-stage release (60ms initial, 1-15s full) - we use ~200ms approximation
-		// - Soft 3:1 ratio from T4 optical cell
-		// - Very soft knee from T4 optical cell
-		// All parameters are tuned adaptively by tuneLA2ACompressor()
-		LA2AEnabled:   true,
-		LA2AThreshold: -18, // -18dB threshold (tuned relative to RMS in adaptive)
-		LA2ARatio:     3.0, // 3:1 ratio (LA-2A Compress mode baseline)
-		LA2AAttack:    10,  // 10ms attack (LA-2A fixed attack, preserves transients)
-		LA2ARelease:   200, // 200ms release (LA-2A two-stage approximation)
-		LA2AMakeup:    0,   // Unity gain (0 dB - loudnorm handles all level adjustment)
-		LA2AKnee:      4.0, // Soft knee (LA-2A T4 optical cell characteristic)
-		LA2AMix:       1.0, // 100% wet (true LA-2A has no parallel compression)
-
-		// De-esser - automatic sibilance reduction
-		DeessEnabled:   true,
-		DeessIntensity: 0.0, // 0.0 = disabled by default, will be set adaptively if enabled
-		DeessAmount:    0.5, // 50% ducking on treble (moderate reduction)
-		DeessFreq:      0.5, // Keep 50% of original frequency content (balanced)
-
-		// Target values (for reference only)
-		TargetI:   -16.0, // Reference LUFS target (not enforced)
-		TargetTP:  -0.3,  // Reference true peak (not enforced, alimiter does real limiting at -1.5)
-		TargetLRA: 7.0,   // Reference loudness range (EBU R128 default)
-
-		// Adeclick - click/pop repair (Pass 4 only)
-		// Tuned for transparent repair at lower CPU cost
-		AdeclickEnabled:   true,
-		AdeclickThreshold: 2.0,  // Less sensitive threshold reduces CPU cost without harming repair quality
-		AdeclickWindow:    55.0, // Default window, appropriate for speech
-		AdeclickOverlap:   50.0, // Lower overlap further reduces cost while remaining within FFmpeg's valid range
-		AdeclickMethod:    "s",  // Spline interpolation preserves transient peak shapes better than the default average method
-
-		// Filter chain order - use default order
 		FilterOrder: Pass2FilterOrder,
+	}
+}
 
-		// Loudnorm - enabled by default with podcast-optimised settings
-		LoudnormEnabled:   true,
-		LoudnormTargetI:   -16.0, // Podcast standard (-16 LUFS)
-		LoudnormTargetTP:  -2.0,  // Conservative headroom (prevents limiter clipping to 0.0 dBTP)
-		LoudnormTargetLRA: 20.0,  // High value to prevent dynamic mode fallback (must be >= source LRA)
-		LoudnormDualMono:  true,  // CRITICAL for mono recordings
-		LoudnormLinear:    true,  // Prefer linear (transparent) mode
-	}}
+func defaultDownmixConfig() DownmixConfig {
+	return DownmixConfig{Enabled: true}
+}
+
+func defaultAnalysisConfig() AnalysisConfig {
+	return AnalysisConfig{Enabled: true}
+}
+
+func defaultResampleConfig() ResampleConfig {
+	return ResampleConfig{
+		Enabled:    true,
+		SampleRate: 44100,
+		Format:     "s16",
+		FrameSize:  4096,
+	}
+}
+
+func defaultDS201HighPassConfig() DS201HighPassConfig {
+	return DS201HighPassConfig{
+		Enabled:   true,
+		Frequency: 80.0,
+		Poles:     ds201HPDefaultPoles,
+		Width:     ds201HPDefaultWidth,
+		Mix:       ds201HPDefaultMix,
+		Transform: ds201HPDefaultTransform,
+	}
+}
+
+func defaultDS201LowPassConfig() DS201LowPassConfig {
+	return DS201LowPassConfig{
+		Enabled:   true,
+		Frequency: 16000.0,
+		Poles:     2,
+		Width:     0.707,
+		Mix:       1.0,
+		Transform: "tdii",
+	}
+}
+
+func defaultNoiseRemoveConfig() NoiseRemoveConfig {
+	return NoiseRemoveConfig{
+		Enabled:          true,
+		CompandEnabled:   true,
+		Strength:         noiseRemoveProductionStrength,
+		PatchSec:         noiseRemoveProductionPatchSec,
+		ResearchSec:      noiseRemoveProductionResearchSec,
+		Smooth:           noiseRemoveProductionSmooth,
+		CompandThreshold: -55.0,
+		CompandExpansion: 6.0,
+		CompandAttack:    0.005,
+		CompandDecay:     0.100,
+		CompandKnee:      6.0,
+	}
+}
+
+func defaultDS201GateConfig() DS201GateConfig {
+	return DS201GateConfig{
+		Enabled:   true,
+		Threshold: 0.01,
+		Ratio:     2.0,
+		Attack:    12,
+		Release:   350,
+		Range:     0.0625,
+		Knee:      3.0,
+		Makeup:    1.0,
+		Detection: "rms",
+	}
+}
+
+func defaultLA2AConfig() LA2AConfig {
+	return LA2AConfig{
+		Enabled:   true,
+		Threshold: -18,
+		Ratio:     3.0,
+		Attack:    10,
+		Release:   200,
+		Makeup:    0,
+		Knee:      4.0,
+		Mix:       1.0,
+	}
+}
+
+func defaultDeesserConfig() DeesserConfig {
+	return DeesserConfig{
+		Enabled:   true,
+		Intensity: 0.0,
+		Amount:    0.5,
+		Frequency: 0.5,
+	}
+}
+
+func defaultAdeclickConfig() AdeclickConfig {
+	return AdeclickConfig{
+		Enabled:   true,
+		Threshold: 2.0,
+		Window:    55.0,
+		Overlap:   50.0,
+		Method:    "s",
+	}
+}
+
+func defaultLoudnormConfig() LoudnormConfig {
+	return LoudnormConfig{
+		Enabled:   true,
+		TargetI:   -16.0,
+		TargetTP:  -2.0,
+		TargetLRA: 20.0,
+		DualMono:  true,
+		Linear:    true,
+	}
 }
 
 func DefaultEffectiveFilterConfig() *EffectiveFilterConfig {
@@ -445,6 +519,9 @@ func cloneFilterOrder(order []FilterID) []FilterID {
 }
 
 func copyFilterDefaults(dst *EffectiveFilterConfig, src *filterConfigDefaults) {
+	if dst == nil {
+		return
+	}
 	*dst = EffectiveFilterConfig(cloneFilterDefaults(src))
 }
 
@@ -467,7 +544,8 @@ func LinearToDb(linear float64) float64 {
 // Uses FFmpeg's built-in channel layout conversion which handles various input
 // configurations (stereo, mono, single-channel recordings) correctly.
 func (cfg *EffectiveFilterConfig) buildDownmixFilter() string {
-	if !cfg.DownmixEnabled {
+	downmix := cfg.Downmix
+	if !downmix.Enabled {
 		return ""
 	}
 	// aformat with channel_layouts=mono uses FFmpeg's standard downmix matrix
@@ -490,7 +568,8 @@ func (cfg *EffectiveFilterConfig) buildDownmixFilter() string {
 // separately via measureWithLoudnorm() which reads the processed file without
 // encoding output.
 func (cfg *EffectiveFilterConfig) buildAnalysisFilter() string {
-	if !cfg.AnalysisEnabled {
+	analysis := cfg.Analysis
+	if !analysis.Enabled {
 		return ""
 	}
 	// astats: provides noise floor, dynamic range, and additional measurements for adaptive processing:
@@ -530,14 +609,15 @@ func (cfg *EffectiveFilterConfig) buildAnalysisFilter() string {
 		"astats=metadata=1:measure_perchannel=all,"+
 			"aspectralstats=win_size=2048:win_func=hann:measure=all,"+
 			"ebur128=metadata=1:peak=sample+true:dualmono=true:target=%.0f",
-		cfg.TargetI)
+		cfg.Loudnorm.TargetI)
 }
 
 // buildResampleFilter builds the output format standardisation filter.
 // Ensures consistent output: 44.1kHz, 16-bit, mono, fixed frame size.
 // Pass 2 only - applied after all processing and analysis.
 func (cfg *EffectiveFilterConfig) buildResampleFilter() string {
-	if !cfg.ResampleEnabled {
+	resample := cfg.Resample
+	if !resample.Enabled {
 		return ""
 	}
 	return cfg.buildRequiredOutputFormatFilter()
@@ -545,10 +625,11 @@ func (cfg *EffectiveFilterConfig) buildResampleFilter() string {
 
 // buildRequiredOutputFormatFilter builds the mandatory output format filter.
 // Use this when a pass must restore encoder-compatible audio regardless of
-// ResampleEnabled.
+// Resample.Enabled.
 func (cfg *EffectiveFilterConfig) buildRequiredOutputFormatFilter() string {
+	resample := cfg.Resample
 	return fmt.Sprintf("aformat=sample_rates=%d:channel_layouts=mono:sample_fmts=%s,asetnsamples=n=%d",
-		cfg.ResampleSampleRate, cfg.ResampleFormat, cfg.ResampleFrameSize)
+		resample.SampleRate, resample.Format, resample.FrameSize)
 }
 
 // buildDS201HighpassFilter builds the DS201-inspired high-pass filter.
@@ -565,31 +646,32 @@ func (cfg *EffectiveFilterConfig) buildRequiredOutputFormatFilter() string {
 // - transform: filter algorithm (tdii=best floating-point accuracy)
 // - mix: wet/dry blend (1.0=full filter, 0.7=subtle for warm voices)
 func (cfg *EffectiveFilterConfig) buildDS201HighpassFilter() string {
-	if !cfg.DS201HPEnabled {
+	highpass := cfg.DS201HighPass
+	if !highpass.Enabled {
 		return ""
 	}
 
-	poles := cfg.DS201HPPoles
+	poles := highpass.Poles
 	if poles < 1 {
 		poles = 2 // Default to standard 12dB/oct
 	}
 
-	width := cfg.DS201HPWidth
+	width := highpass.Width
 	if width <= 0 {
 		width = 0.707 // Butterworth default
 	}
 
 	hpSpec := fmt.Sprintf("highpass=f=%.0f:poles=%d:width_type=q:width=%.3f:normalize=1",
-		cfg.DS201HPFreq, poles, width)
+		highpass.Frequency, poles, width)
 
 	// Add transform type if specified (tdii = best floating-point accuracy)
-	if cfg.DS201HPTransform != "" {
-		hpSpec += fmt.Sprintf(":a=%s", cfg.DS201HPTransform)
+	if highpass.Transform != "" {
+		hpSpec += fmt.Sprintf(":a=%s", highpass.Transform)
 	}
 
 	// Add mix parameter if not full wet (for warm voice protection)
-	if cfg.DS201HPMix > 0 && cfg.DS201HPMix < 1.0 {
-		hpSpec += fmt.Sprintf(":m=%.2f", cfg.DS201HPMix)
+	if highpass.Mix > 0 && highpass.Mix < 1.0 {
+		hpSpec += fmt.Sprintf(":m=%.2f", highpass.Mix)
 	}
 
 	return hpSpec
@@ -609,33 +691,34 @@ func (cfg *EffectiveFilterConfig) buildDS201HighpassFilter() string {
 // - transform: filter algorithm (tdii=best floating-point accuracy)
 // - mix: wet/dry blend (1.0=full filter)
 //
-// Returns empty string if DS201LPEnabled is false.
+// Returns empty string if DS201LowPass.Enabled is false.
 func (cfg *EffectiveFilterConfig) buildDS201LowPassFilter() string {
-	if !cfg.DS201LPEnabled {
+	lowpass := cfg.DS201LowPass
+	if !lowpass.Enabled {
 		return ""
 	}
 
-	poles := cfg.DS201LPPoles
+	poles := lowpass.Poles
 	if poles < 1 {
 		poles = 2 // Default to standard 12dB/oct
 	}
 
-	width := cfg.DS201LPWidth
+	width := lowpass.Width
 	if width <= 0 {
 		width = 0.707 // Butterworth default
 	}
 
 	lpSpec := fmt.Sprintf("lowpass=f=%.0f:poles=%d:width_type=q:width=%.3f:normalize=1",
-		cfg.DS201LPFreq, poles, width)
+		lowpass.Frequency, poles, width)
 
 	// Add transform type if specified (tdii = best floating-point accuracy)
-	if cfg.DS201LPTransform != "" {
-		lpSpec += fmt.Sprintf(":a=%s", cfg.DS201LPTransform)
+	if lowpass.Transform != "" {
+		lpSpec += fmt.Sprintf(":a=%s", lowpass.Transform)
 	}
 
 	// Add mix parameter if not full wet (for subtle application)
-	if cfg.DS201LPMix > 0 && cfg.DS201LPMix < 1.0 {
-		lpSpec += fmt.Sprintf(":m=%.2f", cfg.DS201LPMix)
+	if lowpass.Mix > 0 && lowpass.Mix < 1.0 {
+		lpSpec += fmt.Sprintf(":m=%.2f", lowpass.Mix)
 	}
 
 	return lpSpec
@@ -659,19 +742,20 @@ func (cfg *EffectiveFilterConfig) buildDS201LowPassFilter() string {
 // - decay: 100ms (fixed, empirically validated for speech)
 // - soft-knee: 6dB (fixed, transparent)
 func (cfg *EffectiveFilterConfig) buildNoiseRemoveFilter() string {
-	if !cfg.NoiseRemoveEnabled {
+	noiseRemove := cfg.NoiseRemove
+	if !noiseRemove.Enabled {
 		return ""
 	}
 
 	filters := make([]string, 0, 2)
 	filters = append(filters, fmt.Sprintf("anlmdn=s=%.5f:p=%.4f:r=%.4f:m=%.0f",
-		cfg.NoiseRemoveStrength,
-		cfg.NoiseRemovePatchSec,
-		cfg.NoiseRemoveResearchSec,
-		cfg.NoiseRemoveSmooth,
+		noiseRemove.Strength,
+		noiseRemove.PatchSec,
+		noiseRemove.ResearchSec,
+		noiseRemove.Smooth,
 	))
 
-	if cfg.NoiseRemoveCompandEnabled {
+	if noiseRemove.CompandEnabled {
 		filters = append(filters, cfg.buildNoiseRemoveCompandFilter())
 	}
 
@@ -682,11 +766,12 @@ func (cfg *EffectiveFilterConfig) buildNoiseRemoveFilter() string {
 // Compand uses FLAT reduction curve with uniform expansion below threshold.
 // Parameters are derived from Pass 1 measurements in tuneNoiseRemove (adaptive.go).
 func (cfg *EffectiveFilterConfig) buildNoiseRemoveCompandFilter() string {
+	noiseRemove := cfg.NoiseRemove
 	// Build FLAT reduction curve
 	// Every point below threshold gets the same expansion (reduction)
 	// Points: -90 → (-90 - exp), -75 → (-75 - exp), threshold → threshold, -30 → -30, 0 → 0
-	exp := cfg.NoiseRemoveCompandExpansion
-	thresh := cfg.NoiseRemoveCompandThreshold
+	exp := noiseRemove.CompandExpansion
+	thresh := noiseRemove.CompandThreshold
 
 	out90 := -90.0 - exp
 	out75 := -75.0 - exp
@@ -695,9 +780,9 @@ func (cfg *EffectiveFilterConfig) buildNoiseRemoveCompandFilter() string {
 	// Points format: in1/out1|in2/out2|...
 	return fmt.Sprintf(
 		"compand=attacks=%.3f:decays=%.3f:soft-knee=%.1f:points=-90/%.0f|-75/%.0f|%.0f/%.0f|-30/-30|0/0",
-		cfg.NoiseRemoveCompandAttack,
-		cfg.NoiseRemoveCompandDecay,
-		cfg.NoiseRemoveCompandKnee,
+		noiseRemove.CompandAttack,
+		noiseRemove.CompandDecay,
+		noiseRemove.CompandKnee,
 		out90, out75,
 		thresh, thresh,
 	)
@@ -708,10 +793,11 @@ func (cfg *EffectiveFilterConfig) buildNoiseRemoveCompandFilter() string {
 // Minimum 10ms attack prevents click artifacts from rapid gain changes.
 // Detection mode is adaptive: RMS for tonal bleed, peak for clean recordings.
 func (cfg *EffectiveFilterConfig) buildDS201GateFilter() string {
-	if !cfg.DS201GateEnabled {
+	gate := cfg.DS201Gate
+	if !gate.Enabled {
 		return ""
 	}
-	detection := cfg.DS201GateDetection
+	detection := gate.Detection
 	if detection == "" {
 		detection = "rms" // Safe default for speech
 	}
@@ -719,14 +805,14 @@ func (cfg *EffectiveFilterConfig) buildDS201GateFilter() string {
 	return fmt.Sprintf(
 		"agate=threshold=%.6f:ratio=%.1f:attack=%.2f:release=%.0f:"+
 			"range=%.4f:knee=%.1f:detection=%s:makeup=%.1f",
-		cfg.DS201GateThreshold,
-		cfg.DS201GateRatio,
-		cfg.DS201GateAttack,
-		cfg.DS201GateRelease,
-		cfg.DS201GateRange,
-		cfg.DS201GateKnee,
+		gate.Threshold,
+		gate.Ratio,
+		gate.Attack,
+		gate.Release,
+		gate.Range,
+		gate.Knee,
 		detection,
-		cfg.DS201GateMakeup,
+		gate.Makeup,
 	)
 }
 
@@ -735,19 +821,20 @@ func (cfg *EffectiveFilterConfig) buildDS201GateFilter() string {
 // optical compressor's gentle, program-dependent character.
 // Converts dB values to linear for FFmpeg's format.
 func (cfg *EffectiveFilterConfig) buildLA2ACompressorFilter() string {
-	if !cfg.LA2AEnabled {
+	la2a := cfg.LA2A
+	if !la2a.Enabled {
 		return ""
 	}
 	return fmt.Sprintf(
 		"acompressor=threshold=%.6f:ratio=%.1f:attack=%.0f:release=%.0f:"+
 			"makeup=%.2f:knee=%.1f:detection=rms:mix=%.2f",
-		DbToLinear(cfg.LA2AThreshold),
-		cfg.LA2ARatio,
-		cfg.LA2AAttack,
-		cfg.LA2ARelease,
-		DbToLinear(cfg.LA2AMakeup),
-		cfg.LA2AKnee,
-		cfg.LA2AMix,
+		Decibels(la2a.Threshold).LinearAmplitude().Float64(),
+		la2a.Ratio,
+		la2a.Attack,
+		la2a.Release,
+		Decibels(la2a.Makeup).LinearAmplitude().Float64(),
+		la2a.Knee,
+		la2a.Mix,
 	)
 }
 
@@ -755,14 +842,15 @@ func (cfg *EffectiveFilterConfig) buildLA2ACompressorFilter() string {
 // Automatically detects and reduces harsh sibilance ("s" sounds).
 // Returns empty string if disabled or intensity is 0.
 func (cfg *EffectiveFilterConfig) buildDeesserFilter() string {
-	if !cfg.DeessEnabled || cfg.DeessIntensity <= 0 {
+	deesser := cfg.Deesser
+	if !deesser.Enabled || deesser.Intensity <= 0 {
 		return ""
 	}
 	return fmt.Sprintf(
 		"deesser=i=%.2f:m=%.2f:f=%.2f",
-		cfg.DeessIntensity,
-		cfg.DeessAmount,
-		cfg.DeessFreq,
+		deesser.Intensity,
+		deesser.Amount,
+		deesser.Frequency,
 	)
 }
 
@@ -775,17 +863,18 @@ func (cfg *EffectiveFilterConfig) buildDeesserFilter() string {
 // - w (window): Analysis window in ms (10-100, default 55)
 // - o (overlap): Window overlap percentage (50-95, default 75)
 func (cfg *EffectiveFilterConfig) buildAdeclickFilter() string {
-	if !cfg.AdeclickEnabled {
+	adeclick := cfg.Adeclick
+	if !adeclick.Enabled {
 		return ""
 	}
 	spec := fmt.Sprintf(
 		"adeclick=t=%.1f:w=%.0f:o=%.0f",
-		cfg.AdeclickThreshold,
-		cfg.AdeclickWindow,
-		cfg.AdeclickOverlap,
+		adeclick.Threshold,
+		adeclick.Window,
+		adeclick.Overlap,
 	)
-	if cfg.AdeclickMethod != "" {
-		spec += ":m=" + cfg.AdeclickMethod
+	if adeclick.Method != "" {
+		spec += ":m=" + adeclick.Method
 	}
 	return spec
 }

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -13,84 +13,150 @@ import (
 // All filters are disabled by default - enable only what you need for each test.
 // This isolates tests from application default configuration changes.
 func newTestBaseConfig() *BaseFilterConfig {
-	return &BaseFilterConfig{filterConfigDefaults: filterConfigDefaults{
-		// Infrastructure filters (disabled by default for isolated tests)
-		DownmixEnabled:     false,
-		AnalysisEnabled:    false,
-		ResampleEnabled:    false,
-		ResampleSampleRate: 44100,
-		ResampleFormat:     "s16",
-		ResampleFrameSize:  4096,
-
-		// Processing filters (all disabled by default)
-		DS201HPEnabled:     false,
-		NoiseRemoveEnabled: false,
-		DS201GateEnabled:   false,
-		LA2AEnabled:        false,
-		DeessEnabled:       false,
-
-		// Sensible defaults for parameters (used when filter is enabled)
-		DS201HPFreq:        80.0,
-		DS201HPPoles:       2,     // 12dB/oct standard Butterworth
-		DS201HPWidth:       0.707, // Butterworth
-		DS201HPMix:         1.0,   // Full wet
-		DS201HPTransform:   "tdii",
-		DS201GateThreshold: 0.01,
-		DS201GateRatio:     2.0,
-		DS201GateAttack:    20,
-		DS201GateRelease:   250,
-		DS201GateRange:     0.0625,
-		DS201GateKnee:      2.828,
-		DS201GateMakeup:    1.0,
-		LA2AThreshold:      -20,
-		LA2ARatio:          2.5,
-		LA2AAttack:         15,
-		LA2ARelease:        80,
-		LA2AMakeup:         0, // Unity gain - loudnorm handles all level adjustment
-		LA2AKnee:           2.5,
-		LA2AMix:            1.0,
-		DeessIntensity:     0.5,
-		DeessAmount:        0.5,
-		DeessFreq:          0.5,
-		TargetI:            -16.0,
-		TargetTP:           -0.3,
-		TargetLRA:          7.0,
-
-		// NoiseRemove defaults (anlmdn + compand)
-		NoiseRemoveCompandEnabled:   true,
-		NoiseRemoveStrength:         0.00001,
-		NoiseRemovePatchSec:         0.006,
-		NoiseRemoveResearchSec:      0.0058,
-		NoiseRemoveSmooth:           11.0,
-		NoiseRemoveCompandThreshold: -50.0,
-		NoiseRemoveCompandExpansion: 10.0,
-		NoiseRemoveCompandAttack:    0.005,
-		NoiseRemoveCompandDecay:     0.100,
-		NoiseRemoveCompandKnee:      6.0,
-
-		// Loudnorm defaults (Pass 3)
-		LoudnormEnabled:   true,
-		LoudnormTargetI:   -16.0,
-		LoudnormTargetTP:  -1.5,
-		LoudnormTargetLRA: 11.0,
-		LoudnormDualMono:  true,
-		LoudnormLinear:    true,
-
-		// Adeclick defaults (Pass 4)
-		AdeclickEnabled:   true,
-		AdeclickThreshold: 2.0,
-		AdeclickWindow:    55.0,
-		AdeclickOverlap:   50.0,
-		AdeclickMethod:    "s",
-
-		FilterOrder: Pass2FilterOrder,
-	}}
+	defaults := assembleFilterDefaults(
+		DownmixConfig{Enabled: false},
+		AnalysisConfig{Enabled: false},
+		ResampleConfig{Enabled: false, SampleRate: 44100, Format: "s16", FrameSize: 4096},
+		DS201HighPassConfig{
+			Enabled:   false,
+			Frequency: 80.0,
+			Poles:     2,
+			Width:     0.707,
+			Mix:       1.0,
+			Transform: "tdii",
+		},
+		DS201LowPassConfig{
+			Enabled:   false,
+			Frequency: 16000.0,
+			Poles:     2,
+			Width:     0.707,
+			Mix:       1.0,
+		},
+		NoiseRemoveConfig{
+			Enabled:          false,
+			CompandEnabled:   true,
+			Strength:         0.00001,
+			PatchSec:         0.006,
+			ResearchSec:      0.0058,
+			Smooth:           11.0,
+			CompandThreshold: -50.0,
+			CompandExpansion: 10.0,
+			CompandAttack:    0.005,
+			CompandDecay:     0.100,
+			CompandKnee:      6.0,
+		},
+		DS201GateConfig{
+			Enabled:   false,
+			Threshold: 0.01,
+			Ratio:     2.0,
+			Attack:    20,
+			Release:   250,
+			Range:     0.0625,
+			Knee:      2.828,
+			Makeup:    1.0,
+			Detection: "rms",
+		},
+		LA2AConfig{
+			Enabled:   false,
+			Threshold: -20,
+			Ratio:     2.5,
+			Attack:    15,
+			Release:   80,
+			Makeup:    0,
+			Knee:      2.5,
+			Mix:       1.0,
+		},
+		DeesserConfig{Enabled: false, Intensity: 0.5, Amount: 0.5, Frequency: 0.5},
+		AdeclickConfig{Enabled: true, Threshold: 2.0, Window: 55.0, Overlap: 50.0, Method: "s"},
+		LoudnormConfig{Enabled: true, TargetI: -16.0, TargetTP: -1.5, TargetLRA: 11.0, DualMono: true, Linear: true},
+	)
+	defaults.FilterOrder = Pass2FilterOrder
+	return &BaseFilterConfig{filterConfigDefaults: defaults}
 }
 
 // newTestConfig creates a minimal effective config for builder and tuner tests
 // that operate after seed assembly.
 func newTestConfig() *EffectiveFilterConfig {
 	return deriveEffectiveFilterConfig(newTestBaseConfig())
+}
+
+func TestFilterFamilyConfigTypesExist(t *testing.T) {
+	configType := reflect.TypeFor[filterConfigDefaults]()
+	tests := []struct {
+		field string
+		typ   reflect.Type
+	}{
+		{"Downmix", reflect.TypeFor[DownmixConfig]()},
+		{"Analysis", reflect.TypeFor[AnalysisConfig]()},
+		{"Resample", reflect.TypeFor[ResampleConfig]()},
+		{"DS201HighPass", reflect.TypeFor[DS201HighPassConfig]()},
+		{"DS201LowPass", reflect.TypeFor[DS201LowPassConfig]()},
+		{"NoiseRemove", reflect.TypeFor[NoiseRemoveConfig]()},
+		{"DS201Gate", reflect.TypeFor[DS201GateConfig]()},
+		{"LA2A", reflect.TypeFor[LA2AConfig]()},
+		{"Deesser", reflect.TypeFor[DeesserConfig]()},
+		{"Adeclick", reflect.TypeFor[AdeclickConfig]()},
+		{"Loudnorm", reflect.TypeFor[LoudnormConfig]()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			field, ok := configType.FieldByName(tt.field)
+			if !ok {
+				t.Fatalf("filterConfigDefaults missing %s", tt.field)
+			}
+			if field.Type != tt.typ {
+				t.Fatalf("%s type = %s, want %s", tt.field, field.Type, tt.typ)
+			}
+		})
+	}
+
+	analysisField, ok := reflect.TypeFor[AnalysisConfig]().FieldByName("SilenceScanDuration")
+	if !ok {
+		t.Fatal("AnalysisConfig missing SilenceScanDuration")
+	}
+	if analysisField.Type != reflect.TypeFor[time.Duration]() {
+		t.Fatalf("AnalysisConfig.SilenceScanDuration type = %s, want %s",
+			analysisField.Type, reflect.TypeFor[time.Duration]())
+	}
+}
+
+func TestDefaultFilterConfigComposesTypedDefaults(t *testing.T) {
+	config := DefaultFilterConfig()
+
+	if config.Downmix != defaultDownmixConfig() {
+		t.Errorf("Downmix = %+v, want %+v", config.Downmix, defaultDownmixConfig())
+	}
+	if config.Analysis != defaultAnalysisConfig() {
+		t.Errorf("Analysis = %+v, want %+v", config.Analysis, defaultAnalysisConfig())
+	}
+	if config.Resample != defaultResampleConfig() {
+		t.Errorf("Resample = %+v, want %+v", config.Resample, defaultResampleConfig())
+	}
+	if config.DS201HighPass != defaultDS201HighPassConfig() {
+		t.Errorf("DS201HighPass = %+v, want %+v", config.DS201HighPass, defaultDS201HighPassConfig())
+	}
+	if config.DS201LowPass != defaultDS201LowPassConfig() {
+		t.Errorf("DS201LowPass = %+v, want %+v", config.DS201LowPass, defaultDS201LowPassConfig())
+	}
+	if config.NoiseRemove != defaultNoiseRemoveConfig() {
+		t.Errorf("NoiseRemove = %+v, want %+v", config.NoiseRemove, defaultNoiseRemoveConfig())
+	}
+	if config.DS201Gate != defaultDS201GateConfig() {
+		t.Errorf("DS201Gate = %+v, want %+v", config.DS201Gate, defaultDS201GateConfig())
+	}
+	if config.LA2A != defaultLA2AConfig() {
+		t.Errorf("LA2A = %+v, want %+v", config.LA2A, defaultLA2AConfig())
+	}
+	if config.Deesser != defaultDeesserConfig() {
+		t.Errorf("Deesser = %+v, want %+v", config.Deesser, defaultDeesserConfig())
+	}
+	if config.Adeclick != defaultAdeclickConfig() {
+		t.Errorf("Adeclick = %+v, want %+v", config.Adeclick, defaultAdeclickConfig())
+	}
+	if config.Loudnorm != defaultLoudnormConfig() {
+		t.Errorf("Loudnorm = %+v, want %+v", config.Loudnorm, defaultLoudnormConfig())
+	}
 }
 
 func TestBuildFilterSpec(t *testing.T) {
@@ -106,11 +172,11 @@ func TestBuildFilterSpec(t *testing.T) {
 
 	t.Run("resample enabled produces output format filters", func(t *testing.T) {
 		config := newTestConfig()
-		config.ResampleEnabled = true
+		config.Resample.Enabled = true
 
 		spec := config.BuildFilterSpec()
 
-		// Output format filters should be present when ResampleEnabled
+		// Output format filters should be present when Resample.Enabled
 		if !strings.Contains(spec, "aformat=sample_rates=44100") {
 			t.Error("Missing aformat output filter")
 		}
@@ -140,11 +206,11 @@ func TestBuildFilterSpec(t *testing.T) {
 	t.Run("enabled filters appear in spec", func(t *testing.T) {
 		config := newTestConfig()
 		// Enable specific filters for this test
-		config.DS201HPEnabled = true
-		config.DS201GateEnabled = true
-		config.LA2AEnabled = true
-		config.DeessEnabled = true
-		config.ResampleEnabled = true // Required for output format filters
+		config.DS201HighPass.Enabled = true
+		config.DS201Gate.Enabled = true
+		config.LA2A.Enabled = true
+		config.Deesser.Enabled = true
+		config.Resample.Enabled = true // Required for output format filters
 
 		spec := config.BuildFilterSpec()
 
@@ -170,10 +236,10 @@ func TestBuildFilterSpec(t *testing.T) {
 	t.Run("no NaN values in filter spec", func(t *testing.T) {
 		config := newTestConfig()
 		// Enable all filters to maximize coverage
-		config.DS201HPEnabled = true
-		config.DS201GateEnabled = true
-		config.LA2AEnabled = true
-		config.DeessEnabled = true
+		config.DS201HighPass.Enabled = true
+		config.DS201Gate.Enabled = true
+		config.LA2A.Enabled = true
+		config.Deesser.Enabled = true
 
 		spec := config.BuildFilterSpec()
 
@@ -185,10 +251,10 @@ func TestBuildFilterSpec(t *testing.T) {
 	t.Run("no Inf values in filter spec", func(t *testing.T) {
 		config := newTestConfig()
 		// Enable all filters to maximize coverage
-		config.DS201HPEnabled = true
-		config.DS201GateEnabled = true
-		config.LA2AEnabled = true
-		config.DeessEnabled = true
+		config.DS201HighPass.Enabled = true
+		config.DS201Gate.Enabled = true
+		config.LA2A.Enabled = true
+		config.Deesser.Enabled = true
 
 		spec := config.BuildFilterSpec()
 
@@ -220,17 +286,17 @@ func TestBuildFilterSpec(t *testing.T) {
 			t.Error("Disabled alimiter filter present in spec")
 		}
 
-		// With ResampleEnabled=false (from newTestConfig), no aformat should be present
+		// With Resample.Enabled=false (from newTestConfig), no aformat should be present
 		// This is intentional - infrastructure filters are now controlled by flags
 		if strings.Contains(spec, "aformat=sample_rates=44100") {
-			t.Error("aformat should not appear when ResampleEnabled=false")
+			t.Error("aformat should not appear when Resample.Enabled=false")
 		}
 	})
 
 	t.Run("de-esser excluded when intensity is zero", func(t *testing.T) {
 		config := newTestConfig()
-		config.DeessEnabled = true
-		config.DeessIntensity = 0.0 // Disabled by intensity
+		config.Deesser.Enabled = true
+		config.Deesser.Intensity = 0.0 // Disabled by intensity
 
 		spec := config.BuildFilterSpec()
 
@@ -241,8 +307,8 @@ func TestBuildFilterSpec(t *testing.T) {
 
 	t.Run("aformat appears after analysis filters when both enabled", func(t *testing.T) {
 		config := newTestConfig()
-		config.AnalysisEnabled = true
-		config.ResampleEnabled = true
+		config.Analysis.Enabled = true
+		config.Resample.Enabled = true
 		// Use Pass2FilterOrder which has Analysis before Resample
 		config.FilterOrder = Pass2FilterOrder
 
@@ -250,7 +316,7 @@ func TestBuildFilterSpec(t *testing.T) {
 
 		// Should contain ebur128 analysis filter
 		if !strings.Contains(spec, "ebur128=") {
-			t.Fatal("Missing ebur128 filter when AnalysisEnabled=true")
+			t.Fatal("Missing ebur128 filter when Analysis.Enabled=true")
 		}
 
 		// ebur128 converts to f64 internally - aformat must come after to convert back to s16
@@ -293,7 +359,7 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "low-pass disabled",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.DS201LPEnabled = false
+				config.DS201LowPass.Enabled = false
 				config.FilterOrder = []FilterID{FilterDS201LowPass}
 				return config
 			}(),
@@ -303,12 +369,12 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "low-pass enabled",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.DS201LPEnabled = true
-				config.DS201LPFreq = 14500.0
-				config.DS201LPPoles = 1
-				config.DS201LPWidth = 0.5
-				config.DS201LPMix = 0.75
-				config.DS201LPTransform = "zdf"
+				config.DS201LowPass.Enabled = true
+				config.DS201LowPass.Frequency = 14500.0
+				config.DS201LowPass.Poles = 1
+				config.DS201LowPass.Width = 0.5
+				config.DS201LowPass.Mix = 0.75
+				config.DS201LowPass.Transform = "zdf"
 				config.FilterOrder = []FilterID{FilterDS201LowPass}
 				return config
 			}(),
@@ -318,15 +384,15 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "gate tuned",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.DS201GateEnabled = true
-				config.DS201GateThreshold = 0.003162
-				config.DS201GateRatio = 3.5
-				config.DS201GateAttack = 10.5
-				config.DS201GateRelease = 425
-				config.DS201GateRange = 0.0316
-				config.DS201GateKnee = 4.5
-				config.DS201GateDetection = "peak"
-				config.DS201GateMakeup = 1.2
+				config.DS201Gate.Enabled = true
+				config.DS201Gate.Threshold = 0.003162
+				config.DS201Gate.Ratio = 3.5
+				config.DS201Gate.Attack = 10.5
+				config.DS201Gate.Release = 425
+				config.DS201Gate.Range = 0.0316
+				config.DS201Gate.Knee = 4.5
+				config.DS201Gate.Detection = "peak"
+				config.DS201Gate.Makeup = 1.2
 				config.FilterOrder = []FilterID{FilterDS201Gate}
 				return config
 			}(),
@@ -336,14 +402,14 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "LA-2A high-crest tuned values",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.LA2AEnabled = true
-				config.LA2AThreshold = -30.0
-				config.LA2ARatio = 4.0
-				config.LA2AAttack = 10
-				config.LA2ARelease = 60
-				config.LA2AMakeup = 0
-				config.LA2AKnee = 6.0
-				config.LA2AMix = 0.85
+				config.LA2A.Enabled = true
+				config.LA2A.Threshold = -30.0
+				config.LA2A.Ratio = 4.0
+				config.LA2A.Attack = 10
+				config.LA2A.Release = 60
+				config.LA2A.Makeup = 0
+				config.LA2A.Knee = 6.0
+				config.LA2A.Mix = 0.85
 				config.FilterOrder = []FilterID{FilterLA2ACompressor}
 				return config
 			}(),
@@ -353,8 +419,8 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "noise-remove compand disabled",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.NoiseRemoveEnabled = true
-				config.NoiseRemoveCompandEnabled = false
+				config.NoiseRemove.Enabled = true
+				config.NoiseRemove.CompandEnabled = false
 				config.FilterOrder = []FilterID{FilterNoiseRemove}
 				return config
 			}(),
@@ -364,10 +430,10 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "noise-remove compand enabled",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.NoiseRemoveEnabled = true
-				config.NoiseRemoveCompandEnabled = true
-				config.NoiseRemoveCompandThreshold = -48.0
-				config.NoiseRemoveCompandExpansion = 12.0
+				config.NoiseRemove.Enabled = true
+				config.NoiseRemove.CompandEnabled = true
+				config.NoiseRemove.CompandThreshold = -48.0
+				config.NoiseRemove.CompandExpansion = 12.0
 				config.FilterOrder = []FilterID{FilterNoiseRemove}
 				return config
 			}(),
@@ -378,8 +444,8 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "de-esser disabled",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.DeessEnabled = true
-				config.DeessIntensity = 0
+				config.Deesser.Enabled = true
+				config.Deesser.Intensity = 0
 				config.FilterOrder = []FilterID{FilterDeesser}
 				return config
 			}(),
@@ -389,10 +455,10 @@ func TestBuildFilterSpecBehaviourBaseline(t *testing.T) {
 			name: "de-esser enabled",
 			config: func() *EffectiveFilterConfig {
 				config := newTestConfig()
-				config.DeessEnabled = true
-				config.DeessIntensity = 0.6
-				config.DeessAmount = 0.4
-				config.DeessFreq = 0.7
+				config.Deesser.Enabled = true
+				config.Deesser.Intensity = 0.6
+				config.Deesser.Amount = 0.4
+				config.Deesser.Frequency = 0.7
 				config.FilterOrder = []FilterID{FilterDeesser}
 				return config
 			}(),
@@ -490,8 +556,8 @@ func TestBuildDS201HighpassFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := newTestConfig()
-			config.DS201HPEnabled = tt.enabled
-			config.DS201HPFreq = tt.freq
+			config.DS201HighPass.Enabled = tt.enabled
+			config.DS201HighPass.Frequency = tt.freq
 
 			spec := config.buildDS201HighpassFilter()
 
@@ -539,8 +605,8 @@ func TestBuildDS201GateFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := newTestConfig()
-			config.DS201GateEnabled = tt.enabled
-			config.DS201GateThreshold = tt.threshold
+			config.DS201Gate.Enabled = tt.enabled
+			config.DS201Gate.Threshold = tt.threshold
 
 			spec := config.buildDS201GateFilter()
 
@@ -557,7 +623,7 @@ func TestBuildDS201GateFilter(t *testing.T) {
 
 	t.Run("disabled returns empty", func(t *testing.T) {
 		config := newTestConfig()
-		config.DS201GateEnabled = false
+		config.DS201Gate.Enabled = false
 
 		spec := config.buildDS201GateFilter()
 		if spec != "" {
@@ -602,8 +668,8 @@ func TestBuildDS201LowPassFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := newTestConfig()
-			config.DS201LPEnabled = tt.enabled
-			config.DS201LPFreq = tt.freq
+			config.DS201LowPass.Enabled = tt.enabled
+			config.DS201LowPass.Frequency = tt.freq
 
 			spec := config.buildDS201LowPassFilter()
 
@@ -624,9 +690,9 @@ func TestBuildDS201LowPassFilter(t *testing.T) {
 func TestBuildLA2ACompressorFilter(t *testing.T) {
 	t.Run("typical podcast compression", func(t *testing.T) {
 		config := newTestConfig()
-		config.LA2AEnabled = true
-		config.LA2AThreshold = -20.0
-		config.LA2ARatio = 2.5
+		config.LA2A.Enabled = true
+		config.LA2A.Threshold = -20.0
+		config.LA2A.Ratio = 2.5
 
 		spec := config.buildLA2ACompressorFilter()
 
@@ -651,7 +717,7 @@ func TestBuildLA2ACompressorFilter(t *testing.T) {
 
 	t.Run("disabled returns empty", func(t *testing.T) {
 		config := newTestConfig()
-		config.LA2AEnabled = false
+		config.LA2A.Enabled = false
 
 		spec := config.buildLA2ACompressorFilter()
 		if spec != "" {
@@ -703,8 +769,8 @@ func TestBuildDeesserFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := newTestConfig()
-			config.DeessEnabled = tt.enabled
-			config.DeessIntensity = tt.intensity
+			config.Deesser.Enabled = tt.enabled
+			config.Deesser.Intensity = tt.intensity
 
 			spec := config.buildDeesserFilter()
 
@@ -725,7 +791,7 @@ func TestBuildDeesserFilter(t *testing.T) {
 func TestBuildNoiseRemoveFilter(t *testing.T) {
 	t.Run("disabled returns empty", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = false
+		config.NoiseRemove.Enabled = false
 
 		spec := config.buildNoiseRemoveFilter()
 		if spec != "" {
@@ -735,7 +801,7 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 
 	t.Run("enabled produces anlmdn+compand chain", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
+		config.NoiseRemove.Enabled = true
 
 		spec := config.buildNoiseRemoveFilter()
 
@@ -759,11 +825,11 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 
 	t.Run("anlmdn parameters formatted correctly", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveStrength = 0.00001
-		config.NoiseRemovePatchSec = 0.006
-		config.NoiseRemoveResearchSec = 0.0058
-		config.NoiseRemoveSmooth = 11.0
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.Strength = 0.00001
+		config.NoiseRemove.PatchSec = 0.006
+		config.NoiseRemove.ResearchSec = 0.0058
+		config.NoiseRemove.Smooth = 11.0
 
 		spec := config.buildNoiseRemoveFilter()
 
@@ -783,12 +849,12 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 
 	t.Run("compand parameters include threshold and expansion", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveCompandThreshold = -50.0
-		config.NoiseRemoveCompandExpansion = 10.0
-		config.NoiseRemoveCompandAttack = 0.005
-		config.NoiseRemoveCompandDecay = 0.100
-		config.NoiseRemoveCompandKnee = 6.0
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.CompandThreshold = -50.0
+		config.NoiseRemove.CompandExpansion = 10.0
+		config.NoiseRemove.CompandAttack = 0.005
+		config.NoiseRemove.CompandDecay = 0.100
+		config.NoiseRemove.CompandKnee = 6.0
 
 		spec := config.buildNoiseRemoveFilter()
 
@@ -816,8 +882,8 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 
 	t.Run("compand enabled produces anlmdn+compand chain", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveCompandEnabled = true
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.CompandEnabled = true
 
 		spec := config.buildNoiseRemoveFilter()
 
@@ -831,8 +897,8 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 
 	t.Run("compand disabled produces anlmdn-only spec", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveCompandEnabled = false
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.CompandEnabled = false
 
 		spec := config.buildNoiseRemoveFilter()
 
@@ -846,8 +912,8 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 
 	t.Run("anlmdn appears before compand", func(t *testing.T) {
 		config := newTestConfig()
-		config.NoiseRemoveEnabled = true
-		config.NoiseRemoveCompandEnabled = true
+		config.NoiseRemove.Enabled = true
+		config.NoiseRemove.CompandEnabled = true
 
 		spec := config.buildNoiseRemoveFilter()
 
@@ -862,9 +928,9 @@ func TestBuildNoiseRemoveFilter(t *testing.T) {
 		expansions := []float64{6.0, 15.0, 40.0}
 		for _, exp := range expansions {
 			config := newTestConfig()
-			config.NoiseRemoveEnabled = true
-			config.NoiseRemoveCompandThreshold = -55.0
-			config.NoiseRemoveCompandExpansion = exp
+			config.NoiseRemove.Enabled = true
+			config.NoiseRemove.CompandThreshold = -55.0
+			config.NoiseRemove.CompandExpansion = exp
 
 			spec := config.buildNoiseRemoveFilter()
 
@@ -892,11 +958,11 @@ func TestBuildAdeclickFilter(t *testing.T) {
 
 	t.Run("custom parameters", func(t *testing.T) {
 		config := newTestConfig()
-		config.AdeclickEnabled = true
-		config.AdeclickThreshold = 2.0
-		config.AdeclickWindow = 100.0
-		config.AdeclickOverlap = 50.0
-		config.AdeclickMethod = "s"
+		config.Adeclick.Enabled = true
+		config.Adeclick.Threshold = 2.0
+		config.Adeclick.Window = 100.0
+		config.Adeclick.Overlap = 50.0
+		config.Adeclick.Method = "s"
 
 		spec := config.buildAdeclickFilter()
 
@@ -916,11 +982,11 @@ func TestBuildAdeclickFilter(t *testing.T) {
 
 	t.Run("empty method omits m segment", func(t *testing.T) {
 		config := newTestConfig()
-		config.AdeclickEnabled = true
-		config.AdeclickThreshold = 2.0
-		config.AdeclickWindow = 55.0
-		config.AdeclickOverlap = 50.0
-		config.AdeclickMethod = ""
+		config.Adeclick.Enabled = true
+		config.Adeclick.Threshold = 2.0
+		config.Adeclick.Window = 55.0
+		config.Adeclick.Overlap = 50.0
+		config.Adeclick.Method = ""
 
 		spec := config.buildAdeclickFilter()
 
@@ -935,7 +1001,7 @@ func TestBuildAdeclickFilter(t *testing.T) {
 
 	t.Run("disabled returns empty", func(t *testing.T) {
 		config := newTestConfig()
-		config.AdeclickEnabled = false
+		config.Adeclick.Enabled = false
 
 		spec := config.buildAdeclickFilter()
 		if spec != "" {
@@ -947,11 +1013,11 @@ func TestBuildAdeclickFilter(t *testing.T) {
 func TestFilterOrderRespected(t *testing.T) {
 	config := newTestConfig()
 	// Enable filters that appear at start and end
-	config.DS201HPEnabled = true
-	config.DS201GateEnabled = true
-	config.DeessEnabled = true
-	config.DeessIntensity = 0.5
-	config.ResampleEnabled = true // Required for aformat output filter
+	config.DS201HighPass.Enabled = true
+	config.DS201Gate.Enabled = true
+	config.Deesser.Enabled = true
+	config.Deesser.Intensity = 0.5
+	config.Resample.Enabled = true // Required for aformat output filter
 	config.FilterOrder = Pass2FilterOrder
 
 	spec := config.BuildFilterSpec()
@@ -977,6 +1043,8 @@ func TestFilterOrderRespected(t *testing.T) {
 func TestDeriveAdaptiveFilterResultDeepCopiesFilterOrder(t *testing.T) {
 	base := DefaultFilterConfig()
 	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
+	base.Analysis.SilenceScanDuration = 2 * time.Second
+	base.Resample.SampleRate = 48000
 
 	adaptive := deriveAdaptiveFilterResult(base)
 	if adaptive == nil {
@@ -990,35 +1058,73 @@ func TestDeriveAdaptiveFilterResultDeepCopiesFilterOrder(t *testing.T) {
 	if base.FilterOrder[0] == FilterDownmix {
 		t.Fatal("adaptive FilterOrder mutation changed base FilterOrder")
 	}
+	if adaptive.Analysis.SilenceScanDuration != base.Analysis.SilenceScanDuration {
+		t.Errorf("Analysis.SilenceScanDuration = %s, want %s",
+			adaptive.Analysis.SilenceScanDuration, base.Analysis.SilenceScanDuration)
+	}
+	if adaptive.Resample.SampleRate != base.Resample.SampleRate {
+		t.Errorf("Resample.SampleRate = %d, want %d",
+			adaptive.Resample.SampleRate, base.Resample.SampleRate)
+	}
+	adaptive.Resample.SampleRate = 32000
+	if base.Resample.SampleRate == 32000 {
+		t.Fatal("adaptive typed Resample mutation changed base Resample")
+	}
+}
+
+func TestCloneFilterDefaultsCopiesTypedFamilies(t *testing.T) {
+	base := DefaultFilterConfig()
+	base.Analysis.SilenceScanDuration = 3 * time.Second
+	base.NoiseRemove.CompandEnabled = false
+	base.FilterOrder = []FilterID{FilterAnalysis, FilterDeesser}
+
+	clone := cloneFilterDefaults(&base.filterConfigDefaults)
+	if clone.Analysis.SilenceScanDuration != base.Analysis.SilenceScanDuration {
+		t.Errorf("Analysis.SilenceScanDuration = %s, want %s",
+			clone.Analysis.SilenceScanDuration, base.Analysis.SilenceScanDuration)
+	}
+	if clone.NoiseRemove.CompandEnabled != base.NoiseRemove.CompandEnabled {
+		t.Errorf("NoiseRemove.CompandEnabled = %v, want %v",
+			clone.NoiseRemove.CompandEnabled, base.NoiseRemove.CompandEnabled)
+	}
+	if !reflect.DeepEqual(clone.FilterOrder, base.FilterOrder) {
+		t.Errorf("FilterOrder = %v, want %v", clone.FilterOrder, base.FilterOrder)
+	}
+
+	clone.FilterOrder[0] = FilterDownmix
+	if base.FilterOrder[0] == FilterDownmix {
+		t.Fatal("clone FilterOrder mutation changed base FilterOrder")
+	}
 }
 
 func TestAssembleEffectiveFilterConfig(t *testing.T) {
 	base := DefaultFilterConfig()
 	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
-	base.TargetI = -18.0
-	base.SilenceScanDuration = 2 * time.Second
+	base.Loudnorm.TargetI = -18.0
+	base.Analysis.SilenceScanDuration = 2 * time.Second
 
 	adaptive := deriveAdaptiveFilterResult(base)
-	adaptive.DS201HPFreq = 65.0
-	adaptive.NoiseRemoveCompandEnabled = false
+	adaptive.DS201HighPass.Frequency = 65.0
+	adaptive.NoiseRemove.CompandEnabled = false
 	adaptive.FilterOrder = []FilterID{FilterDownmix}
 
 	effective := assembleEffectiveFilterConfig(base, adaptive)
 	if effective == nil {
 		t.Fatal("assembleEffectiveFilterConfig returned nil")
 	}
-	if effective.DS201HPFreq != adaptive.DS201HPFreq {
-		t.Errorf("DS201HPFreq = %.1f, want adaptive %.1f", effective.DS201HPFreq, adaptive.DS201HPFreq)
+	if effective.DS201HighPass.Frequency != adaptive.DS201HighPass.Frequency {
+		t.Errorf("DS201HighPass.Frequency = %.1f, want adaptive %.1f",
+			effective.DS201HighPass.Frequency, adaptive.DS201HighPass.Frequency)
 	}
-	if effective.NoiseRemoveCompandEnabled {
-		t.Error("NoiseRemoveCompandEnabled = true, want adaptive false")
+	if effective.NoiseRemove.CompandEnabled {
+		t.Error("NoiseRemove.CompandEnabled = true, want adaptive false")
 	}
-	if effective.TargetI != base.TargetI {
-		t.Errorf("TargetI = %.1f, want base %.1f", effective.TargetI, base.TargetI)
+	if effective.Loudnorm.TargetI != base.Loudnorm.TargetI {
+		t.Errorf("Loudnorm.TargetI = %.1f, want base %.1f", effective.Loudnorm.TargetI, base.Loudnorm.TargetI)
 	}
-	if effective.SilenceScanDuration != base.SilenceScanDuration {
-		t.Errorf("SilenceScanDuration = %s, want base %s",
-			effective.SilenceScanDuration, base.SilenceScanDuration)
+	if effective.Analysis.SilenceScanDuration != base.Analysis.SilenceScanDuration {
+		t.Errorf("Analysis.SilenceScanDuration = %s, want base %s",
+			effective.Analysis.SilenceScanDuration, base.Analysis.SilenceScanDuration)
 	}
 	if !reflect.DeepEqual(effective.FilterOrder, base.FilterOrder) {
 		t.Errorf("FilterOrder = %v, want base order %v", effective.FilterOrder, base.FilterOrder)
@@ -1038,9 +1144,9 @@ func TestAssembleEffectiveFilterConfig(t *testing.T) {
 func TestDeriveEffectiveFilterConfig(t *testing.T) {
 	base := DefaultFilterConfig()
 	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
-	base.TargetI = -18.0
-	base.SilenceScanDuration = 2 * time.Second
-	base.NoiseRemoveCompandThreshold = -48.0
+	base.Loudnorm.TargetI = -18.0
+	base.Analysis.SilenceScanDuration = 2 * time.Second
+	base.NoiseRemove.CompandThreshold = -48.0
 
 	derived := deriveEffectiveFilterConfig(base)
 	if derived == nil {
@@ -1055,21 +1161,22 @@ func TestDeriveEffectiveFilterConfig(t *testing.T) {
 		t.Error("derived FilterOrder mutation changed base FilterOrder")
 	}
 
-	if derived.TargetI != base.TargetI {
-		t.Errorf("TargetI = %.1f, want %.1f", derived.TargetI, base.TargetI)
+	if derived.Loudnorm.TargetI != base.Loudnorm.TargetI {
+		t.Errorf("Loudnorm.TargetI = %.1f, want %.1f", derived.Loudnorm.TargetI, base.Loudnorm.TargetI)
 	}
-	if derived.SilenceScanDuration != base.SilenceScanDuration {
-		t.Errorf("SilenceScanDuration = %s, want %s", derived.SilenceScanDuration, base.SilenceScanDuration)
+	if derived.Analysis.SilenceScanDuration != base.Analysis.SilenceScanDuration {
+		t.Errorf("Analysis.SilenceScanDuration = %s, want %s",
+			derived.Analysis.SilenceScanDuration, base.Analysis.SilenceScanDuration)
 	}
-	if derived.NoiseRemoveCompandThreshold != base.NoiseRemoveCompandThreshold {
-		t.Errorf("NoiseRemoveCompandThreshold = %.1f, want %.1f",
-			derived.NoiseRemoveCompandThreshold, base.NoiseRemoveCompandThreshold)
+	if derived.NoiseRemove.CompandThreshold != base.NoiseRemove.CompandThreshold {
+		t.Errorf("NoiseRemove.CompandThreshold = %.1f, want %.1f",
+			derived.NoiseRemove.CompandThreshold, base.NoiseRemove.CompandThreshold)
 	}
 
 	if !reflect.DeepEqual(base.FilterOrder, []FilterID{FilterDeesser, FilterAnalysis}) ||
-		base.TargetI != -18.0 ||
-		base.SilenceScanDuration != 2*time.Second ||
-		base.NoiseRemoveCompandThreshold != -48.0 {
+		base.Loudnorm.TargetI != -18.0 ||
+		base.Analysis.SilenceScanDuration != 2*time.Second ||
+		base.NoiseRemove.CompandThreshold != -48.0 {
 		t.Error("deriveEffectiveFilterConfig mutated caller-owned defaults")
 	}
 }
@@ -1077,21 +1184,100 @@ func TestDeriveEffectiveFilterConfig(t *testing.T) {
 func assertNoStaleEffectiveConfigFields(t *testing.T) {
 	t.Helper()
 
-	configType := reflect.TypeFor[EffectiveFilterConfig]()
-	for _, field := range []string{
+	for _, typ := range []reflect.Type{
+		reflect.TypeFor[filterConfigDefaults](),
+		reflect.TypeFor[EffectiveFilterConfig](),
+	} {
+		assertNoStaleConfigFields(t, typ)
+	}
+}
+
+func assertNoStaleConfigFields(t *testing.T, configType reflect.Type) {
+	t.Helper()
+
+	for _, field := range staleFlatConfigFieldNames() {
+		if _, ok := configType.FieldByName(field); ok {
+			t.Errorf("%s contains stale field %s", configType.Name(), field)
+		}
+	}
+}
+
+func staleFlatConfigFieldNames() []string {
+	return []string{
 		"Pass",
 		"Measurements",
 		"OutputAnalysisEnabled",
+		"DownmixEnabled",
+		"AnalysisEnabled",
+		"SilenceScanDuration",
+		"ResampleEnabled",
+		"ResampleSampleRate",
+		"ResampleFormat",
+		"ResampleFrameSize",
+		"DS201HPEnabled",
+		"DS201HPFreq",
+		"DS201HPPoles",
+		"DS201HPWidth",
+		"DS201HPMix",
+		"DS201HPTransform",
+		"DS201LPEnabled",
+		"DS201LPFreq",
+		"DS201LPPoles",
+		"DS201LPWidth",
+		"DS201LPMix",
+		"DS201LPTransform",
+		"NoiseRemoveEnabled",
+		"NoiseRemoveCompandEnabled",
+		"NoiseRemoveStrength",
+		"NoiseRemovePatchSec",
+		"NoiseRemoveResearchSec",
+		"NoiseRemoveSmooth",
+		"NoiseRemoveCompandThreshold",
+		"NoiseRemoveCompandExpansion",
+		"NoiseRemoveCompandAttack",
+		"NoiseRemoveCompandDecay",
+		"NoiseRemoveCompandKnee",
+		"DS201GateEnabled",
+		"DS201GateThreshold",
+		"DS201GateRatio",
+		"DS201GateAttack",
+		"DS201GateRelease",
+		"DS201GateRange",
+		"DS201GateKnee",
+		"DS201GateMakeup",
+		"DS201GateDetection",
+		"LA2AEnabled",
+		"LA2AThreshold",
+		"LA2ARatio",
+		"LA2AAttack",
+		"LA2ARelease",
+		"LA2AMakeup",
+		"LA2AKnee",
+		"LA2AMix",
+		"DeessEnabled",
+		"DeessIntensity",
+		"DeessAmount",
+		"DeessFreq",
+		"AdeclickEnabled",
+		"AdeclickThreshold",
+		"AdeclickWindow",
+		"AdeclickOverlap",
+		"AdeclickMethod",
+		"TargetI",
+		"TargetTP",
+		"TargetLRA",
+		"LoudnormEnabled",
+		"LoudnormTargetI",
+		"LoudnormTargetTP",
+		"LoudnormTargetLRA",
+		"LoudnormDualMono",
+		"LoudnormLinear",
 		"DS201LPReason",
 		"DS201GateClampReason",
 		"LA2AHighCrestActive",
 		"LA2AHighCrestDeficit",
 		"LA2AHighCrestSeverity",
 		"LA2AHighCrestProjectedTP",
-	} {
-		if _, ok := configType.FieldByName(field); ok {
-			t.Errorf("EffectiveFilterConfig contains stale field %s", field)
-		}
 	}
 }
 
@@ -1140,12 +1326,58 @@ func TestDbToLinearFormula(t *testing.T) {
 	}
 }
 
+func TestDecibelLinearAmplitudeWrappers(t *testing.T) {
+	t.Run("dB to linear delegates to DbToLinear", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			db   float64
+		}{
+			{"LA-2A threshold", -20.0},
+			{"LA-2A makeup", 3.0},
+			{"DS201 gate threshold", -40.0},
+			{"DS201 gate range", -27.0},
+			{"limiter ceiling", -12.4},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.name, func(t *testing.T) {
+				got := Decibels(tt.db).LinearAmplitude().Float64()
+				want := DbToLinear(tt.db)
+				if math.Abs(got-want) > 0.0000001 {
+					t.Errorf("Decibels(%.1f).LinearAmplitude() = %.10f, want %.10f", tt.db, got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("linear to dB delegates to LinearToDb", func(t *testing.T) {
+		testCases := []struct {
+			name   string
+			linear float64
+		}{
+			{"DS201 diagnostics threshold", 0.01},
+			{"DS201 diagnostics range", 0.044668},
+			{"silent floor", 0.0},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.name, func(t *testing.T) {
+				got := LinearAmplitude(tt.linear).Decibels().Float64()
+				want := LinearToDb(tt.linear)
+				if math.Abs(got-want) > 0.0000001 {
+					t.Errorf("LinearAmplitude(%.6f).Decibels() = %.10f, want %.10f", tt.linear, got, want)
+				}
+			})
+		}
+	})
+}
+
 // Tests for infrastructure filters (Downmix, Analysis, Resample)
 
 func TestBuildDownmixFilter(t *testing.T) {
 	t.Run("enabled returns aformat mono", func(t *testing.T) {
 		config := newTestConfig()
-		config.DownmixEnabled = true
+		config.Downmix.Enabled = true
 
 		result := config.buildDownmixFilter()
 
@@ -1156,7 +1388,7 @@ func TestBuildDownmixFilter(t *testing.T) {
 
 	t.Run("disabled returns empty string", func(t *testing.T) {
 		config := newTestConfig()
-		config.DownmixEnabled = false
+		config.Downmix.Enabled = false
 
 		result := config.buildDownmixFilter()
 
@@ -1169,8 +1401,8 @@ func TestBuildDownmixFilter(t *testing.T) {
 func TestBuildAnalysisFilter(t *testing.T) {
 	t.Run("enabled returns astats+aspectralstats+ebur128 chain", func(t *testing.T) {
 		config := newTestConfig()
-		config.AnalysisEnabled = true
-		config.TargetI = -16.0
+		config.Analysis.Enabled = true
+		config.Loudnorm.TargetI = -16.0
 
 		result := config.buildAnalysisFilter()
 
@@ -1195,21 +1427,21 @@ func TestBuildAnalysisFilter(t *testing.T) {
 		}
 	})
 
-	t.Run("uses configured TargetI", func(t *testing.T) {
+	t.Run("uses configured Loudnorm.TargetI", func(t *testing.T) {
 		config := newTestConfig()
-		config.AnalysisEnabled = true
-		config.TargetI = -14.0
+		config.Analysis.Enabled = true
+		config.Loudnorm.TargetI = -14.0
 
 		result := config.buildAnalysisFilter()
 
 		if !strings.Contains(result, "target=-14") {
-			t.Errorf("buildAnalysisFilter() should use TargetI=-14, got %q", result)
+			t.Errorf("buildAnalysisFilter() should use Loudnorm.TargetI=-14, got %q", result)
 		}
 	})
 
 	t.Run("disabled returns empty string", func(t *testing.T) {
 		config := newTestConfig()
-		config.AnalysisEnabled = false
+		config.Analysis.Enabled = false
 
 		result := config.buildAnalysisFilter()
 
@@ -1222,10 +1454,10 @@ func TestBuildAnalysisFilter(t *testing.T) {
 func TestBuildResampleFilter(t *testing.T) {
 	t.Run("enabled returns aformat+asetnsamples with default params", func(t *testing.T) {
 		config := newTestConfig()
-		config.ResampleEnabled = true
-		config.ResampleSampleRate = 44100
-		config.ResampleFormat = "s16"
-		config.ResampleFrameSize = 4096
+		config.Resample.Enabled = true
+		config.Resample.SampleRate = 44100
+		config.Resample.Format = "s16"
+		config.Resample.FrameSize = 4096
 
 		result := config.buildResampleFilter()
 
@@ -1237,10 +1469,10 @@ func TestBuildResampleFilter(t *testing.T) {
 
 	t.Run("uses configured parameters", func(t *testing.T) {
 		config := newTestConfig()
-		config.ResampleEnabled = true
-		config.ResampleSampleRate = 48000
-		config.ResampleFormat = "s32"
-		config.ResampleFrameSize = 2048
+		config.Resample.Enabled = true
+		config.Resample.SampleRate = 48000
+		config.Resample.Format = "s32"
+		config.Resample.FrameSize = 2048
 
 		result := config.buildResampleFilter()
 
@@ -1252,7 +1484,7 @@ func TestBuildResampleFilter(t *testing.T) {
 
 	t.Run("disabled returns empty string", func(t *testing.T) {
 		config := newTestConfig()
-		config.ResampleEnabled = false
+		config.Resample.Enabled = false
 
 		result := config.buildResampleFilter()
 
@@ -1264,10 +1496,10 @@ func TestBuildResampleFilter(t *testing.T) {
 
 func TestBuildRequiredOutputFormatFilter(t *testing.T) {
 	config := newTestConfig()
-	config.ResampleEnabled = false
-	config.ResampleSampleRate = 48000
-	config.ResampleFormat = "s32"
-	config.ResampleFrameSize = 2048
+	config.Resample.Enabled = false
+	config.Resample.SampleRate = 48000
+	config.Resample.Format = "s32"
+	config.Resample.FrameSize = 2048
 
 	result := config.buildRequiredOutputFormatFilter()
 

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -224,12 +224,13 @@ func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filter
 	// Build measurement filter: loudnorm (without linear=true) + null sink
 	// loudnorm in single-pass mode outputs its measurements to JSON when freed
 	// We use print_format=json to get input_i, input_tp, input_lra, input_thresh, target_offset
+	loudnorm := config.Loudnorm
 	filterSpec := fmt.Sprintf(
 		"loudnorm=I=%.1f:TP=%.1f:LRA=%.1f:dual_mono=%s:print_format=json",
-		config.LoudnormTargetI,
-		config.LoudnormTargetTP,
-		config.LoudnormTargetLRA,
-		boolToString(config.LoudnormDualMono),
+		loudnorm.TargetI,
+		loudnorm.TargetTP,
+		loudnorm.TargetLRA,
+		boolToString(loudnorm.DualMono),
 	)
 
 	if filterPrefix != "" {
@@ -404,7 +405,7 @@ func buildPreLimiterPrefix(preGainDB, ceiling float64, needsLimiting bool) strin
 		parts = append(parts, fmt.Sprintf("volume=%.1fdB", preGainDB))
 	}
 
-	limiterCeilingLinear := math.Pow(10, ceiling/20.0)
+	limiterCeilingLinear := Decibels(ceiling).LinearAmplitude().Float64()
 	limiterFilter := fmt.Sprintf(
 		"alimiter=limit=%.6f:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
 		limiterCeilingLinear,
@@ -520,7 +521,8 @@ func ApplyNormalisation(
 	inputMeasurements *AudioMeasurements,
 	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
 ) (*NormalisationResult, error) {
-	if !config.LoudnormEnabled {
+	loudnorm := config.Loudnorm
+	if !loudnorm.Enabled {
 		return &NormalisationResult{Skipped: true}, nil
 	}
 
@@ -534,15 +536,15 @@ func ApplyNormalisation(
 	// that Pass 4 will apply, closing the measurement mismatch.
 	limiterCeiling, limiterNeeded, limiterClamped := calculateLimiterCeiling(
 		outputMeasurements.OutputI, outputMeasurements.OutputTP,
-		config.LoudnormTargetI, config.LoudnormTargetTP,
+		loudnorm.TargetI, loudnorm.TargetTP,
 	)
 	preGainDB, reDerivedCeiling := calculatePreGain(
-		outputMeasurements.OutputI, config.LoudnormTargetI, config.LoudnormTargetTP,
+		outputMeasurements.OutputI, loudnorm.TargetI, loudnorm.TargetTP,
 	)
 	if limiterClamped {
 		limiterCeiling = reDerivedCeiling
 	}
-	limiterGain := config.LoudnormTargetI - outputMeasurements.OutputI
+	limiterGain := loudnorm.TargetI - outputMeasurements.OutputI
 
 	// Build filter prefix for Pass 3 measurement
 	filterPrefix := buildPreLimiterPrefix(preGainDB, limiterCeiling, limiterNeeded)
@@ -573,8 +575,8 @@ func ApplyNormalisation(
 	effectiveTargetI, _, linearPossible := calculateLinearModeTarget(
 		measurement.InputI,
 		measurement.InputTP,
-		config.LoudnormTargetI,
-		config.LoudnormTargetTP,
+		loudnorm.TargetI,
+		loudnorm.TargetTP,
 	)
 
 	// Use loudnorm's own target_offset from the measurement pass
@@ -582,7 +584,7 @@ func ApplyNormalisation(
 
 	// Store the effective target in config for loudnorm filter construction
 	effectiveConfig := *config
-	effectiveConfig.LoudnormTargetI = effectiveTargetI
+	effectiveConfig.Loudnorm.TargetI = effectiveTargetI
 
 	// Pass 4: Apply loudnorm with linear=true and the measurements
 	finalLUFS, finalTP, finalMeasurements, loudnormStats, regionMeasurementTime, err := applyLoudnormAndMeasure(inputPath, &effectiveConfig, measurement, inputMeasurements, preGainDB, limiterCeiling, limiterNeeded, progressCallback)
@@ -608,7 +610,7 @@ func ApplyNormalisation(
 		WithinTarget:          withinTarget,
 		Skipped:               false,
 		LoudnormStats:         loudnormStats,
-		RequestedTargetI:      config.LoudnormTargetI,
+		RequestedTargetI:      loudnorm.TargetI,
 		EffectiveTargetI:      effectiveTargetI,
 		LinearModeForced:      !linearPossible,
 		LimiterEnabled:        limiterNeeded,
@@ -810,6 +812,7 @@ func applyLoudnormAndMeasure(
 // first pass measurement, not from external calculations.
 func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, preGainDB float64, ceiling float64, needsLimiting bool) string {
 	var filters []string
+	loudnorm := config.Loudnorm
 
 	// 1. Build pre-limiter prefix (volume + alimiter) from pre-computed values
 	prefix := buildPreLimiterPrefix(preGainDB, ceiling, needsLimiting)
@@ -829,16 +832,16 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 	// effectiveMeasuredI/effectiveMeasuredTP adjustment needed.
 	loudnormFilter := fmt.Sprintf(
 		"loudnorm=I=%.2f:TP=%.2f:LRA=%.1f:measured_I=%.2f:measured_TP=%.2f:measured_LRA=%.2f:measured_thresh=%.2f:offset=%.2f:dual_mono=%s:linear=%s:print_format=json",
-		config.LoudnormTargetI,  // Using %.2f for precision on adjusted targets
-		config.LoudnormTargetTP, // Also %.2f for consistency
-		config.LoudnormTargetLRA,
+		loudnorm.TargetI,  // Using %.2f for precision on adjusted targets
+		loudnorm.TargetTP, // Also %.2f for consistency
+		loudnorm.TargetLRA,
 		measurement.InputI,
 		measurement.InputTP,
 		measurement.InputLRA,
 		measurement.InputThresh,
 		measurement.TargetOffset, // From first pass - critical for linear mode
-		boolToString(config.LoudnormDualMono),
-		boolToString(config.LoudnormLinear),
+		boolToString(loudnorm.DualMono),
+		boolToString(loudnorm.Linear),
 	)
 	filters = append(filters, loudnormFilter)
 

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -933,7 +933,7 @@ func defaultNormalisationTestConfig() *EffectiveFilterConfig {
 
 func loudnormApplicationTestConfig() *EffectiveFilterConfig {
 	config := defaultNormalisationTestConfig()
-	config.AdeclickEnabled = false
+	config.Adeclick.Enabled = false
 	return config
 }
 
@@ -1981,10 +1981,10 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 
 			// Pre-compute values (caller's responsibility after Task 2.2)
 			ceiling, needsLimiting, clamped := calculateLimiterCeiling(
-				tt.inputI, tt.inputTP, config.LoudnormTargetI, config.LoudnormTargetTP,
+				tt.inputI, tt.inputTP, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)
 			preGainDB, reDerivedCeiling := calculatePreGain(
-				tt.inputI, config.LoudnormTargetI, config.LoudnormTargetTP,
+				tt.inputI, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)
 			if clamped {
 				ceiling = reDerivedCeiling
@@ -2053,10 +2053,10 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 
 func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 	config := defaultNormalisationTestConfig()
-	config.ResampleEnabled = false
-	config.ResampleSampleRate = 48000
-	config.ResampleFormat = "s32"
-	config.ResampleFrameSize = 2048
+	config.Resample.Enabled = false
+	config.Resample.SampleRate = 48000
+	config.Resample.Format = "s32"
+	config.Resample.FrameSize = 2048
 
 	measurement := &LoudnormMeasurement{
 		InputI:       -24.0,
@@ -2068,8 +2068,8 @@ func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 
 	filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
 
-	if config.ResampleEnabled {
-		t.Error("buildLoudnormFilterSpec mutated config.ResampleEnabled")
+	if config.Resample.Enabled {
+		t.Error("buildLoudnormFilterSpec mutated config.Resample.Enabled")
 	}
 
 	want := "aformat=sample_rates=48000:channel_layouts=mono:sample_fmts=s32,asetnsamples=n=2048"
@@ -2100,7 +2100,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 
 	t.Run("omits disabled adeclick", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
-		config.AdeclickEnabled = false
+		config.Adeclick.Enabled = false
 
 		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
 
@@ -2125,9 +2125,9 @@ func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 
 	withUnrelatedFilterFields := *base
 	withUnrelatedFilterFields.FilterOrder = []FilterID{FilterAnalysis}
-	withUnrelatedFilterFields.DS201LPFreq = 12000
-	withUnrelatedFilterFields.DS201GateRatio = 4.0
-	withUnrelatedFilterFields.LA2AThreshold = -30.0
+	withUnrelatedFilterFields.DS201LowPass.Frequency = 12000
+	withUnrelatedFilterFields.DS201Gate.Ratio = 4.0
+	withUnrelatedFilterFields.LA2A.Threshold = -30.0
 
 	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, 0, -1.0, false)
 	if gotSpec != controlSpec {
@@ -2314,7 +2314,7 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 
 			// Step 4: verify buildLoudnormFilterSpec receives the full target
 			config := defaultNormalisationTestConfig()
-			config.LoudnormTargetI = effectiveTargetI
+			config.Loudnorm.TargetI = effectiveTargetI
 			measurement := &LoudnormMeasurement{
 				InputI:       tt.measuredI,
 				InputTP:      tt.measuredTP,
@@ -2325,10 +2325,10 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 
 			// Pre-compute values (caller's responsibility after Task 2.2)
 			bCeiling, bNeeded, bClamped := calculateLimiterCeiling(
-				tt.measuredI, tt.measuredTP, config.LoudnormTargetI, config.LoudnormTargetTP,
+				tt.measuredI, tt.measuredTP, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)
 			preGainDB, bReDerived := calculatePreGain(
-				tt.measuredI, config.LoudnormTargetI, config.LoudnormTargetTP,
+				tt.measuredI, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)
 			if bClamped {
 				bCeiling = bReDerived

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
@@ -394,6 +395,7 @@ func TestRenameNoClobberReportsSourceCleanupFailureAfterPublish(t *testing.T) {
 func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
 	base := newTestBaseConfig()
 	base.FilterOrder = []FilterID{FilterAnalysis, FilterDeesser}
+	base.Analysis.SilenceScanDuration = 1500 * time.Millisecond
 
 	first, firstDiagnostics := AdaptConfig(base, &AudioMeasurements{
 		BaseMeasurements: BaseMeasurements{Spectral: SpectralMetrics{Centroid: 5000}},
@@ -409,6 +411,7 @@ func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
 	}
 
 	first.FilterOrder[0] = FilterDownmix
+	first.Analysis.SilenceScanDuration = 250 * time.Millisecond
 
 	if reflect.DeepEqual(first.FilterOrder, base.FilterOrder) {
 		t.Fatal("test setup failed: first effective FilterOrder did not change")
@@ -418,6 +421,14 @@ func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
 	}
 	if !reflect.DeepEqual(second.FilterOrder, []FilterID{FilterAnalysis, FilterDeesser}) {
 		t.Errorf("second effective FilterOrder = %v, want independent copy", second.FilterOrder)
+	}
+	if base.Analysis.SilenceScanDuration != 1500*time.Millisecond {
+		t.Errorf("base Analysis.SilenceScanDuration = %v, want unchanged 1.5s",
+			base.Analysis.SilenceScanDuration)
+	}
+	if second.Analysis.SilenceScanDuration != 1500*time.Millisecond {
+		t.Errorf("second effective Analysis.SilenceScanDuration = %v, want independent copy",
+			second.Analysis.SilenceScanDuration)
 	}
 }
 
@@ -517,11 +528,11 @@ func TestProcessAudio(t *testing.T) {
 	// Create isolated test config with minimal filters for integration test
 	// This ensures the test doesn't break when application defaults change
 	config := newTestBaseConfig()
-	config.DownmixEnabled = true
-	config.AnalysisEnabled = true
-	config.ResampleEnabled = true
-	config.DS201HPEnabled = true // Basic processing
-	config.DS201HPFreq = 95.0
+	config.Downmix.Enabled = true
+	config.Analysis.Enabled = true
+	config.Resample.Enabled = true
+	config.DS201HighPass.Enabled = true // Basic processing
+	config.DS201HighPass.Frequency = 95.0
 	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
 
 	// Process the audio with a no-op progress callback
@@ -555,8 +566,8 @@ func TestProcessAudio(t *testing.T) {
 		t.Fatalf("Failed to reopen output file: %v", err)
 	}
 	defer reader.Close()
-	if outputMetadata.SampleRate != config.ResampleSampleRate {
-		t.Errorf("Output sample rate = %d, want %d", outputMetadata.SampleRate, config.ResampleSampleRate)
+	if outputMetadata.SampleRate != config.Resample.SampleRate {
+		t.Errorf("Output sample rate = %d, want %d", outputMetadata.SampleRate, config.Resample.SampleRate)
 	}
 	if outputMetadata.Channels != 1 {
 		t.Errorf("Output channels = %d, want 1", outputMetadata.Channels)
@@ -578,8 +589,8 @@ func TestProcessAudio(t *testing.T) {
 	if !reflect.DeepEqual(config.FilterOrder, baseFilterOrder) {
 		t.Errorf("base FilterOrder = %v, want %v", config.FilterOrder, baseFilterOrder)
 	}
-	if config.DS201HPFreq != 95.0 {
-		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", config.DS201HPFreq)
+	if config.DS201HighPass.Frequency != 95.0 {
+		t.Errorf("base DS201HighPass.Frequency = %.1f, want unchanged 95.0", config.DS201HighPass.Frequency)
 	}
 	if result.Config == nil {
 		t.Fatal("ProcessAudio returned nil config")
@@ -591,8 +602,8 @@ func TestProcessAudio(t *testing.T) {
 	if !reflect.DeepEqual(result.Config.FilterOrder, Pass2FilterOrder) {
 		t.Errorf("result config FilterOrder = %v, want %v", result.Config.FilterOrder, Pass2FilterOrder)
 	}
-	if result.Config.DS201HPFreq == 95.0 {
-		t.Fatal("result config DS201HPFreq did not adapt from base seed value")
+	if result.Config.DS201HighPass.Frequency == 95.0 {
+		t.Fatal("result config DS201HighPass.Frequency did not adapt from base seed value")
 	}
 	result.Config.FilterOrder[0] = FilterDeesser
 	if config.FilterOrder[0] == FilterDeesser {
@@ -697,11 +708,11 @@ func TestProcessAudioFinalCollisionPreservesOutputAndCleansTemp(t *testing.T) {
 	defer cleanupTestAudio(t, testFile)
 
 	config := newTestBaseConfig()
-	config.DownmixEnabled = true
-	config.AnalysisEnabled = true
-	config.ResampleEnabled = true
-	config.LoudnormEnabled = false
-	config.AdeclickEnabled = false
+	config.Downmix.Enabled = true
+	config.Analysis.Enabled = true
+	config.Resample.Enabled = true
+	config.Loudnorm.Enabled = false
+	config.Adeclick.Enabled = false
 
 	var tempPaths []string
 	oldCreateSiblingTempPath := processorCreateSiblingTempPath
@@ -793,10 +804,10 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	defer cleanupTestAudio(t, testFile)
 
 	config := newTestBaseConfig()
-	config.DownmixEnabled = true
-	config.AnalysisEnabled = true
-	config.DS201HPEnabled = true
-	config.DS201HPFreq = 95.0
+	config.Downmix.Enabled = true
+	config.Analysis.Enabled = true
+	config.DS201HighPass.Enabled = true
+	config.DS201HighPass.Frequency = 95.0
 	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
 
 	result, err := AnalyzeOnlyDetailed(testFile, config, nil)
@@ -817,8 +828,8 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	if !reflect.DeepEqual(config.FilterOrder, baseFilterOrder) {
 		t.Errorf("base FilterOrder = %v, want %v", config.FilterOrder, baseFilterOrder)
 	}
-	if config.DS201HPFreq != 95.0 {
-		t.Errorf("base DS201HPFreq = %.1f, want unchanged 95.0", config.DS201HPFreq)
+	if config.DS201HighPass.Frequency != 95.0 {
+		t.Errorf("base DS201HighPass.Frequency = %.1f, want unchanged 95.0", config.DS201HighPass.Frequency)
 	}
 	if result.AnalysisDuration <= 0 {
 		t.Errorf("AnalysisDuration = %s, want > 0", result.AnalysisDuration)
@@ -832,9 +843,9 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 func TestFilterChainBuilder(t *testing.T) {
 	// Use isolated test config to avoid coupling to application defaults
 	config := newTestConfig()
-	config.DownmixEnabled = true
-	config.AnalysisEnabled = true
-	config.ResampleEnabled = true
+	config.Downmix.Enabled = true
+	config.Analysis.Enabled = true
+	config.Resample.Enabled = true
 
 	// Test Pass 1 (analysis) filter spec
 	filterSpec := config.BuildFilterSpec()
@@ -846,7 +857,7 @@ func TestFilterChainBuilder(t *testing.T) {
 	}
 
 	// Enable additional filters for Pass 2 test
-	config.DS201HPEnabled = true
+	config.DS201HighPass.Enabled = true
 
 	filterSpec = config.BuildFilterSpec()
 	t.Logf("Pass 2 filter spec: %s", filterSpec)


### PR DESCRIPTION
- Replace flat filter config fields with typed nested structs.
- Update builders, adaptive tuning, reporting, and tests to use nested fields.
- Keep defaults and reflection guards aligned with the new layout.
- Add narrow `Decibels` and `LinearAmplitude` wrappers where needed.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
