### PR TITLE
refactor(processor): centralise loudnorm limiter planning

### DIFF
--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -966,23 +966,8 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 	}
 
 	config := *seed.Config
-	limiterCeiling, limiterNeeded, limiterClamped := calculateLimiterCeiling(
-		seed.OutputMeasurements.OutputI,
-		seed.OutputMeasurements.OutputTP,
-		config.Loudnorm.TargetI,
-		config.Loudnorm.TargetTP,
-	)
-	preGainDB, reDerivedCeiling := calculatePreGain(
-		seed.OutputMeasurements.OutputI,
-		config.Loudnorm.TargetI,
-		config.Loudnorm.TargetTP,
-	)
-	if limiterClamped {
-		limiterCeiling = reDerivedCeiling
-	}
-
-	filterPrefix := buildPreLimiterPrefix(preGainDB, limiterCeiling, limiterNeeded)
-	measurement, err := measureWithLoudnorm(seed.OutputPath, &config, filterPrefix, nil)
+	limiter := planLimiterForLoudnorm(seed.OutputMeasurements, &config)
+	measurement, err := measureWithLoudnorm(seed.OutputPath, &config, limiter.pass3Prefix, nil)
 	if err != nil {
 		tb.Fatalf("failed to prepare fullbench loudnorm measurement: %v", err)
 	}
@@ -1006,11 +991,11 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 	return &fullbenchLoudnormSetup{
 		Measurement:       measurement,
 		EffectiveConfig:   &effectiveConfig,
-		Pass3FilterPrefix: filterPrefix,
-		PreGainDB:         preGainDB,
-		LimiterCeiling:    limiterCeiling,
-		LimiterNeeded:     limiterNeeded,
-		LimiterClamped:    limiterClamped,
+		Pass3FilterPrefix: limiter.pass3Prefix,
+		PreGainDB:         limiter.preGainDB,
+		LimiterCeiling:    limiter.ceilingDB,
+		LimiterNeeded:     limiter.needed,
+		LimiterClamped:    limiter.clamped,
 		LinearModeForced:  !linearPossible,
 	}
 }

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -415,6 +415,71 @@ func buildPreLimiterPrefix(preGainDB, ceiling float64, needsLimiting bool) strin
 	return strings.Join(parts, ",")
 }
 
+type limiterPlan struct {
+	preGainDB   float64
+	ceilingDB   float64
+	needed      bool
+	clamped     bool
+	gainDB      float64
+	pass3Prefix string
+}
+
+type loudnormProgressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)
+
+type loudnormApplicationRequest struct {
+	inputPath         string
+	config            *EffectiveFilterConfig
+	measurement       *LoudnormMeasurement
+	inputMeasurements *AudioMeasurements
+	limiter           limiterPlan
+	progress          loudnormProgressCallback
+}
+
+type loudnormApplicationResult struct {
+	finalLUFS             float64
+	finalTP               float64
+	finalMeasurements     *OutputMeasurements
+	loudnormStats         *LoudnormStats
+	regionMeasurementTime time.Duration
+}
+
+type loudnormApplicationPreparation struct {
+	reader        *audio.Reader
+	metadata      *audio.Metadata
+	tempPath      string
+	filterGraph   *ffmpeg.AVFilterGraph
+	bufferSrcCtx  *ffmpeg.AVFilterContext
+	bufferSinkCtx *ffmpeg.AVFilterContext
+}
+
+type loudnormApplicationExecutionResult struct {
+	acc           outputMetadataAccumulators
+	loudnormStats *LoudnormStats
+}
+
+func planLimiterForLoudnorm(output *OutputMeasurements, config *EffectiveFilterConfig) limiterPlan {
+	loudnorm := config.Loudnorm
+	ceilingDB, needed, clamped := calculateLimiterCeiling(
+		output.OutputI, output.OutputTP,
+		loudnorm.TargetI, loudnorm.TargetTP,
+	)
+	preGainDB, reDerivedCeiling := calculatePreGain(
+		output.OutputI, loudnorm.TargetI, loudnorm.TargetTP,
+	)
+	if clamped {
+		ceilingDB = reDerivedCeiling
+	}
+
+	return limiterPlan{
+		preGainDB:   preGainDB,
+		ceilingDB:   ceilingDB,
+		needed:      needed,
+		clamped:     clamped,
+		gainDB:      loudnorm.TargetI - output.OutputI,
+		pass3Prefix: buildPreLimiterPrefix(preGainDB, ceilingDB, needed),
+	}
+}
+
 // calculateLinearModeTarget calculates the target I and offset that ensure loudnorm
 // stays in linear mode (never falls back to dynamic normalization).
 //
@@ -531,28 +596,15 @@ func ApplyNormalisation(
 		progressCallback(PassMeasuring, "Measuring", 0.0, 0.0, nil)
 	}
 
-	// Compute ceiling/pre-gain from Pass 2 ebur128 measurements (before Pass 3)
+	// Compute the limiter prefix from Pass 2 ebur128 measurements (before Pass 3).
 	// This allows Pass 3 to measure through the same volume+alimiter prefix
 	// that Pass 4 will apply, closing the measurement mismatch.
-	limiterCeiling, limiterNeeded, limiterClamped := calculateLimiterCeiling(
-		outputMeasurements.OutputI, outputMeasurements.OutputTP,
-		loudnorm.TargetI, loudnorm.TargetTP,
-	)
-	preGainDB, reDerivedCeiling := calculatePreGain(
-		outputMeasurements.OutputI, loudnorm.TargetI, loudnorm.TargetTP,
-	)
-	if limiterClamped {
-		limiterCeiling = reDerivedCeiling
-	}
-	limiterGain := loudnorm.TargetI - outputMeasurements.OutputI
-
-	// Build filter prefix for Pass 3 measurement
-	filterPrefix := buildPreLimiterPrefix(preGainDB, limiterCeiling, limiterNeeded)
+	limiter := planLimiterForLoudnorm(outputMeasurements, config)
 
 	// Pass 3: Run loudnorm measurement pass on Pass 2 output
 	// When a prefix is active, loudnorm measures the post-limiter signal,
 	// so its InputI/InputTP already reflect pre-gain and limiting.
-	measurement, err := measureWithLoudnorm(inputPath, config, filterPrefix, progressCallback)
+	measurement, err := measureWithLoudnorm(inputPath, config, limiter.pass3Prefix, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("loudnorm measurement pass failed: %w", err)
 	}
@@ -587,7 +639,14 @@ func ApplyNormalisation(
 	effectiveConfig.Loudnorm.TargetI = effectiveTargetI
 
 	// Pass 4: Apply loudnorm with linear=true and the measurements
-	finalLUFS, finalTP, finalMeasurements, loudnormStats, regionMeasurementTime, err := applyLoudnormAndMeasure(inputPath, &effectiveConfig, measurement, inputMeasurements, preGainDB, limiterCeiling, limiterNeeded, progressCallback)
+	application, err := applyLoudnormAndMeasure(loudnormApplicationRequest{
+		inputPath:         inputPath,
+		config:            &effectiveConfig,
+		measurement:       measurement,
+		inputMeasurements: inputMeasurements,
+		limiter:           limiter,
+		progress:          progressCallback,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("loudnorm application failed: %w", err)
 	}
@@ -598,29 +657,29 @@ func ApplyNormalisation(
 	}
 
 	// Validate result is within tolerance of the EFFECTIVE target (not the requested one)
-	finalDeviation := math.Abs(finalLUFS - effectiveTargetI)
+	finalDeviation := math.Abs(application.finalLUFS - effectiveTargetI)
 	withinTarget := finalDeviation <= 0.5
 
 	return &NormalisationResult{
 		InputLUFS:             measurement.InputI,
 		InputTP:               measurement.InputTP,
-		OutputLUFS:            finalLUFS,
-		OutputTP:              finalTP,
+		OutputLUFS:            application.finalLUFS,
+		OutputTP:              application.finalTP,
 		GainApplied:           offset,
 		WithinTarget:          withinTarget,
 		Skipped:               false,
-		LoudnormStats:         loudnormStats,
+		LoudnormStats:         application.loudnormStats,
 		RequestedTargetI:      loudnorm.TargetI,
 		EffectiveTargetI:      effectiveTargetI,
 		LinearModeForced:      !linearPossible,
-		LimiterEnabled:        limiterNeeded,
-		LimiterCeiling:        limiterCeiling,
-		LimiterGain:           limiterGain,
-		PreGainDB:             preGainDB,
-		LimiterClamped:        limiterClamped,
-		Pass3FilterPrefix:     filterPrefix,
-		RegionMeasurementTime: regionMeasurementTime,
-		FinalMeasurements:     finalMeasurements,
+		LimiterEnabled:        limiter.needed,
+		LimiterCeiling:        limiter.ceilingDB,
+		LimiterGain:           limiter.gainDB,
+		PreGainDB:             limiter.preGainDB,
+		LimiterClamped:        limiter.clamped,
+		Pass3FilterPrefix:     limiter.pass3Prefix,
+		RegionMeasurementTime: application.regionMeasurementTime,
+		FinalMeasurements:     application.finalMeasurements,
 	}, nil
 }
 
@@ -636,61 +695,83 @@ func ApplyNormalisation(
 //
 // Returns the measured integrated loudness, true peak, full output measurements,
 // and loudnorm diagnostic stats.
-func applyLoudnormAndMeasure(
-	inputPath string,
-	config *EffectiveFilterConfig,
-	measurement *LoudnormMeasurement,
-	inputMeasurements *AudioMeasurements,
-	preGainDB float64,
-	ceiling float64,
-	needsLimiting bool,
-	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
-) (float64, float64, *OutputMeasurements, *LoudnormStats, time.Duration, error) {
-	// Open input file
-	reader, metadata, err := audio.OpenAudioFile(inputPath)
+func applyLoudnormAndMeasure(request loudnormApplicationRequest) (*loudnormApplicationResult, error) {
+	prep, err := prepareLoudnormApplication(request)
 	if err != nil {
-		return 0.0, 0.0, nil, nil, 0, fmt.Errorf("failed to open input: %w", err)
+		return nil, err
 	}
-	defer reader.Close()
-
-	// Create temporary output file - always FLAC since output is pinned to FLAC
-	tempPath, err := createSiblingTempPath(inputPath, "loudnorm")
-	if err != nil {
-		return 0.0, 0.0, nil, nil, 0, fmt.Errorf("failed to create loudnorm temp output: %w", err)
-	}
+	defer prep.reader.Close()
 	removeTemp := func() {
-		_ = os.Remove(tempPath)
+		_ = os.Remove(prep.tempPath)
+	}
+	captureGraphStats := func() *LoudnormStats {
+		return capturePass4LoudnormStats(&prep.filterGraph)
 	}
 
-	// Build Pass 4 filter graph: loudnorm (second pass with linear=true) → ebur128 (validation)
-	filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, ceiling, needsLimiting)
+	execution, err := executeAndPublishLoudnormApplication(prep, request, captureGraphStats, removeTemp)
+	if err != nil {
+		return &loudnormApplicationResult{loudnormStats: execution.loudnormStats}, err
+	}
 
-	// Create filter graph
+	// Free filter graph before getting stats — loudnorm outputs JSON on graph destruction
+	stats := captureGraphStats()
+
+	return finalizeLoudnormApplicationResult(request, execution, stats), nil
+}
+
+func prepareLoudnormApplication(request loudnormApplicationRequest) (*loudnormApplicationPreparation, error) {
+	reader, metadata, err := audio.OpenAudioFile(request.inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open input: %w", err)
+	}
+
+	tempPath, err := createSiblingTempPath(request.inputPath, "loudnorm")
+	if err != nil {
+		reader.Close()
+		return nil, fmt.Errorf("failed to create loudnorm temp output: %w", err)
+	}
+
+	filterSpec := buildLoudnormFilterSpec(
+		request.config,
+		request.measurement,
+		request.limiter.preGainDB,
+		request.limiter.ceilingDB,
+		request.limiter.needed,
+	)
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := loudnormSetupFilterGraph(
 		reader.GetDecoderContext(),
 		filterSpec,
 	)
 	if err != nil {
-		removeTemp()
-		return 0.0, 0.0, nil, nil, 0, fmt.Errorf("failed to create filter graph: %w", err)
-	}
-	// Note: We free the filter graph explicitly before getting stats, not via defer.
-	// loudnorm outputs its JSON when the filter graph is freed.
-	captureGraphStats := func() *LoudnormStats {
-		stats, err := captureLoudnormGraphFinalisation(&filterGraph)
-		if err != nil {
-			debugLog("Warning: failed to capture Pass 4 loudnorm diagnostics: %v", err)
-			return nil
-		}
-		return stats
+		_ = os.Remove(tempPath)
+		reader.Close()
+		return nil, fmt.Errorf("failed to create filter graph: %w", err)
 	}
 
+	return &loudnormApplicationPreparation{
+		reader:        reader,
+		metadata:      metadata,
+		tempPath:      tempPath,
+		filterGraph:   filterGraph,
+		bufferSrcCtx:  bufferSrcCtx,
+		bufferSinkCtx: bufferSinkCtx,
+	}, nil
+}
+
+func executeAndPublishLoudnormApplication(
+	prep *loudnormApplicationPreparation,
+	request loudnormApplicationRequest,
+	captureGraphStats func() *LoudnormStats,
+	removeTemp func(),
+) (*loudnormApplicationExecutionResult, error) {
+	result := &loudnormApplicationExecutionResult{}
+
 	// Create output encoder (same format as input)
-	encoder, err := loudnormCreateEncoder(tempPath, metadata, bufferSinkCtx)
+	encoder, err := loudnormCreateEncoder(prep.tempPath, prep.metadata, prep.bufferSinkCtx)
 	if err != nil {
-		stats := captureGraphStats()
+		result.loudnormStats = captureGraphStats()
 		removeTemp()
-		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to create encoder: %w", err)
+		return result, fmt.Errorf("failed to create encoder: %w", err)
 	}
 	encoderClosed := false
 	defer func() {
@@ -700,16 +781,15 @@ func applyLoudnormAndMeasure(
 	}()
 
 	// Process frames and accumulate ebur128 measurements using Pass 2's extraction function
-	var acc outputMetadataAccumulators
 	var framesProcessed int64
 
 	// Calculate total samples for accurate progress reporting
-	totalSamples := int64(metadata.Duration * float64(metadata.SampleRate))
+	totalSamples := int64(prep.metadata.Duration * float64(prep.metadata.SampleRate))
 	var samplesProcessed int64
 	const progressUpdateInterval = 100 // Send progress update every N frames
 
 	lenientHandler := func(err error) error { return nil }
-	loopErr := loudnormRunFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	loopErr := loudnormRunFilterGraph(prep.reader, prep.bufferSrcCtx, prep.bufferSinkCtx, FrameLoopConfig{
 		OnPushError: lenientHandler,
 		OnPullError: lenientHandler,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
@@ -717,7 +797,7 @@ func applyLoudnormAndMeasure(
 		},
 		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) error {
 			// Extract validation measurements using Pass 2's function
-			extractOutputFrameMetadata(filteredFrame.Metadata(), &acc)
+			extractOutputFrameMetadata(filteredFrame.Metadata(), &result.acc)
 
 			// Encode frame
 			if err := encoder.WriteFrame(filteredFrame); err != nil {
@@ -727,67 +807,102 @@ func applyLoudnormAndMeasure(
 			framesProcessed++
 
 			// Progress update periodically (every N output frames for smooth updates)
-			if progressCallback != nil && framesProcessed%progressUpdateInterval == 0 {
+			if request.progress != nil && framesProcessed%progressUpdateInterval == 0 {
 				progress := math.Min(0.99, float64(samplesProcessed)/float64(totalSamples))
-				progressCallback(PassNormalising, "Normalising", progress, acc.ebur128OutputI, nil)
+				request.progress(PassNormalising, "Normalising", progress, result.acc.ebur128OutputI, nil)
 			}
 
 			return nil
 		},
 	})
 	if loopErr != nil {
-		stats := captureGraphStats()
+		result.loudnormStats = captureGraphStats()
 		encoderClosed = true
 		_ = encoder.Close()
 		removeTemp()
-		return 0.0, 0.0, nil, stats, 0, loopErr
+		return result, loopErr
 	}
 
 	// Flush encoder
 	if err := encoder.Flush(); err != nil {
-		stats := captureGraphStats()
+		result.loudnormStats = captureGraphStats()
 		encoderClosed = true
 		_ = encoder.Close()
 		removeTemp()
-		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to flush encoder: %w", err)
+		return result, fmt.Errorf("failed to flush encoder: %w", err)
 	}
 
 	// Close encoder before rename
 	encoderClosed = true
 	if err := encoder.Close(); err != nil {
-		stats := captureGraphStats()
+		result.loudnormStats = captureGraphStats()
 		removeTemp()
-		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to close encoder: %w", err)
+		return result, fmt.Errorf("failed to close encoder: %w", err)
 	}
 
 	// Atomic rename: temp file → original file (in-place update)
-	if err := loudnormRename(tempPath, inputPath); err != nil {
-		stats := captureGraphStats()
+	if err := loudnormRename(prep.tempPath, request.inputPath); err != nil {
+		result.loudnormStats = captureGraphStats()
 		removeTemp()
-		return 0.0, 0.0, nil, stats, 0, fmt.Errorf("failed to rename output: %w", err)
+		return result, fmt.Errorf("failed to rename output: %w", err)
 	}
 
-	// Free filter graph before getting stats — loudnorm outputs JSON on graph destruction
-	stats := captureGraphStats()
+	return result, nil
+}
 
-	// Build complete OutputMeasurements from accumulators
-	finalMeasurements := finalizeOutputMeasurements(&acc)
+func capturePass4LoudnormStats(graph **ffmpeg.AVFilterGraph) *LoudnormStats {
+	stats, err := captureLoudnormGraphFinalisation(graph)
+	if err != nil {
+		debugLog("Warning: failed to capture Pass 4 loudnorm diagnostics: %v", err)
+		return nil
+	}
+	return stats
+}
+
+func finalizeLoudnormApplicationResult(
+	request loudnormApplicationRequest,
+	execution *loudnormApplicationExecutionResult,
+	stats *LoudnormStats,
+) *loudnormApplicationResult {
+	finalMeasurements, regionMeasurementTime := finalizeLoudnormOutputMeasurements(
+		request.inputPath,
+		request.inputMeasurements,
+		&execution.acc,
+	)
+
+	return &loudnormApplicationResult{
+		finalLUFS:             execution.acc.ebur128OutputI,
+		finalTP:               execution.acc.ebur128OutputTP,
+		finalMeasurements:     finalMeasurements,
+		loudnormStats:         stats,
+		regionMeasurementTime: regionMeasurementTime,
+	}
+}
+
+func finalizeLoudnormOutputMeasurements(
+	inputPath string,
+	inputMeasurements *AudioMeasurements,
+	acc *outputMetadataAccumulators,
+) (*OutputMeasurements, time.Duration) {
+	finalMeasurements := finalizeOutputMeasurements(acc)
 	var regionMeasurementTime time.Duration
 
-	// Measure silence and speech regions in final output (same regions as Pass 1 profiles)
-	// NOTE: inputPath now contains the normalised output after os.Rename above
-	if inputMeasurements != nil {
-		silRegion, spRegion := extractRegionPair(inputMeasurements)
-		if silRegion != nil || spRegion != nil {
-			regionStart := time.Now()
-			silSample, spSample := MeasureOutputRegions(inputPath, silRegion, spRegion)
-			regionMeasurementTime = time.Since(regionStart)
-			finalMeasurements.SilenceSample = silSample
-			finalMeasurements.SpeechSample = spSample
-		}
+	if inputMeasurements == nil {
+		return finalMeasurements, regionMeasurementTime
 	}
 
-	return acc.ebur128OutputI, acc.ebur128OutputTP, finalMeasurements, stats, regionMeasurementTime, nil
+	silRegion, spRegion := extractRegionPair(inputMeasurements)
+	if silRegion == nil && spRegion == nil {
+		return finalMeasurements, regionMeasurementTime
+	}
+
+	regionStart := time.Now()
+	silSample, spSample := MeasureOutputRegions(inputPath, silRegion, spRegion)
+	regionMeasurementTime = time.Since(regionStart)
+	finalMeasurements.SilenceSample = silSample
+	finalMeasurements.SpeechSample = spSample
+
+	return finalMeasurements, regionMeasurementTime
 }
 
 // buildLoudnormFilterSpec constructs the filter chain for Pass 4 loudnorm application.

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -749,6 +749,50 @@ func TestMeasureWithLoudnormGeneratedAudioCapturesGraphFinalisationJSON(t *testi
 	}
 }
 
+func TestMeasureWithLoudnormProgressCadenceCapsAt099(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+	replaceApplyLoudnormSetupFilterGraph(t, func(
+		*ffmpeg.AVCodecContext,
+		string,
+	) (*ffmpeg.AVFilterGraph, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, error) {
+		return nil, nil, nil, nil
+	})
+
+	replaceLoudnormRunFilterGraph(t, func(
+		_ *audio.Reader,
+		_, _ *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		frame := ffmpeg.AVFrameAlloc()
+		defer ffmpeg.AVFrameFree(&frame)
+		frame.SetNbSamples(44100)
+
+		for range 100 {
+			config.OnInputFrame(frame)
+		}
+		return nil
+	})
+
+	var events []loudnormProgressEvent
+	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
+		events = append(events, loudnormProgressEvent{pass: pass, passName: passName, progress: progress})
+	})
+	if err != nil {
+		t.Fatalf("measureWithLoudnorm() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("progress events = %+v, want one cadence event", events)
+	}
+	requireLoudnormProgressEvent(t, events[0], loudnormProgressEvent{
+		pass:     PassMeasuring,
+		passName: "Measuring",
+		progress: 0.99,
+	})
+	requireLoudnormCaptureStoppedOnce(t, recorder)
+}
+
 type loudnormCleanupRecorder struct {
 	mu     sync.Mutex
 	order  []string
@@ -891,6 +935,19 @@ func replaceApplyLoudnormRename(t *testing.T, rename func(string, string) error)
 	})
 }
 
+func replaceLoudnormRunFilterGraph(
+	t *testing.T,
+	run func(*audio.Reader, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, FrameLoopConfig) error,
+) {
+	t.Helper()
+
+	oldRun := loudnormRunFilterGraph
+	loudnormRunFilterGraph = run
+	t.Cleanup(func() {
+		loudnormRunFilterGraph = oldRun
+	})
+}
+
 type loudnormTestEncoder struct {
 	writeFrame func(*ffmpeg.AVFrame) error
 	flush      func() error
@@ -963,6 +1020,26 @@ func generateLoudnormApplicationTestAudio(t *testing.T) string {
 	return testFile
 }
 
+type loudnormProgressEvent struct {
+	pass     PassNumber
+	passName string
+	progress float64
+}
+
+func requireLoudnormProgressEvent(t *testing.T, got loudnormProgressEvent, want loudnormProgressEvent) {
+	t.Helper()
+
+	if got.pass != want.pass {
+		t.Fatalf("progress pass = %d, want %d", got.pass, want.pass)
+	}
+	if got.passName != want.passName {
+		t.Fatalf("progress passName = %q, want %q", got.passName, want.passName)
+	}
+	if math.Abs(got.progress-want.progress) > 0.000001 {
+		t.Fatalf("progress value = %.6f, want %.6f", got.progress, want.progress)
+	}
+}
+
 func oldFixedLoudnormTempPath(inputPath string) string {
 	return strings.TrimSuffix(inputPath, filepath.Ext(inputPath)) + ".loudnorm.tmp.flac"
 }
@@ -1000,26 +1077,21 @@ func requireNoLoudnormTempFiles(t *testing.T, inputPath string) {
 func applyLoudnormTest(
 	t *testing.T,
 	inputPath string,
-) (float64, float64, *OutputMeasurements, *LoudnormStats, time.Duration, error) {
+) (*loudnormApplicationResult, error) {
 	t.Helper()
 
-	return applyLoudnormAndMeasure(
-		inputPath,
-		loudnormApplicationTestConfig(),
-		loudnormApplicationTestMeasurement(),
-		nil,
-		0,
-		0,
-		false,
-		nil,
-	)
+	return applyLoudnormAndMeasure(loudnormApplicationRequest{
+		inputPath:   inputPath,
+		config:      loudnormApplicationTestConfig(),
+		measurement: loudnormApplicationTestMeasurement(),
+	})
 }
 
 func TestApplyLoudnormAndMeasureDoesNotStartCaptureOnOpenError(t *testing.T) {
 	recorder := installLoudnormCleanupRecorder(t)
 	replaceApplyLoudnormGraphFree(t, recorder, false)
 
-	_, _, _, _, _, err := applyLoudnormTest(t, "/does/not/exist.wav")
+	_, err := applyLoudnormTest(t, "/does/not/exist.wav")
 	if err == nil {
 		t.Fatal("applyLoudnormAndMeasure() error = nil, want open error")
 	}
@@ -1047,7 +1119,7 @@ func TestApplyLoudnormAndMeasureSetupErrorDoesNotStartCaptureOrFreeGraph(t *test
 		return nil, nil, nil, setupErr
 	})
 
-	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	_, err := applyLoudnormTest(t, testFile)
 	if !errors.Is(err, setupErr) {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped setup error", err)
 	}
@@ -1080,7 +1152,7 @@ func TestApplyLoudnormAndMeasureEncoderCreationErrorFreesGraphBeforeStoppingCapt
 		return nil, createErr
 	})
 
-	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	_, err := applyLoudnormTest(t, testFile)
 	if !errors.Is(err, createErr) {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped encoder creation error", err)
 	}
@@ -1129,7 +1201,7 @@ func TestApplyLoudnormAndMeasureLoopErrorFreesGraphBeforeStoppingCapture(t *test
 		loudnormRunFilterGraph = oldRun
 	})
 
-	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	_, err := applyLoudnormTest(t, testFile)
 	if !errors.Is(err, runErr) {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v, want loop error", err)
 	}
@@ -1179,7 +1251,7 @@ func TestApplyLoudnormAndMeasureFlushErrorFreesGraphBeforeStoppingCapture(t *tes
 		loudnormRunFilterGraph = oldRun
 	})
 
-	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	_, err := applyLoudnormTest(t, testFile)
 	if !errors.Is(err, flushErr) {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped flush error", err)
 	}
@@ -1232,7 +1304,7 @@ func TestApplyLoudnormAndMeasureCloseErrorFreesGraphBeforeStoppingCapture(t *tes
 		loudnormRunFilterGraph = oldRun
 	})
 
-	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	_, err := applyLoudnormTest(t, testFile)
 	if !errors.Is(err, closeErr) {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped close error", err)
 	}
@@ -1291,7 +1363,7 @@ func TestApplyLoudnormAndMeasureRenameErrorFreesGraphBeforeStoppingCapture(t *te
 		return renameErr
 	})
 
-	_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+	_, err := applyLoudnormTest(t, testFile)
 	if !errors.Is(err, renameErr) {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v, want wrapped rename error", err)
 	}
@@ -1325,20 +1397,25 @@ func TestApplyLoudnormAndMeasureSuccessFreesGraphBeforeStoppingCapture(t *testin
 		return os.Rename(oldPath, newPath)
 	})
 
-	finalLUFS, _, finalMeasurements, stats, _, err := applyLoudnormTest(t, testFile)
+	result, err := applyLoudnormTest(t, testFile)
 	if err != nil {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v", err)
 	}
+	if result == nil {
+		t.Fatal("loudnorm application result = nil")
+	}
+	stats := result.loudnormStats
 	if stats == nil {
 		t.Fatal("loudnorm stats = nil, want parsed stats")
 	}
 	if stats.OutputI != "-16.0" {
 		t.Fatalf("stats.OutputI = %q, want -16.0", stats.OutputI)
 	}
+	finalMeasurements := result.finalMeasurements
 	if finalMeasurements == nil {
 		t.Fatal("final measurements = nil, want measurements")
 	}
-	if math.IsNaN(finalLUFS) {
+	if math.IsNaN(result.finalLUFS) {
 		t.Fatal("final LUFS is NaN")
 	}
 	if gotOrder := recorder.orderString(); gotOrder != "free,stop" {
@@ -1466,7 +1543,7 @@ func TestApplyLoudnormAndMeasureEncodingAndPublishRunOutsideCapture(t *testing.T
 
 	done := make(chan error, 1)
 	go func() {
-		_, _, _, _, _, err := applyLoudnormTest(t, testFile)
+		_, err := applyLoudnormTest(t, testFile)
 		done <- err
 	}()
 
@@ -1524,13 +1601,18 @@ func TestApplyLoudnormAndMeasureMissingPass4JSONReturnsNilStatsWithoutError(t *t
 		return os.Rename(oldPath, newPath)
 	})
 
-	_, _, finalMeasurements, stats, _, err := applyLoudnormTest(t, testFile)
+	result, err := applyLoudnormTest(t, testFile)
 	if err != nil {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v", err)
 	}
+	if result == nil {
+		t.Fatal("loudnorm application result = nil")
+	}
+	stats := result.loudnormStats
 	if stats != nil {
 		t.Fatalf("loudnorm stats = %+v, want nil", stats)
 	}
+	finalMeasurements := result.finalMeasurements
 	if finalMeasurements == nil {
 		t.Fatal("final measurements = nil, want measurements")
 	}
@@ -1560,13 +1642,18 @@ func TestApplyLoudnormAndMeasureMalformedPass4JSONReturnsNilStatsWithoutError(t 
 		return os.Rename(oldPath, newPath)
 	})
 
-	_, _, finalMeasurements, stats, _, err := applyLoudnormTest(t, testFile)
+	result, err := applyLoudnormTest(t, testFile)
 	if err != nil {
 		t.Fatalf("applyLoudnormAndMeasure() error = %v", err)
 	}
+	if result == nil {
+		t.Fatal("loudnorm application result = nil")
+	}
+	stats := result.loudnormStats
 	if stats != nil {
 		t.Fatalf("loudnorm stats = %+v, want nil", stats)
 	}
+	finalMeasurements := result.finalMeasurements
 	if finalMeasurements == nil {
 		t.Fatal("final measurements = nil, want measurements")
 	}
@@ -1574,6 +1661,89 @@ func TestApplyLoudnormAndMeasureMalformedPass4JSONReturnsNilStatsWithoutError(t 
 		t.Fatalf("cleanup order = %s, want free,stop", gotOrder)
 	}
 	requireLoudnormCaptureStoppedOnce(t, recorder)
+	requireNoLoudnormTempFiles(t, testFile)
+}
+
+func TestApplyNormalisationProgressCadenceGuard(t *testing.T) {
+	testFile := generateLoudnormApplicationTestAudio(t)
+	recorder := installLoudnormCleanupRecorder(t)
+	replaceApplyLoudnormGraphFree(t, recorder, true)
+	replaceApplyLoudnormSetupFilterGraph(t, func(
+		*ffmpeg.AVCodecContext,
+		string,
+	) (*ffmpeg.AVFilterGraph, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, error) {
+		return nil, nil, nil, nil
+	})
+	replaceApplyLoudnormCreateEncoder(t, func(
+		string,
+		*audio.Metadata,
+		*ffmpeg.AVFilterContext,
+	) (loudnormOutputEncoder, error) {
+		return &loudnormTestEncoder{}, nil
+	})
+	replaceApplyLoudnormRename(t, func(oldPath, _ string) error {
+		return os.Remove(oldPath)
+	})
+
+	var runCalls int
+	replaceLoudnormRunFilterGraph(t, func(
+		_ *audio.Reader,
+		_, _ *ffmpeg.AVFilterContext,
+		config FrameLoopConfig,
+	) error {
+		runCalls++
+		frame := ffmpeg.AVFrameAlloc()
+		defer ffmpeg.AVFrameFree(&frame)
+		frame.SetNbSamples(44100)
+
+		for range 100 {
+			config.OnInputFrame(frame)
+			if runCalls == 2 {
+				if err := config.OnFrame(frame, frame); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+
+	var events []loudnormProgressEvent
+	_, err := ApplyNormalisation(
+		testFile,
+		defaultNormalisationTestConfig(),
+		&OutputMeasurements{OutputI: -20.0, OutputTP: -10.0},
+		nil,
+		func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
+			events = append(events, loudnormProgressEvent{pass: pass, passName: passName, progress: progress})
+		},
+	)
+	if err != nil {
+		t.Fatalf("ApplyNormalisation() error = %v", err)
+	}
+	if runCalls != 2 {
+		t.Fatalf("loudnorm run calls = %d, want 2", runCalls)
+	}
+
+	want := []loudnormProgressEvent{
+		{pass: PassMeasuring, passName: "Measuring", progress: 0.0},
+		{pass: PassMeasuring, passName: "Measuring", progress: 0.99},
+		{pass: PassMeasuring, passName: "Measuring", progress: 1.0},
+		{pass: PassNormalising, passName: "Normalising", progress: 0.0},
+		{pass: PassNormalising, passName: "Normalising", progress: 0.99},
+		{pass: PassNormalising, passName: "Normalising", progress: 1.0},
+	}
+	if len(events) != len(want) {
+		t.Fatalf("progress events = %+v, want %+v", events, want)
+	}
+	for i := range want {
+		requireLoudnormProgressEvent(t, events[i], want[i])
+	}
+	if recorder.freeCount() != 2 {
+		t.Fatalf("graph free count = %d, want 2", recorder.freeCount())
+	}
+	if recorder.stopCount() != 2 {
+		t.Fatalf("capture stop count = %d, want 2", recorder.stopCount())
+	}
 	requireNoLoudnormTempFiles(t, testFile)
 }
 
@@ -2493,6 +2663,173 @@ func TestBuildPreLimiterPrefix(t *testing.T) {
 				if !strings.Contains(result, wantLimit) {
 					t.Errorf("expected %q in result %q", wantLimit, result)
 				}
+			}
+		})
+	}
+}
+
+func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		outputI        float64
+		outputTP       float64
+		measurement    LoudnormMeasurement
+		wantPass3      string
+		wantPass4      string
+		wantPass4Start string
+	}{
+		{
+			name:     "non-limited",
+			outputI:  -20.0,
+			outputTP: -10.0,
+			measurement: LoudnormMeasurement{
+				InputI:       -20.0,
+				InputTP:      -10.0,
+				InputLRA:     5.0,
+				InputThresh:  -30.0,
+				TargetOffset: 0.0,
+			},
+			wantPass3:      "",
+			wantPass4Start: "loudnorm=",
+			wantPass4:      "loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-20.00:measured_TP=-10.00:measured_LRA=5.00:measured_thresh=-30.00:offset=0.00:dual_mono=true:linear=true:print_format=json,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+		},
+		{
+			name:     "limited",
+			outputI:  -24.9,
+			outputTP: -5.0,
+			measurement: LoudnormMeasurement{
+				InputI:       -24.9,
+				InputTP:      -5.0,
+				InputLRA:     6.0,
+				InputThresh:  -35.0,
+				TargetOffset: -0.5,
+			},
+			wantPass3:      "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
+			wantPass4Start: "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
+			wantPass4:      "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-24.90:measured_TP=-5.00:measured_LRA=6.00:measured_thresh=-35.00:offset=-0.50:dual_mono=true:linear=true:print_format=json,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+		},
+		{
+			name:     "clamped pre-gain",
+			outputI:  -43.2,
+			outputTP: -18.6,
+			measurement: LoudnormMeasurement{
+				InputI:       -36.5,
+				InputTP:      -24.0,
+				InputLRA:     8.0,
+				InputThresh:  -46.5,
+				TargetOffset: -2.5,
+			},
+			wantPass3:      "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
+			wantPass4Start: "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
+			wantPass4:      "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-36.50:measured_TP=-24.00:measured_LRA=8.00:measured_thresh=-46.50:offset=-2.50:dual_mono=true:linear=true:print_format=json,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := defaultNormalisationTestConfig()
+			output := &OutputMeasurements{
+				OutputI:  tt.outputI,
+				OutputTP: tt.outputTP,
+			}
+
+			limiter := planLimiterForLoudnorm(output, config)
+			if limiter.pass3Prefix != tt.wantPass3 {
+				t.Fatalf("pass 3 prefix = %q, want %q", limiter.pass3Prefix, tt.wantPass3)
+			}
+
+			gotPass4 := buildLoudnormFilterSpec(
+				config,
+				&tt.measurement,
+				limiter.preGainDB,
+				limiter.ceilingDB,
+				limiter.needed,
+			)
+			if !strings.HasPrefix(gotPass4, tt.wantPass4Start) {
+				t.Fatalf("pass 4 filter spec prefix = %q, want prefix %q", gotPass4, tt.wantPass4Start)
+			}
+			if gotPass4 != tt.wantPass4 {
+				t.Fatalf("pass 4 filter spec changed\ngot:  %s\nwant: %s", gotPass4, tt.wantPass4)
+			}
+		})
+	}
+}
+
+func TestPlanLimiterForLoudnormMatchesInlineCalculation(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputI    float64
+		outputTP   float64
+		wantNeeded bool
+		wantClamp  bool
+	}{
+		{
+			name:       "non-limited",
+			outputI:    -20.0,
+			outputTP:   -10.0,
+			wantNeeded: false,
+			wantClamp:  false,
+		},
+		{
+			name:       "limited",
+			outputI:    -24.9,
+			outputTP:   -5.0,
+			wantNeeded: true,
+			wantClamp:  false,
+		},
+		{
+			name:       "clamped",
+			outputI:    -43.2,
+			outputTP:   -18.6,
+			wantNeeded: true,
+			wantClamp:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := defaultNormalisationTestConfig()
+			output := &OutputMeasurements{
+				OutputI:  tt.outputI,
+				OutputTP: tt.outputTP,
+			}
+
+			wantCeiling, wantNeeded, wantClamped := calculateLimiterCeiling(
+				output.OutputI,
+				output.OutputTP,
+				config.Loudnorm.TargetI,
+				config.Loudnorm.TargetTP,
+			)
+			wantPreGainDB, reDerivedCeiling := calculatePreGain(
+				output.OutputI,
+				config.Loudnorm.TargetI,
+				config.Loudnorm.TargetTP,
+			)
+			if wantClamped {
+				wantCeiling = reDerivedCeiling
+			}
+			wantGainDB := config.Loudnorm.TargetI - output.OutputI
+			wantPrefix := buildPreLimiterPrefix(wantPreGainDB, wantCeiling, wantNeeded)
+
+			got := planLimiterForLoudnorm(output, config)
+
+			if got.needed != wantNeeded || got.needed != tt.wantNeeded {
+				t.Fatalf("needed = %v, want inline %v and case %v", got.needed, wantNeeded, tt.wantNeeded)
+			}
+			if got.clamped != wantClamped || got.clamped != tt.wantClamp {
+				t.Fatalf("clamped = %v, want inline %v and case %v", got.clamped, wantClamped, tt.wantClamp)
+			}
+			if math.Abs(got.preGainDB-wantPreGainDB) > 0.01 {
+				t.Fatalf("preGainDB = %.2f, want %.2f", got.preGainDB, wantPreGainDB)
+			}
+			if math.Abs(got.ceilingDB-wantCeiling) > 0.01 {
+				t.Fatalf("ceilingDB = %.2f, want %.2f", got.ceilingDB, wantCeiling)
+			}
+			if math.Abs(got.gainDB-wantGainDB) > 0.01 {
+				t.Fatalf("gainDB = %.2f, want %.2f", got.gainDB, wantGainDB)
+			}
+			if got.pass3Prefix != wantPrefix {
+				t.Fatalf("pass3Prefix = %q, want %q", got.pass3Prefix, wantPrefix)
 			}
 		})
 	}


### PR DESCRIPTION
- Extract shared limiter planning into `planLimiterForLoudnorm` for Pass 3 and Pass 4.
- Split loudnorm application into request/result types and preparation/execution/finalisation helpers.
- Add guard tests for limiter parity, progress cadence, and loudnorm application boundaries.
