### PR TITLE
ci: add Dependabot Nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- enable Dependabot version updates for Nix flakes
- let Dependabot maintain `flake.lock` inputs on a weekly schedule
- remove the old `DeterminateSystems/update-flake-lock` automation to avoid duplicate flake lock PRs

## Test plan
- [x] `git diff --check`
- [x] verified every target repo has a `package-ecosystem: "nix"` Dependabot entry
- [x] verified no tracked old updater references remain: `DeterminateSystems/update-flake-lock`, `update_flake_lock`, `update-flake-lock`
- [x] `actionlint` passed for jivetalking, jivedrop, and jivefire
- [ ] `actionlint` skipped for ffmpeg-statigo because its dev shell does not provide actionlint
- [ ] `nix develop --command go test ./...` currently fails before reaching this change, due missing downloaded ffmpeg-statigo native libraries / submodule setup
