### PR TITLE
refactor(processor): use progress update events for callbacks

### DIFF
--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -211,7 +211,7 @@ type analysisOnlyDeps struct {
 	hasTTY          func() bool
 	openMetadata    func(string) (*audio.Metadata, error)
 	runWithTUI      func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error)
-	analyzeDetailed func(string, *processor.BaseFilterConfig, func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error)
+	analyzeDetailed func(string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)
 	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.EffectiveFilterConfig, *processor.AdaptiveDiagnostics, ...logging.AnalysisTimings)
 	printError      func(string)
 }
@@ -258,31 +258,31 @@ type progressHandler struct {
 	pass4Time  time.Duration
 }
 
-func (ph *progressHandler) callback(pass processor.PassNumber, passName string, progress float64, level float64, measurements *processor.AudioMeasurements) {
-	ph.log("[MAIN] Sending ProgressMsg: Pass %d (%s), Progress %.1f%%, Level %.1f dB", pass, passName, progress*100, level)
+func (ph *progressHandler) callback(update processor.ProgressUpdate) {
+	ph.log("[MAIN] Sending ProgressMsg: Pass %d (%s), Progress %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
 
 	// Track pass timing
 	switch {
-	case pass == processor.PassAnalysis && progress == 0.0:
+	case update.Pass == processor.PassAnalysis && update.Progress == 0.0:
 		ph.pass1Start = time.Now()
-	case pass == processor.PassAnalysis && progress == 1.0:
+	case update.Pass == processor.PassAnalysis && update.Progress == 1.0:
 		ph.pass1Time = time.Since(ph.pass1Start)
-	case pass == processor.PassMeasuring && progress == 0.0:
+	case update.Pass == processor.PassMeasuring && update.Progress == 0.0:
 		ph.pass3Start = time.Now()
-	case pass == processor.PassMeasuring && progress == 1.0:
+	case update.Pass == processor.PassMeasuring && update.Progress == 1.0:
 		ph.pass3Time = time.Since(ph.pass3Start)
-	case pass == processor.PassNormalising && progress == 0.0:
+	case update.Pass == processor.PassNormalising && update.Progress == 0.0:
 		ph.pass4Start = time.Now()
-	case pass == processor.PassNormalising && progress == 1.0:
+	case update.Pass == processor.PassNormalising && update.Progress == 1.0:
 		ph.pass4Time = time.Since(ph.pass4Start)
 	}
 
 	ph.p.Send(ui.ProgressMsg{
-		Pass:         pass,
-		PassName:     passName,
-		Progress:     progress,
-		Level:        level,
-		Measurements: measurements,
+		Pass:         update.Pass,
+		PassName:     update.PassName,
+		Progress:     update.Progress,
+		Level:        update.Level,
+		Measurements: update.Measurements,
 	})
 }
 
@@ -370,11 +370,11 @@ func runAnalysisWithTUI(inputPath string, config *processor.BaseFilterConfig, lo
 		})
 
 		// Create progress callback that sends updates to TUI
-		progressCallback := func(pass processor.PassNumber, passName string, progress float64, level float64, measurements *processor.AudioMeasurements) {
-			log("[ANALYSIS] Progress: Pass %d (%s), %.1f%%, Level %.1f dB", pass, passName, progress*100, level)
+		progressCallback := func(update processor.ProgressUpdate) {
+			log("[ANALYSIS] Progress: Pass %d (%s), %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
 			p.Send(ui.AnalysisProgressMsg{
-				Progress: progress,
-				Level:    level,
+				Progress: update.Progress,
+				Level:    update.Level,
 			})
 		}
 

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -94,6 +94,36 @@ func TestOpenDebugLog_CreateFailureIncludesPath(t *testing.T) {
 	}
 }
 
+func TestProgressCallbackBoundariesUseProcessorEvent(t *testing.T) {
+	progressCallbackType := reflect.TypeFor[processor.ProgressCallback]()
+	progressUpdateType := reflect.TypeFor[processor.ProgressUpdate]()
+
+	depsType := reflect.TypeFor[analysisOnlyDeps]()
+	analyzeDetailed, ok := depsType.FieldByName("analyzeDetailed")
+	if !ok {
+		t.Fatal("analysisOnlyDeps has no analyzeDetailed field")
+	}
+	if analyzeDetailed.Type.Kind() != reflect.Func {
+		t.Fatalf("analysisOnlyDeps.analyzeDetailed = %s, want func", analyzeDetailed.Type)
+	}
+	if analyzeDetailed.Type.NumIn() != 3 {
+		t.Fatalf("analysisOnlyDeps.analyzeDetailed has %d parameters, want 3", analyzeDetailed.Type.NumIn())
+	}
+	if analyzeDetailed.Type.In(2) != progressCallbackType {
+		t.Fatalf("analysisOnlyDeps.analyzeDetailed progress callback = %s, want %s",
+			analyzeDetailed.Type.In(2), progressCallbackType)
+	}
+
+	callbackType := reflect.TypeOf((&progressHandler{}).callback)
+	if callbackType.NumIn() != 1 {
+		t.Fatalf("progressHandler.callback has %d parameters, want 1", callbackType.NumIn())
+	}
+	if callbackType.In(0) != progressUpdateType {
+		t.Fatalf("progressHandler.callback parameter = %s, want %s",
+			callbackType.In(0), progressUpdateType)
+	}
+}
+
 func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 	inputPath := ".bench/analysis/input/sample.wav"
 	config := processor.DefaultFilterConfig()
@@ -118,7 +148,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 			t.Fatal("runWithTUI should not be called for non-TTY output")
 			return nil, nil
 		},
-		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
+		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
 			if path != inputPath {
 				t.Fatalf("analyzeDetailed path = %q, want %q", path, inputPath)
 			}
@@ -196,7 +226,7 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 			t.Fatal("runWithTUI should not be called for non-TTY output")
 			return nil, nil
 		},
-		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress func(processor.PassNumber, string, float64, float64, *processor.AudioMeasurements)) (*processor.AnalysisResult, error) {
+		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
 			if cfg != baseConfig {
 				t.Fatalf("analyzeDetailed config = %p, want shared base %p", cfg, baseConfig)
 			}

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -264,7 +264,7 @@ type OutputMeasurements struct {
 //
 // The noise floor and silence threshold are computed from interval data AFTER the full pass,
 // eliminating the need for a separate pre-scan phase.
-func AnalyzeAudio(filename string, config *BaseFilterConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*AudioMeasurements, error) {
+func AnalyzeAudio(filename string, config *BaseFilterConfig, progressCallback ProgressCallback) (*AudioMeasurements, error) {
 	// Default fallback threshold if interval analysis yields insufficient data
 	const defaultNoiseFloor = -50.0
 
@@ -485,7 +485,7 @@ type analysisFrameCollection struct {
 	silenceMedians   silenceMedians
 }
 
-func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *ProcessingFilterContext, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*analysisFrameCollection, error) {
+func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *ProcessingFilterContext, progressCallback ProgressCallback) (*analysisFrameCollection, error) {
 	reader, metadata, err := audio.OpenAudioFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open audio file: %w", err)
@@ -559,7 +559,12 @@ func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *P
 				if progress > 1.0 {
 					progress = 1.0
 				}
-				progressCallback(context.Pass, "Analyzing", progress, currentLevel, nil)
+				progressCallback(ProgressUpdate{
+					Pass:     context.Pass,
+					PassName: "Analyzing",
+					Progress: progress,
+					Level:    currentLevel,
+				})
 			}
 			frameCount++
 		},

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -319,11 +319,11 @@ func TestAnalyzeAudio(t *testing.T) {
 	t.Run("synthetic_tone_with_silence", func(t *testing.T) {
 		// Progress callback to show analysis progress
 		lastPercent := -1
-		progressCallback := func(pass PassNumber, passName string, progress float64, level float64, m *AudioMeasurements) {
-			percent := int(progress * 100)
+		progressCallback := func(update ProgressUpdate) {
+			percent := int(update.Progress * 100)
 			// Only log at 25% intervals to avoid spam
 			if percent >= lastPercent+25 {
-				t.Logf("  %s: %d%%", passName, percent)
+				t.Logf("  %s: %d%%", update.PassName, percent)
 				lastPercent = percent
 			}
 		}

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -207,7 +207,7 @@ type LoudnormMeasurement struct {
 // Returns:
 //   - measurement: Loudnorm measurements for second pass
 //   - err: Error if measurement failed
-func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filterPrefix string, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*LoudnormMeasurement, error) {
+func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filterPrefix string, progressCallback ProgressCallback) (*LoudnormMeasurement, error) {
 	// Open input file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
@@ -257,7 +257,11 @@ func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filter
 			frameCount++
 			if progressCallback != nil && frameCount%progressUpdateInterval == 0 {
 				progress := math.Min(0.99, float64(samplesProcessed)/float64(totalSamples))
-				progressCallback(PassMeasuring, "Measuring", progress, 0.0, nil)
+				progressCallback(ProgressUpdate{
+					Pass:     PassMeasuring,
+					PassName: "Measuring",
+					Progress: progress,
+				})
 			}
 		},
 	})
@@ -424,15 +428,13 @@ type limiterPlan struct {
 	pass3Prefix string
 }
 
-type loudnormProgressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)
-
 type loudnormApplicationRequest struct {
 	inputPath         string
 	config            *EffectiveFilterConfig
 	measurement       *LoudnormMeasurement
 	inputMeasurements *AudioMeasurements
 	limiter           limiterPlan
-	progress          loudnormProgressCallback
+	progress          ProgressCallback
 }
 
 type loudnormApplicationResult struct {
@@ -584,7 +586,7 @@ func ApplyNormalisation(
 	config *EffectiveFilterConfig,
 	outputMeasurements *OutputMeasurements,
 	inputMeasurements *AudioMeasurements,
-	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
+	progressCallback ProgressCallback,
 ) (*NormalisationResult, error) {
 	loudnorm := config.Loudnorm
 	if !loudnorm.Enabled {
@@ -593,7 +595,10 @@ func ApplyNormalisation(
 
 	// Signal pass start - first we measure, then we apply
 	if progressCallback != nil {
-		progressCallback(PassMeasuring, "Measuring", 0.0, 0.0, nil)
+		progressCallback(ProgressUpdate{
+			Pass:     PassMeasuring,
+			PassName: "Measuring",
+		})
 	}
 
 	// Compute the limiter prefix from Pass 2 ebur128 measurements (before Pass 3).
@@ -616,8 +621,15 @@ func ApplyNormalisation(
 
 	// Signal measurement complete, starting application
 	if progressCallback != nil {
-		progressCallback(PassMeasuring, "Measuring", 1.0, 0.0, nil)
-		progressCallback(PassNormalising, "Normalising", 0.0, 0.0, nil)
+		progressCallback(ProgressUpdate{
+			Pass:     PassMeasuring,
+			PassName: "Measuring",
+			Progress: 1.0,
+		})
+		progressCallback(ProgressUpdate{
+			Pass:     PassNormalising,
+			PassName: "Normalising",
+		})
 	}
 
 	// Calculate effective target I that ensures linear mode (no dynamic fallback)
@@ -653,7 +665,11 @@ func ApplyNormalisation(
 
 	// Signal pass complete
 	if progressCallback != nil {
-		progressCallback(PassNormalising, "Normalising", 1.0, 0.0, nil)
+		progressCallback(ProgressUpdate{
+			Pass:     PassNormalising,
+			PassName: "Normalising",
+			Progress: 1.0,
+		})
 	}
 
 	// Validate result is within tolerance of the EFFECTIVE target (not the requested one)
@@ -809,7 +825,12 @@ func executeAndPublishLoudnormApplication(
 			// Progress update periodically (every N output frames for smooth updates)
 			if request.progress != nil && framesProcessed%progressUpdateInterval == 0 {
 				progress := math.Min(0.99, float64(samplesProcessed)/float64(totalSamples))
-				request.progress(PassNormalising, "Normalising", progress, result.acc.ebur128OutputI, nil)
+				request.progress(ProgressUpdate{
+					Pass:     PassNormalising,
+					PassName: "Normalising",
+					Progress: progress,
+					Level:    result.acc.ebur128OutputI,
+				})
 			}
 
 			return nil

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -776,8 +776,8 @@ func TestMeasureWithLoudnormProgressCadenceCapsAt099(t *testing.T) {
 	})
 
 	var events []loudnormProgressEvent
-	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
-		events = append(events, loudnormProgressEvent{pass: pass, passName: passName, progress: progress})
+	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", func(update ProgressUpdate) {
+		events = append(events, loudnormProgressEvent{pass: update.Pass, passName: update.PassName, progress: update.Progress})
 	})
 	if err != nil {
 		t.Fatalf("measureWithLoudnorm() error = %v", err)
@@ -1713,8 +1713,8 @@ func TestApplyNormalisationProgressCadenceGuard(t *testing.T) {
 		defaultNormalisationTestConfig(),
 		&OutputMeasurements{OutputI: -20.0, OutputTP: -10.0},
 		nil,
-		func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
-			events = append(events, loudnormProgressEvent{pass: pass, passName: passName, progress: progress})
+		func(update ProgressUpdate) {
+			events = append(events, loudnormProgressEvent{pass: update.Pass, passName: update.PassName, progress: update.Progress})
 		},
 	)
 	if err != nil {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -26,11 +26,14 @@ type AnalysisResult struct {
 
 // AnalyzeOnlyDetailed performs Pass 1 analysis and returns stage timing details.
 func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
-	progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements),
+	progressCallback ProgressCallback,
 ) (*AnalysisResult, error) {
 	// Pass 1: Analysis
 	if progressCallback != nil {
-		progressCallback(PassAnalysis, "Analyzing", 0.0, 0.0, nil)
+		progressCallback(ProgressUpdate{
+			Pass:     PassAnalysis,
+			PassName: "Analyzing",
+		})
 	}
 
 	analysisStart := time.Now()
@@ -41,7 +44,12 @@ func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 	analysisDuration := time.Since(analysisStart)
 
 	if progressCallback != nil {
-		progressCallback(PassAnalysis, "Analyzing", 1.0, 0.0, measurements)
+		progressCallback(ProgressUpdate{
+			Pass:         PassAnalysis,
+			PassName:     "Analyzing",
+			Progress:     1.0,
+			Measurements: measurements,
+		})
 	}
 
 	// Adapt config to show what would be used in Pass 2
@@ -65,10 +73,13 @@ func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 //
 // The output file will be named <basename>-LUFS-NN-processed.<ext> in the same directory as the input
 // If progressCallback is not nil, it will be called with progress updates
-func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements)) (*ProcessingResult, error) {
+func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback ProgressCallback) (*ProcessingResult, error) {
 	// Pass 1: Analysis
 	if progressCallback != nil {
-		progressCallback(PassAnalysis, "Analyzing", 0.0, 0.0, nil)
+		progressCallback(ProgressUpdate{
+			Pass:     PassAnalysis,
+			PassName: "Analyzing",
+		})
 	}
 
 	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
@@ -77,7 +88,12 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	}
 
 	if progressCallback != nil {
-		progressCallback(PassAnalysis, "Analyzing", 1.0, 0.0, measurements)
+		progressCallback(ProgressUpdate{
+			Pass:         PassAnalysis,
+			PassName:     "Analyzing",
+			Progress:     1.0,
+			Measurements: measurements,
+		})
 	}
 
 	// Adapt filter configuration based on Pass 1 measurements
@@ -88,7 +104,11 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 
 	// Pass 2: Processing
 	if progressCallback != nil {
-		progressCallback(PassProcessing, "Processing", 0.0, 0.0, measurements)
+		progressCallback(ProgressUpdate{
+			Pass:         PassProcessing,
+			PassName:     "Processing",
+			Measurements: measurements,
+		})
 	}
 
 	outputPath, err := processorCreateSiblingTempPath(inputPath, "processing")
@@ -115,7 +135,12 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback f
 	}
 
 	if progressCallback != nil {
-		progressCallback(PassProcessing, "Processing", 1.0, 0.0, measurements)
+		progressCallback(ProgressUpdate{
+			Pass:         PassProcessing,
+			PassName:     "Processing",
+			Progress:     1.0,
+			Measurements: measurements,
+		})
 	}
 
 	// Measure silence and speech regions in Pass 2 output (before normalisation) for comparison
@@ -214,7 +239,7 @@ type ProcessingResult struct {
 // Applies the filter chain built by BuildFilterSpec() which includes asendcmd for noise profile learning
 // when NoiseProfileStart/End timestamps are set in the config.
 // If outputMeasurements is non-nil, populates it with Pass 2 output analysis.
-func processWithFilters(inputPath, outputPath string, config *EffectiveFilterConfig, progressCallback func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements), measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) (InputMetadata, error) {
+func processWithFilters(inputPath, outputPath string, config *EffectiveFilterConfig, progressCallback ProgressCallback, measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) (InputMetadata, error) {
 	// Open input audio file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
@@ -286,7 +311,13 @@ func processWithFilters(inputPath, outputPath string, config *EffectiveFilterCon
 				if progress > 1.0 {
 					progress = 1.0
 				}
-				progressCallback(PassProcessing, "Processing", progress, currentLevel, measurements)
+				progressCallback(ProgressUpdate{
+					Pass:         PassProcessing,
+					PassName:     "Processing",
+					Progress:     progress,
+					Level:        currentLevel,
+					Measurements: measurements,
+				})
 			}
 		},
 		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) error {

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -432,24 +432,57 @@ func TestEffectiveConfigFilterOrderIsolation(t *testing.T) {
 	}
 }
 
-func TestProcessorSeedParameterOwnershipBoundary(t *testing.T) {
+func TestProcessorSeedAndProgressCallbackBoundaries(t *testing.T) {
+	progressCallbackType := reflect.TypeFor[ProgressCallback]()
+
 	tests := []struct {
-		name       string
-		fn         any
-		configArg  int
-		parameters int
+		name        string
+		fn          any
+		configArg   int
+		progressArg int
+		parameters  int
 	}{
 		{
-			name:       "ProcessAudio",
-			fn:         ProcessAudio,
-			configArg:  1,
-			parameters: 3,
+			name:        "ProcessAudio",
+			fn:          ProcessAudio,
+			configArg:   1,
+			progressArg: 2,
+			parameters:  3,
 		},
 		{
-			name:       "AnalyzeOnlyDetailed",
-			fn:         AnalyzeOnlyDetailed,
-			configArg:  1,
-			parameters: 3,
+			name:        "AnalyzeOnlyDetailed",
+			fn:          AnalyzeOnlyDetailed,
+			configArg:   1,
+			progressArg: 2,
+			parameters:  3,
+		},
+		{
+			name:        "AnalyzeAudio",
+			fn:          AnalyzeAudio,
+			configArg:   1,
+			progressArg: 2,
+			parameters:  3,
+		},
+		{
+			name:        "processWithFilters",
+			fn:          processWithFilters,
+			configArg:   2,
+			progressArg: 3,
+			parameters:  6,
+		},
+		{
+			name:        "measureWithLoudnorm",
+			fn:          measureWithLoudnorm,
+			configArg:   1,
+			progressArg: 3,
+			parameters:  4,
+		},
+		{
+			name:        "ApplyNormalisation",
+			fn:          ApplyNormalisation,
+			configArg:   1,
+			progressArg: 4,
+			parameters:  5,
 		},
 	}
 
@@ -461,7 +494,71 @@ func TestProcessorSeedParameterOwnershipBoundary(t *testing.T) {
 			}
 
 			assertSeedConfigTypeCannotOwnPerFileState(t, typ.In(tt.configArg))
+
+			if typ.In(tt.progressArg) != progressCallbackType {
+				t.Fatalf("%s progress callback parameter = %s, want %s",
+					tt.name, typ.In(tt.progressArg), progressCallbackType)
+			}
 		})
+	}
+}
+
+func TestProgressUpdateTypeShape(t *testing.T) {
+	typ := reflect.TypeFor[ProgressUpdate]()
+
+	tests := []struct {
+		name string
+		want reflect.Type
+	}{
+		{name: "Pass", want: reflect.TypeFor[PassNumber]()},
+		{name: "PassName", want: reflect.TypeFor[string]()},
+		{name: "Progress", want: reflect.TypeFor[float64]()},
+		{name: "Level", want: reflect.TypeFor[float64]()},
+		{name: "Measurements", want: reflect.TypeFor[*AudioMeasurements]()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field, ok := typ.FieldByName(tt.name)
+			if !ok {
+				t.Fatalf("ProgressUpdate has no %s field", tt.name)
+			}
+			if field.Type != tt.want {
+				t.Fatalf("ProgressUpdate.%s = %s, want %s", tt.name, field.Type, tt.want)
+			}
+		})
+	}
+}
+
+func TestProgressCallbackTypeCompiles(t *testing.T) {
+	measurements := &AudioMeasurements{}
+	var got ProgressUpdate
+
+	var callback ProgressCallback = func(update ProgressUpdate) {
+		got = update
+	}
+	callback(ProgressUpdate{
+		Pass:         PassAnalysis,
+		PassName:     "Analyzing",
+		Progress:     0.5,
+		Level:        -18.0,
+		Measurements: measurements,
+	})
+
+	if got.Pass != PassAnalysis {
+		t.Fatalf("callback Pass = %d, want %d", got.Pass, PassAnalysis)
+	}
+	if got.PassName != "Analyzing" {
+		t.Fatalf("callback PassName = %q, want %q", got.PassName, "Analyzing")
+	}
+	if got.Progress != 0.5 {
+		t.Fatalf("callback Progress = %.2f, want 0.50", got.Progress)
+	}
+	if got.Level != -18.0 {
+		t.Fatalf("callback Level = %.2f, want -18.00", got.Level)
+	}
+	if got.Measurements != measurements {
+		t.Fatal("callback Measurements did not preserve pointer")
 	}
 }
 
@@ -536,7 +633,7 @@ func TestProcessAudio(t *testing.T) {
 	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
 
 	// Process the audio with a no-op progress callback
-	result, err := ProcessAudio(testFile, config, func(pass PassNumber, passName string, progress float64, level float64, measurements *AudioMeasurements) {
+	result, err := ProcessAudio(testFile, config, func(update ProgressUpdate) {
 		// No-op for tests
 	})
 	if err != nil {

--- a/internal/processor/progress.go
+++ b/internal/processor/progress.go
@@ -1,0 +1,14 @@
+package processor
+
+// ProgressUpdate describes a processor progress event without depending on UI
+// message types.
+type ProgressUpdate struct {
+	Pass         PassNumber
+	PassName     string
+	Progress     float64
+	Level        float64
+	Measurements *AudioMeasurements
+}
+
+// ProgressCallback receives processor progress events.
+type ProgressCallback func(ProgressUpdate)


### PR DESCRIPTION
- Add `ProgressUpdate` and `ProgressCallback` to carry progress data in one value
- Move UI message mapping into `cmd/jivetalking/main.go`
- Remove the temporary legacy adapter and update processor call sites
- Add boundary tests for callback shape and progress event fields