### PR TITLE
fix(processor): round LUFS value in output filenames

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -189,7 +189,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 	}
 
 	// Rename output file to include LUFS value: <name>-processed.<ext> → <name>-LUFS-NN-processed.<ext>
-	lufsValue := int(math.Abs(result.OutputLUFS))
+	lufsValue := lufsFilenameValue(result.OutputLUFS)
 	finalPath := generateLUFSOutputPath(inputPath, lufsValue)
 	if err := renameNoClobber(outputPath, finalPath); err != nil {
 		return nil, fmt.Errorf("failed to publish output: %w", err)
@@ -367,4 +367,8 @@ func generateLUFSOutputPath(inputPath string, lufsValue int) string {
 	filename := filepath.Base(inputPath)
 	nameWithoutExt := strings.TrimSuffix(filename, filepath.Ext(filename))
 	return filepath.Join(dir, fmt.Sprintf("%s-LUFS-%d-processed.flac", nameWithoutExt, lufsValue))
+}
+
+func lufsFilenameValue(outputLUFS float64) int {
+	return int(math.Round(math.Abs(outputLUFS)))
 }

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -39,6 +39,28 @@ func TestGenerateLUFSOutputPath(t *testing.T) {
 	}
 }
 
+func TestLUFSFilenameValueRoundsNearestWhole(t *testing.T) {
+	cases := []struct {
+		name string
+		lufs float64
+		want int
+	}{
+		{"round down", -16.4, 16},
+		{"half rounds up", -16.5, 17},
+		{"round up", -16.6, 17},
+		{"positive value", 15.5, 16},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lufsFilenameValue(tc.lufs)
+			if got != tc.want {
+				t.Errorf("lufsFilenameValue(%v) = %d, want %d", tc.lufs, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCreateSiblingTempPath(t *testing.T) {
 	dir := t.TempDir()
 	targetPath := filepath.Join(dir, "presenter.wav")


### PR DESCRIPTION
- Use nearest whole LUFS value when generating processed file names
- Add coverage for rounding down, half-up, and positive LUFS inputs