### PR TITLE
fix(processor): insert aresample between loudnorm and adeclick in Pass 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ internal/
 1. **Pass 1 (Analysis):** Measures LUFS, true peak, LRA, noise floor, spectral characteristics; detects room-tone/speech regions via 250ms interval sampling
 2. **Pass 2 (Processing):** Applies adaptive filter chain tuned to measurements; output measured for before/after comparison
 3. **Pass 3 (Measuring):** Optionally prepends `volume` (pre-gain) + `alimiter` (Volumax) when limiting is active, then runs loudnorm in measurement mode (JSON output via FFmpeg log capture) to get input stats for linear mode; measures the post-limiter signal so `measured_I`/`measured_TP` are accurate
-4. **Pass 4 (Normalising):** Applies `volume` (pre-gain, when ceiling clamped) + `alimiter` (Volumax) + `loudnorm` (linear mode) + `adeclick`; pre-gain raises very quiet recordings so the alimiter can use a viable ceiling; `alimiter` creates headroom so loudnorm achieves full linear gain to reach -16 LUFS
+4. **Pass 4 (Normalising):** Applies `volume` (pre-gain, when ceiling clamped) + `alimiter` (Volumax) + `loudnorm` (linear mode) + `aresample` (source rate) + `adeclick`; pre-gain raises very quiet recordings so the alimiter can use a viable ceiling; `alimiter` creates headroom so loudnorm achieves full linear gain to reach -16 LUFS
 
 **Filter chain order (Pass 2):**
 ```
@@ -72,12 +72,12 @@ Order rationale: downmix to mono first; HP/LP removes frequency extremes before 
 
 **Noise removal default:** Production uses `anlmdn_production_current`: `anlmdn` runs at the source sample rate with `r=0.0020` (`r_min`) and `m=3` (`m_strict`), followed by `compand` for residual suppression when a noise profile is available. No sample-rate cap or exit restore - downstream filters (gate, LA-2A, de-esser, analysis) operate at the source rate throughout. The matrix spike at `.bench/anlmdn-matrix-spike` validated this path against the previous 32 kHz cap default (`r=0.0045`, `m=11`) at ~35 % faster Pass 2 with metric-equivalent quality. In benchmark context, refer to the 0.3.1 historical path as `anlmdn_legacy_default`.
 
-**Adeclick default:** Production uses `adeclick=t=2.0:w=55:o=50:m=s` (spline interpolation, halved overlap vs prior default) for ~75% Pass 4 runtime reduction at metric-parity quality; the gentle limiter attack keeps source clicks below the relaxed threshold. In benchmark context, refer to the production path as `adeclick_current_t_2_0_w_55_o_50_m_s`. No legacy variant is retained in the matrix.
+**Adeclick default:** Production uses `adeclick=t=2.0:w=55:o=50:m=s` (spline interpolation, halved overlap vs prior default) for ~75% Pass 4 runtime reduction at metric-parity quality; the gentle limiter attack keeps source clicks below the relaxed threshold. In benchmark context, refer to the production path as `adeclick_current_t_2_0_w_55_o_50_m_s`. No legacy variant is retained in the matrix. Note: adeclick runs at the source sample rate via an `aresample` inserted before it; loudnorm in linear mode emits at 192 kHz internally, and running adeclick at that rate quadrupled its sample count - the dominant Pass 4 cost on long files until the resample was added.
 
 **Normalisation (Pass 3/4):**
 ```
 Pass 3: [volume (pre-gain, when clamped) → alimiter (Volumax)] → loudnorm (measure-only, print_format=json) → captures LoudnormStats JSON
-Pass 4: volume (pre-gain, when clamped) → alimiter (Volumax, peak reduction) → loudnorm (linear mode, input stats from Pass 3) → adeclick
+Pass 4: volume (pre-gain, when clamped) → alimiter (Volumax, peak reduction) → loudnorm (linear mode, input stats from Pass 3) → aresample (source rate) → adeclick
 ```
 
 **Output filename:** `<name>-LUFS-NN-processed.<ext>` where NN is the truncated (not rounded) absolute LUFS value of the final output (e.g., -26.8 LUFS produces `LUFS-26`).

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -483,4 +483,40 @@ The `r_half_m_strict` / `r_half_m_relax` "compensation" hypothesis was wrong. `m
 
 ---
 
-Document compiled May 2026; end-to-end comparison (§6) added May 2026. The working investigation notes, the per-filter benchmark Go fixtures, and the `bench-anlmdn-*` / `bench-adeclick-*` justfile recipes have been retired. Their reasoning is preserved here.
+---
+
+## 8. Pass 4 rate discovery: loudnorm linear mode emits at 192 kHz
+
+*Added May 2026.*
+
+After the §5 adeclick tuning shipped, a long-file timing observation exposed a previously unknown rate issue in Pass 4. A 49-minute file projected Pass 4 at 9-20 minutes; after the fix it completed in ~1m29s. The §5 matrix had not isolated sample rate as a variable, so the dominant cost was invisible during tuning.
+
+### 8.1 The discovery
+
+FFmpeg's `loudnorm` filter in `linear=true` mode upsamples internally to 192 kHz and **emits at 192 kHz**. The §5 benchmark constructed each Pass 4 candidate graph as:
+
+```
+[volume + alimiter] → loudnorm → adeclick → astats → aspectralstats → ebur128 → resample
+```
+
+With no resample between `loudnorm` and `adeclick`, every filter after loudnorm received a 192 kHz stream for a 48 kHz source - 4× the sample count. The §5 runtime measurements were therefore accurate for the graph they tested, but the graph was processing adeclick (and the analysis tail) at a rate four times higher than the source rate the parameters were tuned for. The "~75% runtime reduction" reported in §5.6 was relative to the *previous* adeclick clause at 192 kHz, not relative to source-rate operation. In other words, §5 measured adeclick's speed at two different parameter settings, both at 192 kHz, and correctly found the new clause faster - it just never isolated the rate as a separate variable.
+
+### 8.2 The fix
+
+An `aresample` to the source sample rate is now inserted between `loudnorm` and `adeclick`:
+
+```
+volume (pre-gain, when clamped) → alimiter (Volumax) → loudnorm (linear) → aresample (source rate) → adeclick → astats → aspectralstats → ebur128 → resample
+```
+
+The adeclick parameters themselves are unchanged (`t=2.0:w=55:o=50:m=s`). The analysis filters (`astats`, `aspectralstats`, `ebur128`) also benefit: they now run at the source rate they were designed to see, matching the Pass 1 and Pass 2 measurement context.
+
+### 8.3 Measured impact
+
+On a 49-minute file, Pass 4 projected 9-20 minutes before the fix and completed in ~1m29s after. The per-60s-segment standalone Pass 4 chain (loudnorm + adeclick + analysis tail + resample) measured 4.21s → 0.94s, a 4.5× reduction.
+
+The adeclick quality parameters are unchanged; the fix removes a structural overhead that the §5 matrix did not observe.
+
+---
+
+Document compiled May 2026; end-to-end comparison (§6) added May 2026; Pass 4 rate discovery (§8) added May 2026. The working investigation notes, the per-filter benchmark Go fixtures, and the `bench-anlmdn-*` / `bench-adeclick-*` justfile recipes have been retired. Their reasoning is preserved here.

--- a/docs/FilterLimiter-CBS-Volumax.md
+++ b/docs/FilterLimiter-CBS-Volumax.md
@@ -196,7 +196,7 @@ The volume filter applies no dynamics processing, no lookahead, and creates no a
 volume (pre-gain) → alimiter → loudnorm → aresample (source rate) → adeclick → astats → aspectralstats → ebur128 → resample
 ```
 
-**Filter chain when not clamped (unchanged):**
+**Filter chain when not clamped (no pre-gain):**
 ```
 alimiter → loudnorm → aresample (source rate) → adeclick → astats → aspectralstats → ebur128 → resample
 ```

--- a/docs/FilterLimiter-CBS-Volumax.md
+++ b/docs/FilterLimiter-CBS-Volumax.md
@@ -193,12 +193,12 @@ The volume filter applies no dynamics processing, no lookahead, and creates no a
 
 **Filter chain when clamped:**
 ```
-volume (pre-gain) → alimiter → loudnorm → adeclick → astats → aspectralstats → ebur128 → resample
+volume (pre-gain) → alimiter → loudnorm → aresample (source rate) → adeclick → astats → aspectralstats → ebur128 → resample
 ```
 
 **Filter chain when not clamped (unchanged):**
 ```
-alimiter → loudnorm → adeclick → astats → aspectralstats → ebur128 → resample
+alimiter → loudnorm → aresample (source rate) → adeclick → astats → aspectralstats → ebur128 → resample
 ```
 
 ---

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -399,7 +399,7 @@ func buildFullbenchPass4ResampleFilter(config *EffectiveFilterConfig) string {
 func buildFullbenchProductionPass4SpecWithoutAdeclick(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	pass4Config := *config
 	pass4Config.Adeclick.Enabled = false
-	return buildLoudnormFilterSpec(&pass4Config, measurement, 0, 0, false)
+	return buildLoudnormFilterSpec(&pass4Config, measurement, 0, 0, false, 48000)
 }
 
 func extractFullbenchFilterClause(spec, prefix string) string {
@@ -554,7 +554,7 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 	productionConfig := *config
 	productionConfig.Adeclick.Enabled = false
 	productionClause := extractFullbenchFilterClause(
-		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false),
+		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false, 48000),
 		"loudnorm=",
 	)
 	benchmarkClause := buildFullbenchLoudnormClause(config, measurement)

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -702,7 +702,7 @@ func ApplyNormalisation(
 // applyLoudnormAndMeasure applies loudnorm's second pass to the audio file and measures the result.
 // Uses in-place processing: reads input, applies loudnorm, writes to temp file, renames.
 //
-// Filter chain: [volume+alimiter] → loudnorm → [adeclick] → astats → aspectralstats → ebur128 → resample
+// Filter chain: [volume+alimiter] → loudnorm → aresample → [adeclick] → astats → aspectralstats → ebur128 → resample
 //
 // This is the second pass of loudnorm's two-pass workflow. The first pass
 // measurements come from measureWithLoudnorm() (stored in LoudnormMeasurement).
@@ -753,6 +753,7 @@ func prepareLoudnormApplication(request loudnormApplicationRequest) (*loudnormAp
 		request.limiter.preGainDB,
 		request.limiter.ceilingDB,
 		request.limiter.needed,
+		metadata.SampleRate,
 	)
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := loudnormSetupFilterGraph(
 		reader.GetDecoderContext(),
@@ -796,12 +797,10 @@ func executeAndPublishLoudnormApplication(
 		}
 	}()
 
-	// Process frames and accumulate ebur128 measurements using Pass 2's extraction function
-	var framesProcessed int64
-
 	// Calculate total samples for accurate progress reporting
 	totalSamples := int64(prep.metadata.Duration * float64(prep.metadata.SampleRate))
 	var samplesProcessed int64
+	var inputFramesRead int64
 	const progressUpdateInterval = 100 // Send progress update every N frames
 
 	lenientHandler := func(err error) error { return nil }
@@ -809,7 +808,22 @@ func executeAndPublishLoudnormApplication(
 		OnPushError: lenientHandler,
 		OnPullError: lenientHandler,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
+			// Drive progress from input-frame consumption so the bar advances
+			// monotonically. loudnorm and adeclick drain output frames in large
+			// bursts, so reporting on output drain alone makes the bar stall then
+			// sweep. samplesProcessed and totalSamples are both at the input rate.
 			samplesProcessed += int64(inputFrame.NbSamples())
+			inputFramesRead++
+
+			if request.progress != nil && inputFramesRead%progressUpdateInterval == 0 {
+				progress := math.Min(0.99, float64(samplesProcessed)/float64(totalSamples))
+				request.progress(ProgressUpdate{
+					Pass:     PassNormalising,
+					PassName: "Normalising",
+					Progress: progress,
+					Level:    result.acc.ebur128OutputI,
+				})
+			}
 		},
 		OnFrame: func(inputFrame, filteredFrame *ffmpeg.AVFrame) error {
 			// Extract validation measurements using Pass 2's function
@@ -818,19 +832,6 @@ func executeAndPublishLoudnormApplication(
 			// Encode frame
 			if err := encoder.WriteFrame(filteredFrame); err != nil {
 				return fmt.Errorf("encoding failed: %w", err)
-			}
-
-			framesProcessed++
-
-			// Progress update periodically (every N output frames for smooth updates)
-			if request.progress != nil && framesProcessed%progressUpdateInterval == 0 {
-				progress := math.Min(0.99, float64(samplesProcessed)/float64(totalSamples))
-				request.progress(ProgressUpdate{
-					Pass:     PassNormalising,
-					PassName: "Normalising",
-					Progress: progress,
-					Level:    result.acc.ebur128OutputI,
-				})
 			}
 
 			return nil
@@ -928,7 +929,7 @@ func finalizeLoudnormOutputMeasurements(
 
 // buildLoudnormFilterSpec constructs the filter chain for Pass 4 loudnorm application.
 //
-// Chain order: [volume+alimiter] → loudnorm → [adeclick] → astats → aspectralstats → ebur128 → resample
+// Chain order: [volume+alimiter] → loudnorm → aresample → [adeclick] → astats → aspectralstats → ebur128 → resample
 //
 // The caller pre-computes preGainDB, ceiling, and needsLimiting from Pass 2 measurements.
 // This function builds the prefix via buildPreLimiterPrefix() and passes measurement.InputI
@@ -946,7 +947,7 @@ func finalizeLoudnormOutputMeasurements(
 //
 // Per ffmpeg-loudnorm-helper: the offset parameter MUST come from loudnorm's own
 // first pass measurement, not from external calculations.
-func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, preGainDB float64, ceiling float64, needsLimiting bool) string {
+func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, preGainDB float64, ceiling float64, needsLimiting bool, sourceSampleRate int) string {
 	var filters []string
 	loudnorm := config.Loudnorm
 
@@ -981,29 +982,38 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 	)
 	filters = append(filters, loudnormFilter)
 
-	// 3. adeclick for click/pop repair
+	// 3. Resample back to the source rate before adeclick.
+	// loudnorm's linear-mode true-peak limiter upsamples to 192kHz internally and
+	// emits at 192kHz. Downstream filters (adeclick, astats, aspectralstats, ebur128)
+	// would otherwise run at 4x the sample count. Resampling here restores the rate
+	// adeclick and the analysis filters were tuned for in Pass 2.
+	if sourceSampleRate > 0 {
+		filters = append(filters, fmt.Sprintf("aresample=%d", sourceSampleRate))
+	}
+
+	// 4. adeclick for click/pop repair
 	// Repairs waveform discontinuities from limiter/loudnorm gain transitions
 	// Must come after loudnorm (catches its clicks) and before measurement filters
 	if spec := config.buildAdeclickFilter(); spec != "" {
 		filters = append(filters, spec)
 	}
 
-	// 4. astats for amplitude measurements (same as Pass 2)
+	// 5. astats for amplitude measurements (same as Pass 2)
 	// Provides noise floor, dynamic range, RMS level, peak level, etc.
 	// measure_perchannel=all requests all available per-channel statistics
 	filters = append(filters, "astats=metadata=1:measure_perchannel=all")
 
-	// 5. aspectralstats for spectral analysis (same as Pass 2)
+	// 6. aspectralstats for spectral analysis (same as Pass 2)
 	// Provides centroid, spread, skewness, kurtosis, entropy, flatness, crest, rolloff, etc.
 	// win_size=2048 and win_func=hann match Pass 2 settings for comparable measurements
 	filters = append(filters, "aspectralstats=win_size=2048:win_func=hann:measure=all")
 
-	// 6. ebur128 for loudness validation (metadata only, no audio modification)
+	// 7. ebur128 for loudness validation (metadata only, no audio modification)
 	// dualmono=true ensures accurate mono loudness measurement
 	// Note: ebur128 upsamples to 192kHz internally and outputs f64
 	filters = append(filters, "ebur128=metadata=1:peak=sample+true:dualmono=true")
 
-	// 7. Resample back to output format (44.1kHz/s16/mono)
+	// 8. Resample back to output format (44.1kHz/s16/mono)
 	// Required because ebur128 outputs f64 at 192kHz; encoder expects s16 at 44.1kHz
 	filters = append(filters, config.buildRequiredOutputFormatFilter())
 

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -2160,7 +2160,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 				ceiling = reDerivedCeiling
 			}
 
-			filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, ceiling, needsLimiting)
+			filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, ceiling, needsLimiting, 48000)
 
 			// (a)/(b): Check volume filter presence
 			hasVolume := strings.Contains(filterSpec, "volume=")
@@ -2236,7 +2236,7 @@ func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 		TargetOffset: -0.5,
 	}
 
-	filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
+	filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000)
 
 	if config.Resample.Enabled {
 		t.Error("buildLoudnormFilterSpec mutated config.Resample.Enabled")
@@ -2260,7 +2260,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	t.Run("uses Pass 4 adeclick helper", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
+		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000)
 
 		const want = "adeclick=t=2.0:w=55:o=50:m=s"
 		if !strings.Contains(filterSpec, want) {
@@ -2272,10 +2272,63 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 		config.Adeclick.Enabled = false
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false)
+		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000)
 
 		if strings.Contains(filterSpec, "adeclick=") {
 			t.Errorf("buildLoudnormFilterSpec() emitted disabled adeclick\nfilterSpec: %s", filterSpec)
+		}
+	})
+}
+
+func TestBuildLoudnormFilterSpecSourceRateResample(t *testing.T) {
+	measurement := &LoudnormMeasurement{
+		InputI:       -24.0,
+		InputTP:      -5.0,
+		InputLRA:     6.0,
+		InputThresh:  -34.0,
+		TargetOffset: -0.5,
+	}
+
+	// Pins source-rate derivation against a NON-48000 rate so a future refactor
+	// that hardcodes 48000 (instead of deriving from metadata) or drops the
+	// param is caught. The resample must sit after loudnorm and immediately
+	// before adeclick.
+	t.Run("derives resample rate and orders it between loudnorm and adeclick", func(t *testing.T) {
+		config := defaultNormalisationTestConfig()
+
+		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 96000)
+
+		const wantResample = "aresample=96000"
+		if !strings.Contains(filterSpec, wantResample) {
+			t.Fatalf("buildLoudnormFilterSpec() missing %q (hardcoded 48000?)\nfilterSpec: %s", wantResample, filterSpec)
+		}
+		if strings.Contains(filterSpec, "aresample=48000") {
+			t.Fatalf("buildLoudnormFilterSpec() emitted hardcoded aresample=48000 for 96000 source rate\nfilterSpec: %s", filterSpec)
+		}
+
+		loudnormAt := strings.Index(filterSpec, "loudnorm=")
+		resampleAt := strings.Index(filterSpec, wantResample)
+		adeclickAt := strings.Index(filterSpec, "adeclick=")
+		if loudnormAt < 0 || resampleAt < 0 || adeclickAt < 0 {
+			t.Fatalf("missing a required stage (loudnorm=%d aresample=%d adeclick=%d)\nfilterSpec: %s", loudnormAt, resampleAt, adeclickAt, filterSpec)
+		}
+		if loudnormAt >= resampleAt || resampleAt >= adeclickAt {
+			t.Fatalf("stage order = loudnorm@%d, aresample@%d, adeclick@%d, want loudnorm < aresample < adeclick\nfilterSpec: %s", loudnormAt, resampleAt, adeclickAt, filterSpec)
+		}
+	})
+
+	// Pins the sourceSampleRate <= 0 guard: no resample stage emitted, adeclick
+	// still present.
+	t.Run("omits resample when source rate is zero", func(t *testing.T) {
+		config := defaultNormalisationTestConfig()
+
+		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 0)
+
+		if strings.Contains(filterSpec, "aresample=") {
+			t.Fatalf("buildLoudnormFilterSpec() emitted aresample for zero source rate\nfilterSpec: %s", filterSpec)
+		}
+		if !strings.Contains(filterSpec, "adeclick=") {
+			t.Fatalf("buildLoudnormFilterSpec() dropped adeclick when source rate is zero\nfilterSpec: %s", filterSpec)
 		}
 	})
 }
@@ -2291,7 +2344,7 @@ func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 
 	base := defaultNormalisationTestConfig()
 	assertNoStaleEffectiveConfigFields(t)
-	controlSpec := buildLoudnormFilterSpec(base, measurement, 0, -1.0, false)
+	controlSpec := buildLoudnormFilterSpec(base, measurement, 0, -1.0, false, 48000)
 
 	withUnrelatedFilterFields := *base
 	withUnrelatedFilterFields.FilterOrder = []FilterID{FilterAnalysis}
@@ -2299,7 +2352,7 @@ func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 	withUnrelatedFilterFields.DS201Gate.Ratio = 4.0
 	withUnrelatedFilterFields.LA2A.Threshold = -30.0
 
-	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, 0, -1.0, false)
+	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, 0, -1.0, false, 48000)
 	if gotSpec != controlSpec {
 		t.Fatalf("buildLoudnormFilterSpec() changed when unrelated filter fields changed\ncontrol: %s\ngot:     %s", controlSpec, gotSpec)
 	}
@@ -2504,7 +2557,7 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 				bCeiling = bReDerived
 			}
 
-			filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, bCeiling, bNeeded)
+			filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, bCeiling, bNeeded, 48000)
 			if !bClamped {
 				t.Error("expected pre-computation to report clamped")
 			}
@@ -2691,7 +2744,7 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 			},
 			wantPass3:      "",
 			wantPass4Start: "loudnorm=",
-			wantPass4:      "loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-20.00:measured_TP=-10.00:measured_LRA=5.00:measured_thresh=-30.00:offset=0.00:dual_mono=true:linear=true:print_format=json,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+			wantPass4:      "loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-20.00:measured_TP=-10.00:measured_LRA=5.00:measured_thresh=-30.00:offset=0.00:dual_mono=true:linear=true:print_format=json,aresample=48000,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
 		},
 		{
 			name:     "limited",
@@ -2706,7 +2759,7 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 			},
 			wantPass3:      "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
 			wantPass4Start: "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
-			wantPass4:      "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-24.90:measured_TP=-5.00:measured_LRA=6.00:measured_thresh=-35.00:offset=-0.50:dual_mono=true:linear=true:print_format=json,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+			wantPass4:      "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-24.90:measured_TP=-5.00:measured_LRA=6.00:measured_thresh=-35.00:offset=-0.50:dual_mono=true:linear=true:print_format=json,aresample=48000,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
 		},
 		{
 			name:     "clamped pre-gain",
@@ -2721,7 +2774,7 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 			},
 			wantPass3:      "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
 			wantPass4Start: "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
-			wantPass4:      "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-36.50:measured_TP=-24.00:measured_LRA=8.00:measured_thresh=-46.50:offset=-2.50:dual_mono=true:linear=true:print_format=json,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+			wantPass4:      "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-36.50:measured_TP=-24.00:measured_LRA=8.00:measured_thresh=-46.50:offset=-2.50:dual_mono=true:linear=true:print_format=json,aresample=48000,adeclick=t=2.0:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
 		},
 	}
 
@@ -2744,6 +2797,7 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 				limiter.preGainDB,
 				limiter.ceilingDB,
 				limiter.needed,
+				48000,
 			)
 			if !strings.HasPrefix(gotPass4, tt.wantPass4Start) {
 				t.Fatalf("pass 4 filter spec prefix = %q, want prefix %q", gotPass4, tt.wantPass4Start)


### PR DESCRIPTION
loudnorm in linear mode upsamples internally to 192 kHz and emits at that rate. Without resampling back to source rate, adeclick and downstream analysis filters processed 4× sample count, causing ~4.5× slowdown on Pass 4.

- Add sourceSampleRate parameter to buildLoudnormFilterSpec(), guard aresample
- Move Pass 4 progress reporting to OnInputFrame for steady cadence
- Add TestBuildLoudnormFilterSpecSourceRateResample guard test (two subtests)
- Update docs and AGENTS.md with rate discovery and impact analysis

Measured impact: 4.21s → 0.94s per 60s segment (4.5× faster).