### PR TITLE
refactor(processor): remove global DebugLog and thread logger through call chains

### DIFF
--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -118,8 +118,8 @@ func main() {
 		}
 	}
 
-	// Set the processor package's debug log function to use the same log
-	processor.DebugLog = log
+	// Set the config's debug log function to use the same log
+	config.SetLogger(log)
 
 	// Handle analysis-only mode: run Pass 1 and display results, skip TUI
 	if cliArgs.AnalysisOnly {

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -112,7 +112,7 @@ func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) (*Ef
 
 	tuneDS201Gate(effectiveConfig, diagnostics, measurements) // DS201-style soft expander gate
 	tuneDeesser(effectiveConfig, measurements)
-	tuneLA2ACompressor(effectiveConfig, diagnostics, measurements)
+	tuneLA2ACompressor(effectiveConfig, diagnostics, measurements, config.logger)
 	// tuneVolumaxLimiter removed - limiter moved to Pass 4, tuned from Pass 3 measurements
 
 	// Final safety checks

--- a/internal/processor/adaptive_la2a.go
+++ b/internal/processor/adaptive_la2a.go
@@ -119,8 +119,8 @@ type la2aOverrides struct {
 //
 // This implementation uses spectral measurements to emulate program-dependent
 // behaviour that the optical T4 cell provides naturally.
-func tuneLA2ACompressor(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
-	overrides := applyHighCrestOverrides(config, diagnostics, measurements)
+func tuneLA2ACompressor(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements, log debugLogger) {
+	overrides := applyHighCrestOverrides(config, diagnostics, measurements, log)
 	tuneLA2AAttack(config, measurements)
 	tuneLA2ARelease(config, measurements, overrides)
 	tuneLA2ARatio(config, measurements, overrides)
@@ -138,9 +138,9 @@ func tuneLA2ACompressor(config *EffectiveFilterConfig, diagnostics *AdaptiveDiag
 //
 // Diagnostic fields are always populated (active or not) when diagnostics is non-nil.
 // Returns zero-value la2aOverrides when no overrides are needed (deficit <= 0).
-func applyHighCrestOverrides(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) la2aOverrides {
+func applyHighCrestOverrides(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements, log debugLogger) la2aOverrides {
 	if measurements.SpeechProfile == nil {
-		debugLog("high-crest: SpeechProfile is nil, using full-file InputI/InputTP for deficit calculation")
+		log.Logf("high-crest: SpeechProfile is nil, using full-file InputI/InputTP for deficit calculation")
 	}
 
 	// Deficit calculation

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -2513,7 +2513,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 					SpeechProfile: tt.speechProfile,
 				}
 
-				overrides := applyHighCrestOverrides(config, diagnostics, measurements)
+				overrides := applyHighCrestOverrides(config, diagnostics, measurements, nil)
 
 				if diagnostics.LA2AHighCrestActive != tt.wantActive {
 					t.Errorf("LA2AHighCrestActive = %v, want %v", diagnostics.LA2AHighCrestActive, tt.wantActive)
@@ -2584,7 +2584,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 					SpeechProfile: &SpeechCandidateMetrics{},
 				}
 
-				overrides := applyHighCrestOverrides(config, diagnostics, measurements)
+				overrides := applyHighCrestOverrides(config, diagnostics, measurements, nil)
 
 				assertClose(t, "ThresholdFloor", overrides.ThresholdFloor, tt.wantThresholdFloor, 0.01)
 				assertClose(t, "RatioFloor", overrides.RatioFloor, tt.wantRatioFloor, 0.01)
@@ -2624,7 +2624,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 				SpeechProfile: &SpeechCandidateMetrics{},
 			}
 
-			applyHighCrestOverrides(config, diagnostics, measurements)
+			applyHighCrestOverrides(config, diagnostics, measurements, nil)
 
 			assertClose(t, "deficit", diagnostics.LA2AHighCrestDeficit, tt.wantDeficit, 0.01)
 			assertClose(t, "severity", diagnostics.LA2AHighCrestSeverity, tt.wantSeverity, 0.001)
@@ -2643,7 +2643,7 @@ func TestApplyHighCrestOverrides(t *testing.T) {
 			SpeechProfile: &SpeechCandidateMetrics{},
 		}
 
-		applyHighCrestOverrides(config, diagnostics, measurements)
+		applyHighCrestOverrides(config, diagnostics, measurements, nil)
 
 		if diagnostics.LA2AHighCrestActive {
 			t.Error("expected LA2AHighCrestActive=false for Marius-like input")
@@ -2697,7 +2697,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 			SpeechProfile: speechProfile,
 		}
 
-		tuneLA2ACompressor(config, diagnostics, measurements)
+		tuneLA2ACompressor(config, diagnostics, measurements, nil)
 
 		// Diagnostic fields must be set
 		if !diagnostics.LA2AHighCrestActive {
@@ -2748,7 +2748,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		}
 
 		// Run once with the full tuner chain
-		tuneLA2ACompressor(config, diagnostics, measurements)
+		tuneLA2ACompressor(config, diagnostics, measurements, nil)
 
 		if diagnostics.LA2AHighCrestActive {
 			t.Error("expected LA2AHighCrestActive=false for Marius-like input")
@@ -2766,7 +2766,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 		config2 := newTestConfig()
 		config2.Loudnorm.TargetTP = -2.0
 		diagnostics2 := &AdaptiveDiagnostics{}
-		tuneLA2ACompressor(config2, diagnostics2, measurements)
+		tuneLA2ACompressor(config2, diagnostics2, measurements, nil)
 		assertNoStaleEffectiveConfigFields(t)
 
 		assertClose(t, "ratio", ratioWithOverrides, config2.LA2A.Ratio, 0.001)
@@ -2808,7 +2808,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 					SpeechProfile: speechProfile,
 				}
 
-				tuneLA2ACompressor(config, diagnostics, measurements)
+				tuneLA2ACompressor(config, diagnostics, measurements, nil)
 
 				if diagnostics.LA2AHighCrestActive {
 					t.Errorf("deficit > 0 (%.2f) with hot InputTP (%.1f dBTP) - invariant violated",
@@ -2837,7 +2837,7 @@ func TestTuneLA2ACompressorHighCrest(t *testing.T) {
 			SpeechProfile: speechProfile,
 		}
 
-		tuneLA2ACompressor(config, diagnostics, measurements)
+		tuneLA2ACompressor(config, diagnostics, measurements, nil)
 
 		if !diagnostics.LA2AHighCrestActive {
 			t.Fatal("expected LA2AHighCrestActive=true for maximum severity input")

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -10,15 +10,14 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
 
-// DebugLog is a package-level function for debug logging.
-// When set (non-nil), diagnostic output is written via this function.
-// Set by main.go when --debug flag is enabled.
-var DebugLog func(format string, args ...any)
+// debugLogger is a config-borne debug logging function threaded through the
+// processor.
+type debugLogger func(format string, args ...any)
 
-// debugLog writes to the debug log if enabled, otherwise does nothing.
-func debugLog(format string, args ...any) {
-	if DebugLog != nil {
-		DebugLog(format, args...)
+// Logf writes to the logger if non-nil, otherwise does nothing.
+func (l debugLogger) Logf(format string, args ...any) {
+	if l != nil {
+		l(format, args...)
 	}
 }
 
@@ -285,8 +284,8 @@ func AnalyzeAudio(filename string, config *BaseFilterConfig, progressCallback Pr
 		return nil, err
 	}
 
-	noiseSelection := selectNoiseProfile(measurements, intervals, silenceIntervals, silMedians)
-	selectSpeechProfile(measurements, intervals, noiseSelection)
+	noiseSelection := selectNoiseProfile(measurements, intervals, silenceIntervals, silMedians, config.logger)
+	selectSpeechProfile(measurements, intervals, noiseSelection, config.logger)
 
 	assignInputMeasurementSuggestions(measurements)
 
@@ -298,10 +297,10 @@ type noiseProfileSelection struct {
 	noiseProfile   *NoiseProfile
 }
 
-func selectNoiseProfile(measurements *AudioMeasurements, intervals, silenceIntervals []IntervalSample, silMedians silenceMedians) noiseProfileSelection {
+func selectNoiseProfile(measurements *AudioMeasurements, intervals, silenceIntervals []IntervalSample, silMedians silenceMedians, log debugLogger) noiseProfileSelection {
 	measurements.RoomToneRegions = findRoomToneCandidatesFromIntervals(silenceIntervals, measurements.RoomToneDetectLevel, silMedians)
 
-	roomToneResult := findBestRoomToneRegion(measurements.RoomToneRegions, silenceIntervals)
+	roomToneResult := findBestRoomToneRegion(measurements.RoomToneRegions, silenceIntervals, log)
 	measurements.RoomToneCandidates = roomToneResult.Candidates
 	measurements.VoiceActivated = detectVoiceActivated(roomToneResult.Candidates)
 
@@ -336,7 +335,7 @@ func selectNoiseProfile(measurements *AudioMeasurements, intervals, silenceInter
 	return selection
 }
 
-func selectSpeechProfile(measurements *AudioMeasurements, intervals []IntervalSample, noiseSelection noiseProfileSelection) {
+func selectSpeechProfile(measurements *AudioMeasurements, intervals []IntervalSample, noiseSelection noiseProfileSelection, log debugLogger) {
 	speechSearchStart := 30 * time.Second
 	switch {
 	case noiseSelection.roomToneResult != nil && noiseSelection.roomToneResult.BestRegion != nil:
@@ -347,7 +346,7 @@ func selectSpeechProfile(measurements *AudioMeasurements, intervals []IntervalSa
 
 	measurements.SpeechRegions = findSpeechCandidatesFromIntervals(intervals, speechSearchStart, measurements.VoiceActivated, measurements.RMSLevel, measurements.NoiseFloor)
 
-	speechResult := findBestSpeechRegion(measurements.SpeechRegions, intervals, noiseSelection.noiseProfile)
+	speechResult := findBestSpeechRegion(measurements.SpeechRegions, intervals, noiseSelection.noiseProfile, log)
 	measurements.SpeechCandidates = speechResult.Candidates
 
 	if speechResult.BestRegion == nil {

--- a/internal/processor/analyzer_candidates_room_tone_scoring.go
+++ b/internal/processor/analyzer_candidates_room_tone_scoring.go
@@ -144,7 +144,7 @@ func detectVoiceActivated(candidates []RoomToneCandidateMetrics) bool {
 //
 // Uses pre-collected interval data for measurements - no file re-reading required.
 // Returns an empty result if no suitable region is found.
-func findBestRoomToneRegion(regions []RoomToneRegion, intervals []IntervalSample) *findBestRoomToneRegionResult {
+func findBestRoomToneRegion(regions []RoomToneRegion, intervals []IntervalSample, log debugLogger) *findBestRoomToneRegionResult {
 	result := &findBestRoomToneRegionResult{}
 
 	if len(regions) == 0 {
@@ -186,7 +186,7 @@ func findBestRoomToneRegion(regions []RoomToneRegion, intervals []IntervalSample
 			}
 		}
 
-		score := scoreRoomToneCandidate(metrics)
+		score := scoreRoomToneCandidate(metrics, log)
 		metrics.Score = score
 
 		result.Candidates = append(result.Candidates, *metrics)
@@ -232,13 +232,13 @@ func findBestRoomToneRegion(regions []RoomToneRegion, intervals []IntervalSample
 // scoreRoomToneCandidate computes a composite score for a room tone region candidate.
 // Higher scores indicate better candidates for noise profiling.
 // Returns 0.0 for candidates that should be rejected (e.g., crosstalk detected).
-func scoreRoomToneCandidate(m *RoomToneCandidateMetrics) float64 {
+func scoreRoomToneCandidate(m *RoomToneCandidateMetrics, log debugLogger) float64 {
 	if m == nil {
 		return 0.0
 	}
 
 	if m.RMSLevel <= digitalSilenceRMSThreshold {
-		debugLog("scoreRoomToneCandidate: REJECTING candidate at %.3fs - RMS %.1f dBFS at or below %.1f dBFS threshold (digital silence)",
+		log.Logf("scoreRoomToneCandidate: REJECTING candidate at %.3fs - RMS %.1f dBFS at or below %.1f dBFS threshold (digital silence)",
 			m.Region.Start.Seconds(), m.RMSLevel, digitalSilenceRMSThreshold)
 		m.TransientWarning = fmt.Sprintf(
 			"rejected: RMS %.1f dBFS at or below %.1f dBFS threshold (digital silence from voice-activated recording)",
@@ -247,11 +247,11 @@ func scoreRoomToneCandidate(m *RoomToneCandidateMetrics) float64 {
 		return 0.0
 	}
 
-	isCrosstalk := isLikelyCrosstalk(m)
-	debugLog("scoreRoomToneCandidate: start=%.3fs, CrestFactor=%.2f dB, isCrosstalk=%v",
+	isCrosstalk := isLikelyCrosstalk(m, log)
+	log.Logf("scoreRoomToneCandidate: start=%.3fs, CrestFactor=%.2f dB, isCrosstalk=%v",
 		m.Region.Start.Seconds(), m.CrestFactor, isCrosstalk)
 	if isCrosstalk {
-		debugLog("scoreRoomToneCandidate: REJECTING candidate at %.3fs (returning score=0.0)", m.Region.Start.Seconds())
+		log.Logf("scoreRoomToneCandidate: REJECTING candidate at %.3fs (returning score=0.0)", m.Region.Start.Seconds())
 		m.TransientWarning = fmt.Sprintf(
 			"rejected: crosstalk detected (crest %.1f dB, centroid %.0f Hz)",
 			m.CrestFactor, m.Spectral.Centroid,
@@ -260,7 +260,7 @@ func scoreRoomToneCandidate(m *RoomToneCandidateMetrics) float64 {
 	}
 
 	if m.CrestFactor > silenceCrestFactorMax {
-		debugLog("scoreRoomToneCandidate: REJECTING candidate at %.3fs - crest factor %.1f dB exceeds %.1f dB threshold",
+		log.Logf("scoreRoomToneCandidate: REJECTING candidate at %.3fs - crest factor %.1f dB exceeds %.1f dB threshold",
 			m.Region.Start.Seconds(), m.CrestFactor, silenceCrestFactorMax)
 		m.TransientWarning = fmt.Sprintf(
 			"rejected: crest factor %.1f dB exceeds %.1f dB threshold (transient contamination)",
@@ -335,12 +335,12 @@ func calculateStabilityScore(intervals []IntervalSample) float64 {
 // isLikelyCrosstalk detects if a room tone candidate is likely crosstalk (leaked voice).
 // Returns true if centroid is in voice range AND has peaked/impulsive characteristics,
 // OR if the crest factor indicates severe transient contamination (centroid-independent).
-func isLikelyCrosstalk(m *RoomToneCandidateMetrics) bool {
+func isLikelyCrosstalk(m *RoomToneCandidateMetrics, log debugLogger) bool {
 	crestExceedsThreshold := m.CrestFactor > crosstalkPeakRMSGap
-	debugLog("isLikelyCrosstalk: CrestFactor=%.2f dB, threshold=%.2f dB, exceeds=%v",
+	log.Logf("isLikelyCrosstalk: CrestFactor=%.2f dB, threshold=%.2f dB, exceeds=%v",
 		m.CrestFactor, crosstalkPeakRMSGap, crestExceedsThreshold)
 	if crestExceedsThreshold {
-		debugLog("isLikelyCrosstalk: REJECTING candidate due to crest factor %.2f dB > %.2f dB threshold",
+		log.Logf("isLikelyCrosstalk: REJECTING candidate due to crest factor %.2f dB > %.2f dB threshold",
 			m.CrestFactor, crosstalkPeakRMSGap)
 		return true
 	}

--- a/internal/processor/analyzer_candidates_speech.go
+++ b/internal/processor/analyzer_candidates_speech.go
@@ -391,7 +391,7 @@ type findBestSpeechRegionResult struct {
 // contaminating spectral metrics with pauses.
 // The noiseProfile parameter enables SNR margin checking to penalise candidates
 // too close to the noise floor (where spectral metrics would be unreliable).
-func findBestSpeechRegion(regions []SpeechRegion, intervals []IntervalSample, noiseProfile *NoiseProfile) *findBestSpeechRegionResult {
+func findBestSpeechRegion(regions []SpeechRegion, intervals []IntervalSample, noiseProfile *NoiseProfile, log debugLogger) *findBestSpeechRegionResult {
 	result := &findBestSpeechRegionResult{}
 
 	if len(regions) == 0 {
@@ -424,7 +424,7 @@ func findBestSpeechRegion(regions []SpeechRegion, intervals []IntervalSample, no
 		if noiseProfile != nil {
 			snrMargin := metrics.RMSLevel - noiseProfile.MeasuredNoiseFloor
 			if snrMargin < minSNRMargin {
-				debugLog("Speech candidate at %.1fs has low SNR margin: %.1f dB < %.1f dB minimum",
+				log.Logf("Speech candidate at %.1fs has low SNR margin: %.1f dB < %.1f dB minimum",
 					candidate.Start.Seconds(), snrMargin, minSNRMargin)
 				// Apply penalty factor rather than rejecting outright
 				// This allows selection if no better candidates exist
@@ -433,7 +433,7 @@ func findBestSpeechRegion(regions []SpeechRegion, intervals []IntervalSample, no
 				metrics.Score = score
 			}
 		} else {
-			debugLog("SNR margin check skipped: no noise profile available")
+			log.Logf("SNR margin check skipped: no noise profile available")
 		}
 
 		// Store for reporting

--- a/internal/processor/analyzer_output.go
+++ b/internal/processor/analyzer_output.go
@@ -28,7 +28,7 @@ type regionMeasurements struct {
 // metrics for a time region in an already-opened audio file. This is the
 // shared implementation behind measureOutputRoomToneRegionFromReader and
 // measureOutputSpeechRegionFromReader.
-func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Duration) (*regionMeasurements, error) {
+func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Duration, log debugLogger) (*regionMeasurements, error) {
 	if start < 0 {
 		return nil, fmt.Errorf("invalid region: negative start time")
 	}
@@ -114,23 +114,23 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 		avg = spectralAcc.average(float64(spectralFrameCount))
 	}
 
-	debugLog("  Frames processed: %d", framesProcessed)
-	debugLog("  Spectral frames: %d", spectralFrameCount)
-	debugLog("  Final ebur128 values:")
-	debugLog("    momentaryLUFS: %f", momentaryLUFS)
-	debugLog("    shortTermLUFS: %f", shortTermLUFS)
-	debugLog("    truePeak: %f", truePeak)
-	debugLog("    samplePeak: %f", samplePeak)
-	debugLog("  Final astats values:")
-	debugLog("    rmsLevel: %f (found: %v)", rmsLevel, rmsLevelFound)
-	debugLog("    peakLevel: %f", peakLevel)
-	debugLog("  Averaged spectral values:")
-	debugLog("    spectralCentroid: %f", avg.Centroid)
-	debugLog("    spectralRolloff: %f", avg.Rolloff)
+	log.Logf("  Frames processed: %d", framesProcessed)
+	log.Logf("  Spectral frames: %d", spectralFrameCount)
+	log.Logf("  Final ebur128 values:")
+	log.Logf("    momentaryLUFS: %f", momentaryLUFS)
+	log.Logf("    shortTermLUFS: %f", shortTermLUFS)
+	log.Logf("    truePeak: %f", truePeak)
+	log.Logf("    samplePeak: %f", samplePeak)
+	log.Logf("  Final astats values:")
+	log.Logf("    rmsLevel: %f (found: %v)", rmsLevel, rmsLevelFound)
+	log.Logf("    peakLevel: %f", peakLevel)
+	log.Logf("  Averaged spectral values:")
+	log.Logf("    spectralCentroid: %f", avg.Centroid)
+	log.Logf("    spectralRolloff: %f", avg.Rolloff)
 
 	ebur128Valid := momentaryLUFS != 0.0 || shortTermLUFS != 0.0 || truePeak != 0.0
 	if !ebur128Valid {
-		debugLog("Warning: ebur128 measurements not captured (insufficient duration or warmup time)")
+		log.Logf("Warning: ebur128 measurements not captured (insufficient duration or warmup time)")
 	}
 
 	if crestFactor == 0.0 && rmsLevelFound && peakLevel != 0 {
@@ -158,16 +158,16 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 
 // measureOutputRoomToneRegionFromReader measures a room tone region and maps
 // the result to RoomToneCandidateMetrics.
-func measureOutputRoomToneRegionFromReader(reader *audio.Reader, region RoomToneRegion) (*RoomToneCandidateMetrics, error) {
-	debugLog("=== measureOutputRoomToneRegion: start=%.3fs, duration=%.3fs ===",
+func measureOutputRoomToneRegionFromReader(reader *audio.Reader, region RoomToneRegion, log debugLogger) (*RoomToneCandidateMetrics, error) {
+	log.Logf("=== measureOutputRoomToneRegion: start=%.3fs, duration=%.3fs ===",
 		region.Start.Seconds(), region.Duration.Seconds())
 
-	result, err := measureOutputRegionFromReader(reader, region.Start, region.Duration)
+	result, err := measureOutputRegionFromReader(reader, region.Start, region.Duration, log)
 	if err != nil {
 		return nil, err
 	}
 
-	debugLog("=== measureOutputRoomToneRegion SUMMARY ===")
+	log.Logf("=== measureOutputRoomToneRegion SUMMARY ===")
 
 	return &RoomToneCandidateMetrics{
 		Region:        region,
@@ -211,7 +211,7 @@ func extractRegionPair(m *AudioMeasurements) (*RoomToneRegion, *SpeechRegion) {
 //
 // Either region parameter may be nil to skip that measurement. Returns nil for
 // any skipped or failed measurement (non-fatal - matches existing behaviour).
-func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, speechRegion *SpeechRegion) (*RoomToneCandidateMetrics, *SpeechCandidateMetrics) {
+func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, speechRegion *SpeechRegion, log debugLogger) (*RoomToneCandidateMetrics, *SpeechCandidateMetrics) {
 	if roomToneRegion == nil && speechRegion == nil {
 		return nil, nil
 	}
@@ -219,7 +219,7 @@ func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, spe
 	// Open the output file once for both measurements
 	reader, _, err := audio.OpenAudioFile(outputPath)
 	if err != nil {
-		debugLog("Warning: Failed to open output file for region measurements: %v", err)
+		log.Logf("Warning: Failed to open output file for region measurements: %v", err)
 		return nil, nil
 	}
 	defer reader.Close()
@@ -227,9 +227,9 @@ func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, spe
 	// Measure room tone region first (if requested)
 	var roomToneMetrics *RoomToneCandidateMetrics
 	if roomToneRegion != nil {
-		roomToneMetrics, err = measureOutputRoomToneRegionFromReader(reader, *roomToneRegion)
+		roomToneMetrics, err = measureOutputRoomToneRegionFromReader(reader, *roomToneRegion, log)
 		if err != nil {
-			debugLog("Warning: Failed to measure room tone region: %v", err)
+			log.Logf("Warning: Failed to measure room tone region: %v", err)
 			// Non-fatal - continue to speech measurement
 		}
 	}
@@ -239,14 +239,14 @@ func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, spe
 		if roomToneRegion != nil {
 			// Only need to seek if we already read through the file for room tone
 			if err := reader.SeekTo(0); err != nil {
-				debugLog("Warning: Failed to seek for speech region measurement: %v", err)
+				log.Logf("Warning: Failed to seek for speech region measurement: %v", err)
 				return roomToneMetrics, nil
 			}
 		}
 
-		speechMetrics, err := measureOutputSpeechRegionFromReader(reader, *speechRegion)
+		speechMetrics, err := measureOutputSpeechRegionFromReader(reader, *speechRegion, log)
 		if err != nil {
-			debugLog("Warning: Failed to measure speech region: %v", err)
+			log.Logf("Warning: Failed to measure speech region: %v", err)
 			return roomToneMetrics, nil
 		}
 		return roomToneMetrics, speechMetrics
@@ -257,16 +257,16 @@ func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, spe
 
 // measureOutputSpeechRegionFromReader measures a speech region and maps
 // the result to SpeechCandidateMetrics.
-func measureOutputSpeechRegionFromReader(reader *audio.Reader, region SpeechRegion) (*SpeechCandidateMetrics, error) {
-	debugLog("=== measureOutputSpeechRegion: start=%.3fs, duration=%.3fs ===",
+func measureOutputSpeechRegionFromReader(reader *audio.Reader, region SpeechRegion, log debugLogger) (*SpeechCandidateMetrics, error) {
+	log.Logf("=== measureOutputSpeechRegion: start=%.3fs, duration=%.3fs ===",
 		region.Start.Seconds(), region.Duration.Seconds())
 
-	result, err := measureOutputRegionFromReader(reader, region.Start, region.Duration)
+	result, err := measureOutputRegionFromReader(reader, region.Start, region.Duration, log)
 	if err != nil {
 		return nil, err
 	}
 
-	debugLog("=== measureOutputSpeechRegion SUMMARY ===")
+	log.Logf("=== measureOutputSpeechRegion SUMMARY ===")
 
 	return &SpeechCandidateMetrics{
 		Region:        region,

--- a/internal/processor/analyzer_output_test.go
+++ b/internal/processor/analyzer_output_test.go
@@ -21,7 +21,7 @@ func measureOutputRoomToneRegion(outputPath string, region RoomToneRegion) (*Roo
 	}
 	defer reader.Close()
 
-	return measureOutputRoomToneRegionFromReader(reader, region)
+	return measureOutputRoomToneRegionFromReader(reader, region, nil)
 }
 
 // measureOutputSpeechRegion analyses a speech region in the output file
@@ -37,7 +37,7 @@ func measureOutputSpeechRegion(outputPath string, region SpeechRegion) (*SpeechC
 	}
 	defer reader.Close()
 
-	return measureOutputSpeechRegionFromReader(reader, region)
+	return measureOutputSpeechRegionFromReader(reader, region, nil)
 }
 
 func TestExtractRegionPair(t *testing.T) {

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -859,7 +859,7 @@ func TestFindBestRoomToneRegion_HighestScoreWinsAfterDip(t *testing.T) {
 
 	allIntervals := append(append(intervalsA, intervalsB...), intervalsC...)
 
-	result := findBestRoomToneRegion(regions, allIntervals)
+	result := findBestRoomToneRegion(regions, allIntervals, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -897,7 +897,7 @@ func TestFindBestRoomToneRegion_EarlierCandidatePreferredWithinTolerance(t *test
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestRoomToneRegion(regions, allIntervals)
+	result := findBestRoomToneRegion(regions, allIntervals, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -936,7 +936,7 @@ func TestFindBestRoomToneRegion_AllBelowMinAcceptableScoreFallsBack(t *testing.T
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestRoomToneRegion(regions, allIntervals)
+	result := findBestRoomToneRegion(regions, allIntervals, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected fallback BestRegion when candidates exist below minAcceptableScore")
@@ -974,7 +974,7 @@ func TestFindBestRoomToneRegion_AllRejectedCandidatesDoNotFallback(t *testing.T)
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestRoomToneRegion(regions, allIntervals)
+	result := findBestRoomToneRegion(regions, allIntervals, nil)
 
 	if result.BestRegion != nil {
 		t.Fatalf("BestRegion = %+v, want nil for all rejected candidates", result.BestRegion)
@@ -1000,7 +1000,7 @@ func TestFindBestRoomToneRegion_SingleAcceptableCandidateElected(t *testing.T) {
 	intervals := makeRoomToneTestIntervals(0, 10*time.Second,
 		-65.0, -60.0, 100.0, 0.8, 2.0, 0.0)
 
-	result := findBestRoomToneRegion(regions, intervals)
+	result := findBestRoomToneRegion(regions, intervals, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -1035,7 +1035,7 @@ func TestFindBestRoomToneRegion_LaterCandidateWinsWhenGapExceedsTolerance(t *tes
 	allIntervals = append(allIntervals, intervalsA...)
 	allIntervals = append(allIntervals, intervalsB...)
 
-	result := findBestRoomToneRegion(regions, allIntervals)
+	result := findBestRoomToneRegion(regions, allIntervals, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected a best region to be selected")
@@ -1065,7 +1065,7 @@ func TestFindBestRoomToneRegion_LateCandidateDiscoverable(t *testing.T) {
 	intervals := makeRoomToneTestIntervals(1800*time.Second, 10*time.Second,
 		-75.0, -70.0, 100.0, 0.9, 1.0, 0.0)
 
-	result := findBestRoomToneRegion(regions, intervals)
+	result := findBestRoomToneRegion(regions, intervals, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected candidate at t=1800s to be elected")
@@ -1542,7 +1542,7 @@ func TestFindBestSpeechRegion(t *testing.T) {
 			{Start: 95 * time.Second, End: 100 * time.Second, Duration: 5 * time.Second},
 		}
 
-		result := findBestSpeechRegion(regions, intervals, nil)
+		result := findBestSpeechRegion(regions, intervals, nil, nil)
 
 		if result.BestRegion == nil {
 			t.Fatal("expected a best region to be selected")
@@ -1556,7 +1556,7 @@ func TestFindBestSpeechRegion(t *testing.T) {
 	t.Run("returns nil for empty regions", func(t *testing.T) {
 		intervals := makeSpeechTestIntervals(200, -18.0)
 
-		result := findBestSpeechRegion([]SpeechRegion{}, intervals, nil)
+		result := findBestSpeechRegion([]SpeechRegion{}, intervals, nil, nil)
 
 		if result.BestRegion != nil {
 			t.Error("expected nil BestRegion for empty input")
@@ -1571,7 +1571,7 @@ func TestFindBestSpeechRegion(t *testing.T) {
 			{Start: 40 * time.Second, End: 80 * time.Second, Duration: 40 * time.Second},
 		}
 
-		result := findBestSpeechRegion(regions, intervals, nil)
+		result := findBestSpeechRegion(regions, intervals, nil, nil)
 
 		if len(result.Candidates) != 2 {
 			t.Errorf("expected 2 candidates stored, got %d", len(result.Candidates))
@@ -1610,7 +1610,7 @@ func TestFindBestSpeechRegion_AllBelowMinAcceptableScoreFallsBack(t *testing.T) 
 	intervals = append(intervals, lowScoreIntervals...)
 	intervals = append(intervals, higherScoreIntervals...)
 
-	result := findBestSpeechRegion(regions, intervals, nil)
+	result := findBestSpeechRegion(regions, intervals, nil, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected fallback BestRegion when speech candidates exist below threshold")
@@ -1978,7 +1978,7 @@ func TestFindBestSpeechRegion_WithRefinement(t *testing.T) {
 			return append(first, second...)
 		}()
 
-		result := findBestSpeechRegion(regions, intervals, nil)
+		result := findBestSpeechRegion(regions, intervals, nil, nil)
 
 		if result.BestRegion == nil {
 			t.Fatal("expected a best region to be selected")
@@ -2026,7 +2026,7 @@ func TestFindBestSpeechRegion_WithRefinement(t *testing.T) {
 		// Create intervals with good speech characteristics
 		intervals := makeSpeechIntervalsScorable(0, 180, 6.0, 0.1, 2000.0, -15.0)
 
-		result := findBestSpeechRegion(regions, intervals, nil)
+		result := findBestSpeechRegion(regions, intervals, nil, nil)
 
 		if result.BestRegion == nil {
 			t.Fatal("expected a best region to be selected")
@@ -2062,7 +2062,7 @@ func TestFindBestSpeechRegion_WithRefinement(t *testing.T) {
 			return append(append(poor1, excellent...), poor2...)
 		}()
 
-		result := findBestSpeechRegion(regions, intervals, nil)
+		result := findBestSpeechRegion(regions, intervals, nil, nil)
 
 		if result.BestRegion == nil {
 			t.Fatal("expected a best region to be selected")
@@ -2100,7 +2100,7 @@ func TestFindBestSpeechRegion_SNRMarginCheck(t *testing.T) {
 		}
 
 		// Run with good SNR margin
-		resultGood := findBestSpeechRegion(regions, intervals, noiseProfileGood)
+		resultGood := findBestSpeechRegion(regions, intervals, noiseProfileGood, nil)
 		if resultGood.BestRegion == nil {
 			t.Fatal("expected a best region to be selected with good SNR")
 		}
@@ -2112,7 +2112,7 @@ func TestFindBestSpeechRegion_SNRMarginCheck(t *testing.T) {
 		}
 
 		// Run with poor SNR margin
-		resultBad := findBestSpeechRegion(regions, intervals, noiseProfileBad)
+		resultBad := findBestSpeechRegion(regions, intervals, noiseProfileBad, nil)
 		if resultBad.BestRegion == nil {
 			t.Fatal("expected a best region to be selected even with poor SNR")
 		}
@@ -2156,7 +2156,7 @@ func TestFindBestSpeechRegion_SNRMarginCheck(t *testing.T) {
 		intervals := makeSpeechIntervalsScorable(0, 120, 6.0, 0.1, 1500.0, -20.0)
 
 		// Run without noise profile
-		resultNoProfile := findBestSpeechRegion(regions, intervals, nil)
+		resultNoProfile := findBestSpeechRegion(regions, intervals, nil, nil)
 		if resultNoProfile.BestRegion == nil {
 			t.Fatal("expected a best region to be selected without noise profile")
 		}
@@ -2166,7 +2166,7 @@ func TestFindBestSpeechRegion_SNRMarginCheck(t *testing.T) {
 		noiseProfileGood := &NoiseProfile{
 			MeasuredNoiseFloor: -40.0, // 20 dB margin - passes
 		}
-		resultWithProfile := findBestSpeechRegion(regions, intervals, noiseProfileGood)
+		resultWithProfile := findBestSpeechRegion(regions, intervals, noiseProfileGood, nil)
 
 		// Scores should be equal when nil (no penalty applied)
 		var scoreNoProfile, scoreWithProfile float64
@@ -2725,7 +2725,7 @@ func TestFindBestRoomToneRegion_BoundaryTransientSurvivesAfterRefinement(t *test
 	allIntervals = append(allIntervals, transientIntervals...)
 	allIntervals = append(allIntervals, cleanIntervals...)
 
-	result := findBestRoomToneRegion(regions, allIntervals)
+	result := findBestRoomToneRegion(regions, allIntervals, nil)
 
 	if result.BestRegion == nil {
 		t.Fatal("expected candidate to be elected after pre-scoring refinement trims boundary transient")

--- a/internal/processor/benchmark_test.go
+++ b/internal/processor/benchmark_test.go
@@ -86,7 +86,7 @@ func BenchmarkMeasureOutputRegions(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		MeasureOutputRegions(inputPath, roomToneRegion, speechRegion)
+		MeasureOutputRegions(inputPath, roomToneRegion, speechRegion, nil)
 	}
 }
 

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -242,6 +242,7 @@ func (linear LinearAmplitude) Float64() float64 {
 // BaseFilterConfig holds caller-owned defaults and user-facing options only.
 type BaseFilterConfig struct {
 	filterConfigDefaults
+	logger debugLogger
 }
 
 // AdaptiveFilterResult holds a complete per-file set of tunable filter values.
@@ -313,6 +314,13 @@ type EffectiveFilterConfig filterConfigDefaults
 // podcast spoken word audio processing.
 func DefaultFilterConfig() *BaseFilterConfig {
 	return &BaseFilterConfig{filterConfigDefaults: defaultFilterConfigDefaults()}
+}
+
+// SetLogger installs the debug logger used by the filter chain and all passes
+// that consume this config. Callers outside the package pass a bare function so
+// they need not name the unexported logger type.
+func (cfg *BaseFilterConfig) SetLogger(l func(format string, args ...any)) {
+	cfg.logger = debugLogger(l)
 }
 
 func defaultFilterConfigDefaults() filterConfigDefaults {

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -43,6 +43,13 @@ type LoudnormStats struct {
 }
 
 // loudnormLogCapture manages thread-safe capture of loudnorm's JSON output.
+//
+// Parallelism blocker: capture hijacks FFmpeg's process-global log callback and
+// log level, serialised by lifecycleMu. Only one Pass 3/4 loudnorm measurement
+// can capture at a time, so concurrent multi-file loudnorm measurement is
+// blocked. Resolving it needs an FFmpeg log-routing redesign (per-graph or
+// metadata-based JSON extraction); that decision is deferred to the
+// parallel-design phase.
 var loudnormLogCapture = struct {
 	lifecycleMu  sync.Mutex
 	mu           sync.Mutex
@@ -587,6 +594,7 @@ func ApplyNormalisation(
 	outputMeasurements *OutputMeasurements,
 	inputMeasurements *AudioMeasurements,
 	progressCallback ProgressCallback,
+	log debugLogger,
 ) (*NormalisationResult, error) {
 	loudnorm := config.Loudnorm
 	if !loudnorm.Enabled {
@@ -658,7 +666,7 @@ func ApplyNormalisation(
 		inputMeasurements: inputMeasurements,
 		limiter:           limiter,
 		progress:          progressCallback,
-	})
+	}, log)
 	if err != nil {
 		return nil, fmt.Errorf("loudnorm application failed: %w", err)
 	}
@@ -711,7 +719,7 @@ func ApplyNormalisation(
 //
 // Returns the measured integrated loudness, true peak, full output measurements,
 // and loudnorm diagnostic stats.
-func applyLoudnormAndMeasure(request loudnormApplicationRequest) (*loudnormApplicationResult, error) {
+func applyLoudnormAndMeasure(request loudnormApplicationRequest, log debugLogger) (*loudnormApplicationResult, error) {
 	prep, err := prepareLoudnormApplication(request)
 	if err != nil {
 		return nil, err
@@ -721,7 +729,7 @@ func applyLoudnormAndMeasure(request loudnormApplicationRequest) (*loudnormAppli
 		_ = os.Remove(prep.tempPath)
 	}
 	captureGraphStats := func() *LoudnormStats {
-		return capturePass4LoudnormStats(&prep.filterGraph)
+		return capturePass4LoudnormStats(&prep.filterGraph, log)
 	}
 
 	execution, err := executeAndPublishLoudnormApplication(prep, request, captureGraphStats, removeTemp)
@@ -732,7 +740,7 @@ func applyLoudnormAndMeasure(request loudnormApplicationRequest) (*loudnormAppli
 	// Free filter graph before getting stats — loudnorm outputs JSON on graph destruction
 	stats := captureGraphStats()
 
-	return finalizeLoudnormApplicationResult(request, execution, stats), nil
+	return finalizeLoudnormApplicationResult(request, execution, stats, log), nil
 }
 
 func prepareLoudnormApplication(request loudnormApplicationRequest) (*loudnormApplicationPreparation, error) {
@@ -872,10 +880,10 @@ func executeAndPublishLoudnormApplication(
 	return result, nil
 }
 
-func capturePass4LoudnormStats(graph **ffmpeg.AVFilterGraph) *LoudnormStats {
+func capturePass4LoudnormStats(graph **ffmpeg.AVFilterGraph, log debugLogger) *LoudnormStats {
 	stats, err := captureLoudnormGraphFinalisation(graph)
 	if err != nil {
-		debugLog("Warning: failed to capture Pass 4 loudnorm diagnostics: %v", err)
+		log.Logf("Warning: failed to capture Pass 4 loudnorm diagnostics: %v", err)
 		return nil
 	}
 	return stats
@@ -885,11 +893,13 @@ func finalizeLoudnormApplicationResult(
 	request loudnormApplicationRequest,
 	execution *loudnormApplicationExecutionResult,
 	stats *LoudnormStats,
+	log debugLogger,
 ) *loudnormApplicationResult {
 	finalMeasurements, regionMeasurementTime := finalizeLoudnormOutputMeasurements(
 		request.inputPath,
 		request.inputMeasurements,
 		&execution.acc,
+		log,
 	)
 
 	return &loudnormApplicationResult{
@@ -905,6 +915,7 @@ func finalizeLoudnormOutputMeasurements(
 	inputPath string,
 	inputMeasurements *AudioMeasurements,
 	acc *outputMetadataAccumulators,
+	log debugLogger,
 ) (*OutputMeasurements, time.Duration) {
 	finalMeasurements := finalizeOutputMeasurements(acc)
 	var regionMeasurementTime time.Duration
@@ -919,7 +930,7 @@ func finalizeLoudnormOutputMeasurements(
 	}
 
 	regionStart := time.Now()
-	roomToneSample, spSample := MeasureOutputRegions(inputPath, roomToneRegion, spRegion)
+	roomToneSample, spSample := MeasureOutputRegions(inputPath, roomToneRegion, spRegion, log)
 	regionMeasurementTime = time.Since(regionStart)
 	finalMeasurements.RoomToneSample = roomToneSample
 	finalMeasurements.SpeechSample = spSample

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -1084,7 +1084,7 @@ func applyLoudnormTest(
 		inputPath:   inputPath,
 		config:      loudnormApplicationTestConfig(),
 		measurement: loudnormApplicationTestMeasurement(),
-	})
+	}, nil)
 }
 
 func TestApplyLoudnormAndMeasureDoesNotStartCaptureOnOpenError(t *testing.T) {
@@ -1716,6 +1716,7 @@ func TestApplyNormalisationProgressCadenceGuard(t *testing.T) {
 		func(update ProgressUpdate) {
 			events = append(events, loudnormProgressEvent{pass: update.Pass, passName: update.PassName, progress: update.Progress})
 		},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("ApplyNormalisation() error = %v", err)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -148,7 +148,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 		roomToneRegion, spRegion := extractRegionPair(measurements)
 		if roomToneRegion != nil || spRegion != nil {
 			regionStart := time.Now()
-			roomToneSample, spSample := MeasureOutputRegions(outputPath, roomToneRegion, spRegion)
+			roomToneSample, spSample := MeasureOutputRegions(outputPath, roomToneRegion, spRegion, config.logger)
 			regionTimings.FilteredOutput = time.Since(regionStart)
 			filteredMeasurements.RoomToneSample = roomToneSample
 			filteredMeasurements.SpeechSample = spSample
@@ -159,7 +159,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 	// The FinalMeasurements in the result include region measurements captured in Pass 4
 	var normResult *NormalisationResult
 	if filteredMeasurements != nil {
-		normResult, err = ApplyNormalisation(outputPath, effectiveConfig, filteredMeasurements, measurements, progressCallback)
+		normResult, err = ApplyNormalisation(outputPath, effectiveConfig, filteredMeasurements, measurements, progressCallback, config.logger)
 		if err != nil {
 			return nil, fmt.Errorf("pass 3 failed: %w", err)
 		}

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -504,7 +504,7 @@ func TestProcessorSeedAndProgressCallbackBoundaries(t *testing.T) {
 			fn:          ApplyNormalisation,
 			configArg:   1,
 			progressArg: 4,
-			parameters:  5,
+			parameters:  6,
 		},
 	}
 


### PR DESCRIPTION
Replace the package-level processor.DebugLog global and debugLog() free function with a threaded debugLogger field on BaseFilterConfig and nil-guarded Logf method. Thread the logger as a final parameter through all 5 call chains (room-tone, speech, LA-2A, output-region, loudnorm). Update main.go to call config.SetLogger() instead of setting the global.

Precursor groundwork for parallel multi-file processing: de-globalises the logger without unblocking concurrency (Pass 3/4 serialisation remains on lifecycleMu; log-routing redesign deferred to parallel-design phase).

- Add debugLogger type with nil-guarded Logf method
- Add logger field and SetLogger() method to BaseFilterConfig
- Thread logger through adaptive.go, adaptive_la2a.go, analyzer.go, analyzer_candidates_*, analyzer_output.go, normalise.go call chains
- Update main.go to use config.SetLogger() instead of setting global
- Add loudnormLogCapture parallelism blocker documentation note
- Byte-identical debug log and processed audio output; build/test/lint green
