### PR TITLE
refactor(processor): serialize AVFilterGraphFree calls with mutex for loudnorm concurrency safety

### DIFF
--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -508,7 +508,7 @@ func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *P
 	var filterFreed bool
 	defer func() {
 		if !filterFreed && filterGraph != nil {
-			ffmpeg.AVFilterGraphFree(&filterGraph)
+			freeFilterGraphLocked(&filterGraph)
 		}
 	}()
 
@@ -593,7 +593,7 @@ func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *P
 		silenceIntervals = intervals
 	}
 
-	ffmpeg.AVFilterGraphFree(&filterGraph)
+	freeFilterGraphLocked(&filterGraph)
 	filterFreed = true
 
 	return &analysisFrameCollection{

--- a/internal/processor/analyzer_output.go
+++ b/internal/processor/analyzer_output.go
@@ -9,6 +9,13 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
 
+// outputRegionAnalysisFilterFormat is the fmt.Sprintf format string for the
+// output-region analysis filter graph in measureOutputRegionFromReader. The
+// %f verbs take the region start and duration in seconds. Hoisted to a
+// package-level constant so guard tests can assert the metadata flags against
+// live source without re-typing the filter string.
+const outputRegionAnalysisFilterFormat = "atrim=start=%f:duration=%f,asetpts=PTS-STARTPTS,astats=metadata=1:measure_perchannel=0,aspectralstats=measure=all,ebur128=metadata=1:peak=sample+true"
+
 // regionMeasurements holds the common measurement results from analysing an
 // output audio region. Both room tone and speech region measurement functions
 // share this intermediate type before mapping to their specific candidate types.
@@ -37,7 +44,7 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 	}
 
 	filterSpec := fmt.Sprintf(
-		"atrim=start=%f:duration=%f,asetpts=PTS-STARTPTS,astats=metadata=1:measure_perchannel=0,aspectralstats=measure=all,ebur128=metadata=1:peak=sample+true",
+		outputRegionAnalysisFilterFormat,
 		start.Seconds(),
 		duration.Seconds(),
 	)
@@ -46,7 +53,7 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 	if err != nil {
 		return nil, fmt.Errorf("failed to create analysis filter graph: %w", err)
 	}
-	defer ffmpeg.AVFilterGraphFree(&filterGraph)
+	defer freeFilterGraphLocked(&filterGraph)
 
 	var rmsLevel float64
 	var peakLevel float64

--- a/internal/processor/frame_processor.go
+++ b/internal/processor/frame_processor.go
@@ -153,14 +153,14 @@ func setupFilterGraph(decCtx *ffmpeg.AVCodecContext, filterSpec string) (
 	// Create abuffer source
 	bufferSrcCtx, err := createBufferSource(filterGraph, decCtx)
 	if err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		freeFilterGraphLocked(&filterGraph)
 		return nil, nil, nil, err
 	}
 
 	// Create abuffersink
 	bufferSinkCtx, err := createBufferSink(filterGraph)
 	if err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		freeFilterGraphLocked(&filterGraph)
 		return nil, nil, nil, err
 	}
 
@@ -184,13 +184,13 @@ func setupFilterGraph(decCtx *ffmpeg.AVCodecContext, filterSpec string) (
 	defer filterSpecC.Free()
 
 	if _, err := ffmpeg.AVFilterGraphParsePtr(filterGraph, filterSpecC, &inputs, &outputs, nil); err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		freeFilterGraphLocked(&filterGraph)
 		return nil, nil, nil, fmt.Errorf("failed to parse filter graph: %w", err)
 	}
 
 	// Configure filter graph
 	if _, err := ffmpeg.AVFilterGraphConfig(filterGraph, nil); err != nil {
-		ffmpeg.AVFilterGraphFree(&filterGraph)
+		freeFilterGraphLocked(&filterGraph)
 		return nil, nil, nil, fmt.Errorf("failed to configure filter graph: %w", err)
 	}
 

--- a/internal/processor/loudnorm_logprobe_test.go
+++ b/internal/processor/loudnorm_logprobe_test.go
@@ -1,0 +1,216 @@
+package processor
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
+	"github.com/linuxmatters/jivetalking/internal/audio"
+)
+
+// logProbeRecord captures one av_log callback invocation.
+type logProbeRecord struct {
+	phase    string
+	level    int
+	itemName string
+	rawPtr   uintptr
+	msg      string
+}
+
+// findProbeAudioFile locates any audio file under testdata/ for the probe.
+// Returns "" if none exists.
+func findProbeAudioFile() string {
+	// Prefer the small fixture if present (fast), else any flac/wav.
+	candidates := []string{"fixture-5m.flac"}
+	for _, name := range candidates {
+		p := filepath.Join("..", "..", "testdata", name)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	matches, _ := filepath.Glob(filepath.Join("..", "..", "testdata", "*.flac"))
+	wavs, _ := filepath.Glob(filepath.Join("..", "..", "testdata", "*.wav"))
+	matches = append(matches, wavs...)
+	if len(matches) == 0 {
+		return ""
+	}
+	sort.Strings(matches)
+	return matches[0]
+}
+
+// TestLoudnormLogProbe answers an empirical question for the parallelism design:
+// does any filter in the analysis tail emit at AV_LOG_INFO during the
+// frame-processing loop, or only at graph teardown (AVFilterGraphFree)?
+//
+// It installs a context-aware av_log callback at AV_LOG_INFO level, runs the
+// production analysis tail (astats, aspectralstats, ebur128 with metadata=1)
+// over a real file, tags each log line with a phase marker ("loop" vs "free"),
+// and reports INFO-line counts per phase per originating filter.
+//
+// Verdict rule: only-at-free => a single mutex around AVFilterGraphFree suffices
+// (Option 1). Any mid-loop INFO emission => a context-filtered callback registry
+// is required (Option 3).
+func TestLoudnormLogProbe(t *testing.T) {
+	inputPath := findProbeAudioFile()
+	if inputPath == "" {
+		t.Skip("no audio file found under testdata/; drop a .flac (e.g. testdata/fixture-5m.flac) to run the probe")
+	}
+
+	var (
+		mu      sync.Mutex
+		phase   = "setup"
+		records []logProbeRecord
+	)
+
+	callback := func(ctx *ffmpeg.LogCtx, level int, msg string) {
+		var (
+			itemName string
+			rawPtr   uintptr
+		)
+		if ctx != nil {
+			rawPtr = uintptr(ctx.RawPtr())
+			if class := ctx.Class(); class != nil {
+				itemName = class.ItemName()(ctx.RawPtr()).String()
+			}
+		}
+		mu.Lock()
+		records = append(records, logProbeRecord{
+			phase:    phase,
+			level:    level,
+			itemName: itemName,
+			rawPtr:   rawPtr,
+			msg:      msg,
+		})
+		mu.Unlock()
+	}
+
+	prevLevel, _ := ffmpeg.AVLogGetLevel()
+	ffmpeg.AVLogSetLevel(ffmpeg.AVLogInfo)
+	ffmpeg.AVLogSetCallback(callback)
+	defer func() {
+		ffmpeg.AVLogSetCallback(nil)
+		ffmpeg.AVLogSetLevel(prevLevel)
+	}()
+
+	reader, _, err := audio.OpenAudioFile(inputPath)
+	if err != nil {
+		t.Fatalf("failed to open audio file %q: %v", inputPath, err)
+	}
+	defer reader.Close()
+
+	// Production analysis tail, verbatim, after a mono downmix. Matches
+	// filters.go buildAnalysisFilter() / buildDownmixFilter() composition.
+	filterSpec := "aformat=channel_layouts=mono," +
+		"astats=metadata=1:measure_perchannel=all," +
+		"aspectralstats=win_size=2048:win_func=hann:measure=all," +
+		"ebur128=metadata=1:peak=sample+true:dualmono=true"
+
+	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.GetDecoderContext(), filterSpec)
+	if err != nil {
+		t.Fatalf("failed to set up filter graph: %v", err)
+	}
+
+	mu.Lock()
+	phase = "loop"
+	mu.Unlock()
+
+	if err := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+		OnReadError: func(err error) error { return err },
+		OnPushError: func(err error) error { return err },
+		OnPullError: func(err error) error { return err },
+	}); err != nil {
+		ffmpeg.AVFilterGraphFree(&filterGraph)
+		t.Fatalf("filter graph run failed: %v", err)
+	}
+
+	mu.Lock()
+	phase = "free"
+	mu.Unlock()
+
+	ffmpeg.AVFilterGraphFree(&filterGraph)
+
+	mu.Lock()
+	phase = "done"
+	snapshot := make([]logProbeRecord, len(records))
+	copy(snapshot, records)
+	mu.Unlock()
+
+	// Tally INFO-level lines per phase, broken down by item name.
+	type key struct {
+		phase    string
+		itemName string
+	}
+	infoCounts := map[key]int{}
+	loopContextPtrs := map[string]struct{}{}
+	var loopNilContextLines int
+
+	for _, r := range snapshot {
+		// FFmpeg encodes level low byte; normalise like the binding does.
+		lvl := r.level
+		if lvl >= 0 {
+			lvl &= 0xff
+		}
+		if lvl != ffmpeg.AVLogInfo {
+			continue
+		}
+		name := r.itemName
+		if name == "" {
+			name = "<global/nil-ctx>"
+		}
+		infoCounts[key{r.phase, name}]++
+		if r.phase == "loop" {
+			if r.itemName == "" {
+				loopNilContextLines++
+			} else {
+				loopContextPtrs[r.itemName] = struct{}{}
+			}
+		}
+	}
+
+	t.Logf("PROBE input file: %s", inputPath)
+	t.Logf("PROBE total av_log records captured (all levels/phases): %d", len(snapshot))
+
+	loopTotal := 0
+	freeTotal := 0
+	keys := make([]key, 0, len(infoCounts))
+	for k := range infoCounts {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].phase != keys[j].phase {
+			return keys[i].phase < keys[j].phase
+		}
+		return keys[i].itemName < keys[j].itemName
+	})
+	for _, k := range keys {
+		t.Logf("PROBE INFO phase=%-5s item=%-22s count=%d", k.phase, k.itemName, infoCounts[k])
+		switch k.phase {
+		case "loop":
+			loopTotal += infoCounts[k]
+		case "free":
+			freeTotal += infoCounts[k]
+		}
+	}
+
+	t.Logf("PROBE SUMMARY: INFO lines during loop=%d, during free=%d", loopTotal, freeTotal)
+	t.Logf("PROBE SUMMARY: loop INFO lines with non-nil context: %d distinct item(s) %v; nil-context lines=%d",
+		len(loopContextPtrs), keysOf(loopContextPtrs), loopNilContextLines)
+
+	if loopTotal > 0 {
+		t.Logf("PROBE VERDICT: Option 3 required (context-filtered registry) - %d INFO line(s) emitted mid-loop", loopTotal)
+	} else {
+		t.Logf("PROBE VERDICT: Option 1 viable (graph-free mutex) - zero INFO lines mid-loop; all %d INFO line(s) at graph-free", freeTotal)
+	}
+}
+
+func keysOf(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -45,13 +45,13 @@ type LoudnormStats struct {
 // loudnormLogCapture manages thread-safe capture of loudnorm's JSON output.
 //
 // Parallelism blocker: capture hijacks FFmpeg's process-global log callback and
-// log level, serialised by lifecycleMu. Only one Pass 3/4 loudnorm measurement
-// can capture at a time, so concurrent multi-file loudnorm measurement is
-// blocked. Resolving it needs an FFmpeg log-routing redesign (per-graph or
-// metadata-based JSON extraction); that decision is deferred to the
-// parallel-design phase.
+// log level, serialised by graphFreeMu (held across the whole capture bracket,
+// from raise-level through the graph free to JSON parse). Only one Pass 3/4
+// loudnorm measurement can capture at a time, so concurrent multi-file loudnorm
+// measurement is blocked. Resolving it needs an FFmpeg log-routing redesign
+// (per-graph or metadata-based JSON extraction); that decision is deferred to
+// the parallel-design phase.
 var loudnormLogCapture = struct {
-	lifecycleMu  sync.Mutex
 	mu           sync.Mutex
 	buffer       strings.Builder
 	capturing    bool
@@ -70,6 +70,23 @@ var (
 	}
 	loudnormRename = os.Rename
 )
+
+// graphFreeMu serialises filter-graph frees across the package. The lock is
+// private to the package; frame-processing paths must never acquire it. The
+// loudnorm capture path must NOT call freeFilterGraphLocked: it already holds
+// graphFreeMu across its capture bracket, and the mutex is non-reentrant, so
+// calling the helper there would deadlock.
+var graphFreeMu sync.Mutex
+
+// freeFilterGraphLocked frees a filter graph while holding graphFreeMu, giving a
+// single serialised chokepoint for non-loudnorm graph frees. Do not call it from
+// the loudnorm capture path, which already holds graphFreeMu (re-entry would
+// deadlock on the non-reentrant mutex).
+func freeFilterGraphLocked(graph **ffmpeg.AVFilterGraph) {
+	graphFreeMu.Lock()
+	defer graphFreeMu.Unlock()
+	ffmpeg.AVFilterGraphFree(graph)
+}
 
 type loudnormOutputEncoder interface {
 	WriteFrame(*ffmpeg.AVFrame) error
@@ -93,8 +110,13 @@ func loudnormLogCallback(_ *ffmpeg.LogCtx, _ int, msg string) {
 // FFmpeg logging is process-global, so capture is serialised from start through
 // stop. The narrow capture boundary is graph finalisation, where loudnorm emits
 // JSON as the filter graph is freed.
+//
+// The capture holds graphFreeMu across the whole bracket so the graph free in
+// captureLoudnormGraphFinalisation runs under the same serialisation point as
+// every other graph free. graphFreeMu is non-reentrant, so that free must call
+// loudnormAVFilterGraphFree directly, never freeFilterGraphLocked.
 func startLoudnormCapture() {
-	loudnormLogCapture.lifecycleMu.Lock()
+	graphFreeMu.Lock()
 
 	loudnormLogCapture.mu.Lock()
 	defer loudnormLogCapture.mu.Unlock()
@@ -110,7 +132,7 @@ func startLoudnormCapture() {
 // emitted while loudnorm graph finalisation was captured.
 // Returns the parsed LoudnormStats or an error if JSON was not found/parseable.
 func stopLoudnormCapture() (*LoudnormStats, error) {
-	defer loudnormLogCapture.lifecycleMu.Unlock()
+	defer graphFreeMu.Unlock()
 
 	loudnormLogCapture.mu.Lock()
 	defer loudnormLogCapture.mu.Unlock()

--- a/internal/processor/normalise_guard_test.go
+++ b/internal/processor/normalise_guard_test.go
@@ -1,0 +1,152 @@
+package processor
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
+)
+
+// TestMetadataModeGuard asserts that all three production analysis filter
+// builders emit both astats=metadata=1 and ebur128=metadata=1. The spike that
+// derived the loudnorm-capture metadata flags depends on these flags being
+// present; this guard fails if any builder regresses to metadata=0.
+//
+// Each subtest asserts against live builder output (or the live source
+// constant), never a re-typed copy of the filter string.
+func TestMetadataModeGuard(t *testing.T) {
+	const (
+		astatsMetadata  = "astats=metadata=1"
+		ebur128Metadata = "ebur128=metadata=1"
+	)
+
+	assertBothFlags := func(t *testing.T, builder, spec string) {
+		t.Helper()
+		if !strings.Contains(spec, astatsMetadata) {
+			t.Errorf("%s missing %q\nspec: %s", builder, astatsMetadata, spec)
+		}
+		if !strings.Contains(spec, ebur128Metadata) {
+			t.Errorf("%s missing %q\nspec: %s", builder, ebur128Metadata, spec)
+		}
+	}
+
+	t.Run("buildAnalysisFilter", func(t *testing.T) {
+		config := newTestConfig()
+		config.Analysis.Enabled = true
+
+		assertBothFlags(t, "buildAnalysisFilter()", config.buildAnalysisFilter())
+	})
+
+	t.Run("buildLoudnormFilterSpec", func(t *testing.T) {
+		config := newTestConfig()
+		measurement := &LoudnormMeasurement{
+			InputI:       -24.0,
+			InputTP:      -5.0,
+			InputLRA:     6.0,
+			InputThresh:  -34.0,
+			TargetOffset: -0.5,
+		}
+
+		spec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000)
+		assertBothFlags(t, "buildLoudnormFilterSpec()", spec)
+	})
+
+	t.Run("outputRegionAnalysisFilterFormat", func(t *testing.T) {
+		assertBothFlags(t, "outputRegionAnalysisFilterFormat", outputRegionAnalysisFilterFormat)
+	})
+}
+
+// TestLoudnormCaptureExcludesConcurrentGraphFree proves the loudnorm capture
+// bracket holds graphFreeMu such that a concurrent freeFilterGraphLocked cannot
+// run its graph free until the capture releases the lock.
+//
+// Goroutine A drives captureLoudnormGraphFinalisation with the
+// loudnormAVFilterGraphFree seam swapped for a stub that signals it is inside
+// the free (holding graphFreeMu) then blocks until released. Goroutine B calls
+// freeFilterGraphLocked, which must block on graphFreeMu.Lock() until A's
+// stopLoudnormCapture releases it. B uses ffmpeg.AVFilterGraphFree directly (not
+// the seam) on a nil graph pointer; avfilter_graph_free on a pointer-to-NULL is
+// a no-op, mirroring the existing nil-graph capture tests.
+//
+// Ordering is proven with synchronisation primitives, not sleeps: A flips
+// aReleased only as it leaves the held free, and B records whether aReleased was
+// already set the instant its free returns. If exclusion holds, B always
+// observes the release happened first. A guard timeout fails the test rather
+// than hanging the suite if exclusion is broken.
+func TestLoudnormCaptureExcludesConcurrentGraphFree(t *testing.T) {
+	const deadline = 5 * time.Second
+
+	aInFree := make(chan struct{})  // A is inside the held free, holding graphFreeMu
+	releaseA := make(chan struct{}) // test lets A finish the held free
+	var aReleased atomic.Bool       // set just before A leaves the held free
+
+	// Swap the loudnorm free seam for A. It feeds valid JSON so Stop() parses,
+	// signals it holds the lock, then blocks until the test releases it.
+	oldFree := loudnormAVFilterGraphFree
+	loudnormAVFilterGraphFree = func(graph **ffmpeg.AVFilterGraph) {
+		loudnormLogCallback(nil, ffmpeg.AVLogInfo, loudnormCaptureTestJSON)
+		close(aInFree)
+		<-releaseA
+		aReleased.Store(true)
+		if graph != nil && *graph != nil {
+			oldFree(graph)
+		}
+	}
+	defer func() { loudnormAVFilterGraphFree = oldFree }()
+
+	aDone := make(chan error, 1)
+	go func() {
+		var graph *ffmpeg.AVFilterGraph
+		_, err := captureLoudnormGraphFinalisation(&graph)
+		aDone <- err
+	}()
+
+	// Wait until A holds graphFreeMu inside the free.
+	select {
+	case <-aInFree:
+	case <-time.After(deadline):
+		t.Fatal("goroutine A never entered the held free; capture bracket may not hold graphFreeMu")
+	}
+
+	bStarted := make(chan struct{})
+	bDone := make(chan bool, 1) // value: whether aReleased was already set when B's free returned
+	go func() {
+		close(bStarted)
+		var nilGraph *ffmpeg.AVFilterGraph
+		freeFilterGraphLocked(&nilGraph) // blocks on graphFreeMu until A releases
+		bDone <- aReleased.Load()
+	}()
+
+	// B has launched and is blocking (or about to block) on graphFreeMu.Lock().
+	<-bStarted
+
+	// Exclusion check: while A still holds the lock, B must not have completed.
+	select {
+	case <-bDone:
+		t.Fatal("goroutine B completed its graph free while A held graphFreeMu; exclusion broken")
+	default:
+	}
+
+	// Release A. Its stopLoudnormCapture unlocks graphFreeMu, letting B proceed.
+	close(releaseA)
+
+	select {
+	case err := <-aDone:
+		if err != nil {
+			t.Fatalf("captureLoudnormGraphFinalisation() error = %v", err)
+		}
+	case <-time.After(deadline):
+		t.Fatal("goroutine A never finished its capture after release")
+	}
+
+	select {
+	case sawReleaseFirst := <-bDone:
+		if !sawReleaseFirst {
+			t.Fatal("goroutine B observed its free completing before A released graphFreeMu; exclusion broken")
+		}
+	case <-time.After(deadline):
+		t.Fatal("goroutine B never acquired graphFreeMu after A released it")
+	}
+}

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -271,7 +271,7 @@ func processWithFilters(inputPath, outputPath string, config *EffectiveFilterCon
 	if err != nil {
 		return InputMetadata{}, fmt.Errorf("failed to create filter graph: %w", err)
 	}
-	defer ffmpeg.AVFilterGraphFree(&filterGraph)
+	defer freeFilterGraphLocked(&filterGraph)
 
 	// Create output encoder
 	encoder, err := createOutputEncoder(outputPath, metadata, bufferSinkCtx)


### PR DESCRIPTION
  - Introduce process-global graphFreeMu mutex to serialize all AVFilterGraphFree calls
  - Add freeFilterGraphLocked helper that acquires lock before free in normalise.go
  - Route all 8 production free sites through freeFilterGraphLocked (frame_processor, analyzer, analyzer_output, processor)
  - Extend loudnorm capture bracket (startLoudnormCapture/stopLoudnormCapture) to hold graphFreeMu lock across entire
  raise→install→free→parse→restore span
  - Fold lifecycleMu into graphFreeMu (superset covers all graph-free exclusion, eliminates redundancy)
  - Extract inline filter literal at analyzer_output.go:40 to package-level constant outputRegionAnalysisFilterFormat for guard test reuse
  - Add normalise_guard_test.go with TestMetadataModeGuard and TestLoudnormCaptureExcludesConcurrentGraphFree assertions

  These changes make loudnorm JSON capture safe under parallel multi-file processing. Serial path unchanged; verified under -race.