### PR TITLE
refactor(comments): cleanse codebase and correct stale constant documentation

### DIFF
--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -18,9 +18,8 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/ui"
 )
 
-// version is set via ldflags at build time
-// Local dev builds: "dev"
-// Release builds: git tag (e.g. "0.1.0")
+// version is injected via ldflags at build time. Local dev builds keep "dev";
+// release builds carry the git tag (e.g. "0.1.0").
 var version = "dev"
 
 var errCancelledByUser = errors.New("cancelled by user")
@@ -29,7 +28,7 @@ const debugLogPath = "jivetalking-debug.log"
 
 var createDebugLogFile = os.Create
 
-// CLI defines the command-line interface
+// CLI defines the command-line interface parsed by kong.
 type CLI struct {
 	Version              bool          `short:"v" help:"Show version information"`
 	Debug                bool          `short:"d" help:"Enable debug logging to jivetalking-debug.log"`
@@ -65,8 +64,8 @@ func resolveRoomToneScanDuration(roomTone, silence time.Duration, deprecationOut
 }
 
 func main() {
-	// Suppress FFmpeg info/verbose logging to keep console clean
-	// This prevents astats and other filters from printing summaries to stderr
+	// Suppress FFmpeg info/verbose logging so astats and other filters do not
+	// print summaries to stderr and clutter the console.
 	ffmpeg.AVLogSetLevel(ffmpeg.AVLogError)
 
 	cliArgs := &CLI{}
@@ -80,13 +79,11 @@ func main() {
 		kong.Help(cli.StyledHelpPrinter(kong.HelpOptions{Compact: true})),
 	)
 
-	// Handle version flag
 	if cliArgs.Version {
 		cli.PrintVersion(version)
 		os.Exit(0)
 	}
 
-	// Validate input
 	if len(cliArgs.Files) == 0 {
 		cli.PrintError("No input files specified")
 		_ = ctx.PrintUsage(false)
@@ -99,11 +96,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create default filter configuration
 	config := processor.DefaultFilterConfig()
 	config.Analysis.RoomToneScanDuration = scanDuration
 
-	// Open debug log file if --debug flag is set
 	debugLog, err := openDebugLog(cliArgs.Debug)
 	if err != nil {
 		cli.PrintError(err.Error())
@@ -117,42 +112,35 @@ func main() {
 		sink.Logf(format, args...)
 	}
 
-	// Set the config's debug log function to use the same log
+	// Route the filter chain's debug output through the same serialised sink.
 	config.SetLogger(log)
 
-	// Handle analysis-only mode: run Pass 1 and display results, skip TUI
 	if cliArgs.AnalysisOnly {
 		runAnalysisOnly(cliArgs.Files, config, log)
 		return
 	}
 
-	// Create the Bubbletea UI model
 	model := ui.NewModel(cliArgs.Files)
 
-	// Start the TUI
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	reportWarnings := make(chan string, len(cliArgs.Files))
 
-	// Start processing in background
 	go func() {
 		for i, inputPath := range cliArgs.Files {
 			fileStartTime := time.Now()
 
-			// Signal file start
 			log("[MAIN] Sending FileStartMsg for file %d: %s", i, inputPath)
 			p.Send(ui.FileStartMsg{
 				FileIndex: i,
 				FileName:  inputPath,
 			})
 
-			// Create progress handler
 			ph := &progressHandler{
 				p:         p,
 				log:       log,
 				fileIndex: i,
 			}
 
-			// Process the audio file
 			pass2Start := time.Now()
 			log("[MAIN] Starting ProcessAudio for %s", inputPath)
 			result, err := processor.ProcessAudio(inputPath, config, ph.callback)
@@ -164,6 +152,8 @@ func main() {
 				})
 				continue
 			}
+			// ProcessAudio runs all four passes; isolate Pass 2 by subtracting the
+			// passes the progress handler timed directly.
 			pass2Time := time.Since(pass2Start) - ph.pass1Time - ph.pass3Time - ph.pass4Time
 
 			reportData := buildProcessingReportData(inputPath, fileStartTime, ph.timings(pass2Time), result)
@@ -172,7 +162,6 @@ func main() {
 				reportWarnings <- fmt.Sprintf("Report was not written for %s: %v", inputPath, err)
 			}
 
-			// Signal file complete with actual data
 			log("[MAIN] Sending FileCompleteMsg for file %d", i)
 			p.Send(ui.FileCompleteMsg{
 				FileIndex:  i,
@@ -183,12 +172,10 @@ func main() {
 			})
 		}
 
-		// Signal all complete
 		log("[MAIN] Sending AllCompleteMsg")
 		p.Send(ui.AllCompleteMsg{})
 	}()
 
-	// Run the program
 	if _, err := p.Run(); err != nil {
 		cli.PrintError(fmt.Sprintf("UI error: %v", err))
 		if debugLog != nil {
@@ -273,7 +260,8 @@ func (ph *progressHandler) timings(pass2Time time.Duration) logging.ProcessingTi
 	}
 }
 
-// progressHandler handles progress updates from the processor
+// progressHandler relays processor progress updates to the TUI and records
+// per-pass timings from the start/end progress boundaries.
 type progressHandler struct {
 	p          *tea.Program
 	log        func(string, ...any)
@@ -289,7 +277,8 @@ type progressHandler struct {
 func (ph *progressHandler) callback(update processor.ProgressUpdate) {
 	ph.log("[MAIN] Sending ProgressMsg: Pass %d (%s), Progress %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
 
-	// Track pass timing
+	// Progress 0.0 marks a pass start, 1.0 marks its end; bracket each pass to
+	// measure its wall-clock duration.
 	switch {
 	case update.Pass == processor.PassAnalysis && update.Progress == 0.0:
 		ph.pass1Start = time.Now()
@@ -322,18 +311,17 @@ func runAnalysisOnly(files []string, config *processor.BaseFilterConfig, log fun
 }
 
 func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig, log func(string, ...any), deps analysisOnlyDeps) {
-	// Check if we have a TTY for the progress UI
 	hasTTY := deps.hasTTY()
 
 	for i, inputPath := range files {
-		// Add separator between multiple files
+		// Blank line separates consecutive file reports.
 		if i > 0 {
 			fmt.Fprintln(deps.stdout)
 		}
 
 		log("[ANALYSIS] Starting analysis for %s", inputPath)
 
-		// Get file metadata for duration/sample rate display
+		// Metadata supplies the duration and sample rate shown in the report.
 		metadata, err := deps.openMetadata(inputPath)
 		if err != nil {
 			deps.printError(fmt.Sprintf("Failed to open %s: %v", inputPath, err))
@@ -344,10 +332,9 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 		var analysisErr error
 
 		if hasTTY {
-			// Run with TUI progress display
 			analysisResult, analysisErr = deps.runWithTUI(inputPath, config, log)
 		} else {
-			// Fallback: run without TUI (for non-interactive environments)
+			// No terminal: skip the progress UI for non-interactive environments.
 			log("[ANALYSIS] No TTY available, running without progress UI")
 			fmt.Fprintf(deps.stdout, "Analysing: %s\n", filepath.Base(inputPath))
 			analysisResult, analysisErr = deps.analyzeDetailed(inputPath, config, nil)
@@ -364,7 +351,6 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 
 		log("[ANALYSIS] Analysis complete for %s", inputPath)
 
-		// Display results to console
 		timings := logging.AnalysisTimings{
 			Analysis:   analysisResult.AnalysisDuration,
 			Adaptation: analysisResult.AdaptationDuration,
@@ -373,7 +359,7 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 	}
 }
 
-// isTTY checks if stdout is connected to a terminal
+// isTTY reports whether stdout is connected to a terminal.
 func isTTY() bool {
 	fileInfo, err := os.Stdout.Stat()
 	if err != nil {
@@ -384,21 +370,17 @@ func isTTY() bool {
 
 // runAnalysisWithTUI runs analysis with the Bubbletea progress UI.
 func runAnalysisWithTUI(inputPath string, config *processor.BaseFilterConfig, log func(string, ...any)) (*processor.AnalysisResult, error) {
-	// Create the analysis UI model
 	model := ui.NewAnalysisModel()
 
-	// Start the TUI (not in alt screen so output remains visible)
+	// Run without the alt screen so the report stays on screen after exit.
 	p := tea.NewProgram(model)
 
-	// Run analysis in background goroutine
 	go func(path string) {
-		// Signal analysis start
 		p.Send(ui.AnalysisStartMsg{
 			FileName: path,
 			FilePath: path,
 		})
 
-		// Create progress callback that sends updates to TUI
 		progressCallback := func(update processor.ProgressUpdate) {
 			log("[ANALYSIS] Progress: Pass %d (%s), %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
 			p.Send(ui.AnalysisProgressMsg{
@@ -407,34 +389,29 @@ func runAnalysisWithTUI(inputPath string, config *processor.BaseFilterConfig, lo
 			})
 		}
 
-		// Run analysis-only with progress callback
 		result, err := processor.AnalyzeOnlyDetailed(path, config, progressCallback)
 
-		// Signal completion
 		p.Send(ui.AnalysisCompleteMsg{
 			Result: result,
 			Error:  err,
 		})
 	}(inputPath)
 
-	// Run the TUI until analysis completes
 	finalModel, err := p.Run()
 	if err != nil {
 		return nil, fmt.Errorf("UI error: %w", err)
 	}
 
-	// Get the final model state
 	analysisModel, ok := finalModel.(ui.AnalysisModel)
 	if !ok {
 		return nil, fmt.Errorf("unexpected model type")
 	}
 
-	// Check for analysis error
 	if analysisModel.Error != nil {
 		return nil, analysisModel.Error
 	}
 
-	// Check for user cancellation (TUI exited without completing analysis)
+	// A TUI exit before Done means the user cancelled mid-analysis.
 	if !analysisModel.Done {
 		return nil, errCancelledByUser
 	}

--- a/internal/logging/report.go
+++ b/internal/logging/report.go
@@ -36,7 +36,7 @@ type ReportData struct {
 // GenerateReport creates a detailed analysis report and saves it alongside the output file.
 // The report filename will be <output>-LUFS-NN-processed.log
 //
-// Report structure (Phase 3 restructure):
+// Report structure:
 // 1. Header - file info and timestamp
 // 2. Processing Summary - pass timings
 // 3. Filter Chain Applied - adaptive parameters
@@ -113,7 +113,7 @@ func GenerateReport(data ReportData) error {
 }
 
 // =============================================================================
-// Tabular Report Section Writers (Phase 3 restructure)
+// Tabular Report Section Writers
 // =============================================================================
 
 // writeReportHeader outputs the report header with file info and timestamp.

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -113,7 +113,7 @@ func AdaptConfig(config *BaseFilterConfig, measurements *AudioMeasurements) (*Ef
 	tuneDS201Gate(effectiveConfig, diagnostics, measurements) // DS201-style soft expander gate
 	tuneDeesser(effectiveConfig, measurements)
 	tuneLA2ACompressor(effectiveConfig, diagnostics, measurements, config.logger)
-	// tuneVolumaxLimiter removed - limiter moved to Pass 4, tuned from Pass 3 measurements
+	// The limiter lives in Pass 4 and is tuned from Pass 3 measurements, not here.
 
 	// Final safety checks
 	sanitizeConfig(effectiveConfig)

--- a/internal/processor/adaptive_ds201_gate.go
+++ b/internal/processor/adaptive_ds201_gate.go
@@ -67,9 +67,9 @@ const (
 	ds201GateFluxLow          = 0.01 // Low flux threshold
 	ds201GateZCRLow           = 0.08 // Low zero crossings rate
 	ds201GateFluxHigh         = 0.05 // High flux threshold
-	ds201GateReleaseSustained = 300  // ms - for sustained speech (was 400)
-	ds201GateReleaseMod       = 250  // ms - standard (was 300)
-	ds201GateReleaseDynamic   = 180  // ms - for dynamic content (was 200)
+	ds201GateReleaseSustained = 300  // ms - for sustained speech
+	ds201GateReleaseMod       = 250  // ms - standard
+	ds201GateReleaseDynamic   = 180  // ms - for dynamic content
 	ds201GateReleaseHoldComp  = 50   // ms - compensation for lack of hold parameter
 	ds201GateReleaseTonalComp = 75   // ms - extra for tonal bleed (hide pump)
 	ds201GateReleaseMin       = 150  // ms - minimum release

--- a/internal/processor/adaptive_noise.go
+++ b/internal/processor/adaptive_noise.go
@@ -9,11 +9,11 @@ package processor
 // - Threshold: 5dB above noise floor (catches breaths but not speech)
 // - Expansion: scales with noise severity (gentle for clean, aggressive for noisy)
 //
-// anlmdn remains constant because spike testing validated these parameters:
+// anlmdn stays constant because spike testing validated these parameters:
 // - strength: 0.00001 (minimum)
 // - patch: 6ms (context window)
-// - research: production default (search window)
-// - smooth: 11 (weight smoothing)
+// - research: 2.0ms / 0.0020s (r_min search window)
+// - smooth: 3 (m_strict weight smoothing)
 func tuneNoiseRemove(config *EffectiveFilterConfig, m *AudioMeasurements) {
 	if !config.NoiseRemove.Enabled {
 		return

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -1437,10 +1437,10 @@ func TestTuneDS201Gate(t *testing.T) {
 		// - mixed: < 0.16
 		// - broadband: >= 0.16
 		//
-		// Base release values (lowered for tighter noise control):
-		// - ds201GateReleaseMod = 250ms (was 300ms)
-		// - ds201GateReleaseSustained = 300ms (was 400ms)
-		// - ds201GateReleaseDynamic = 180ms (was 200ms)
+		// Base release values (tuned for tight noise control):
+		// - ds201GateReleaseMod = 250ms
+		// - ds201GateReleaseSustained = 300ms
+		// - ds201GateReleaseDynamic = 180ms
 		tests := []struct {
 			name           string
 			entropy        float64

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -138,10 +138,6 @@ type SpeechCandidateMetrics struct {
 	WasRefined       bool          `json:"was_refined,omitempty"`       // True if region was refined from a longer candidate
 }
 
-// Room tone detection constants for interval-based analysis
-// AudioMeasurements contains the measurements from Pass 1 analysis.
-// Uses ebur128 (LUFS/LRA), astats (dynamic range/noise floor), and aspectralstats (spectral analysis).
-// Room tone detection is performed in Go using 250ms interval sampling for improved accuracy.
 // BaseMeasurements contains fields shared between input (Pass 1) and output (Pass 2) measurements.
 // Embedded in both AudioMeasurements and OutputMeasurements to avoid duplication.
 type BaseMeasurements struct {
@@ -181,7 +177,7 @@ type BaseMeasurements struct {
 
 // AudioMeasurements contains the measurements from Pass 1 analysis.
 // Uses ebur128 (LUFS/LRA), astats (dynamic range/noise floor), and aspectralstats (spectral analysis).
-// Room tone detection is performed in Go using 250ms interval sampling for improved accuracy.
+// Room tone detection runs in Go using 250ms interval sampling rather than an FFmpeg silence filter.
 type AudioMeasurements struct {
 	// Embed shared measurement fields
 	BaseMeasurements
@@ -263,8 +259,8 @@ type OutputMeasurements struct {
 // Implementation note: ebur128 and astats write measurements to frame metadata with lavfi.r128.*
 // and lavfi.astats.Overall.* keys respectively. We extract these from the last processed frames.
 //
-// The noise floor and silence threshold are computed from interval data AFTER the full pass,
-// eliminating the need for a separate pre-scan phase.
+// The noise floor and silence threshold are computed from interval data after the full pass,
+// avoiding the need for a separate pre-scan phase.
 func AnalyzeAudio(filename string, config *BaseFilterConfig, progressCallback ProgressCallback) (*AudioMeasurements, error) {
 	// Default fallback threshold if interval analysis yields insufficient data
 	const defaultNoiseFloor = -50.0
@@ -668,7 +664,7 @@ func calculateAdaptiveDS201GateThreshold(noiseFloor, rmsTrough float64) float64 
 
 // createAnalysisFilterGraph creates an AVFilterGraph for Pass 1 analysis.
 // Uses astats, aspectralstats, and ebur128 filters to extract measurements.
-// Silence detection is now performed in Go using 250ms interval sampling.
+// Silence detection runs in Go using 250ms interval sampling, not in this graph.
 func createAnalysisFilterGraph(
 	decCtx *ffmpeg.AVCodecContext,
 	config *BaseFilterConfig,

--- a/internal/processor/analyzer_candidates_room_tone_scoring.go
+++ b/internal/processor/analyzer_candidates_room_tone_scoring.go
@@ -9,8 +9,8 @@ import (
 
 // Room tone region scoring for measurement reference extraction.
 //
-// The "noise profile" is no longer used for afftdn training (anlmdn is self-adapting).
-// Instead, these measurements serve as:
+// The "noise profile" is not afftdn training data (anlmdn is self-adapting).
+// These measurements serve as:
 // 1. Reference baseline for adaptive filter tuning (gate, compand, highpass)
 // 2. Comparative measurement point (same region re-measured in later passes)
 //
@@ -21,8 +21,8 @@ import (
 //   - Stable (variance) - intentionally recorded, not accidental gaps
 //   - Duration 8-18s - sufficient data without absorbing content changes
 const (
-	// Duration thresholds (Task 5: adjusted constraints)
-	minimumSilenceDuration = 8 * time.Second  // Minimum 8s (up from 2s) to avoid inter-word gaps
+	// Duration thresholds
+	minimumSilenceDuration = 8 * time.Second  // Minimum 8s to avoid inter-word gaps
 	idealDurationMin       = 8 * time.Second  // Ideal range lower bound
 	idealDurationMax       = 18 * time.Second // Ideal range upper bound
 
@@ -69,8 +69,8 @@ const (
 
 	// Scoring weights (must sum to 1.0)
 	stabilityScoreWeight = 0.25
-	amplitudeScoreWeight = 0.30 // was 0.40
-	spectralScoreWeight  = 0.35 // was 0.50
+	amplitudeScoreWeight = 0.30
+	spectralScoreWeight  = 0.35
 	durationScoreWeight  = 0.10
 
 	// Minimum acceptable score for "first wins" selection

--- a/internal/processor/analyzer_candidates_speech.go
+++ b/internal/processor/analyzer_candidates_speech.go
@@ -107,7 +107,8 @@ const (
 	// fluxAcceptableThreshold: natural speech upper bound.
 	fluxAcceptableThreshold = 0.030
 
-	// SNR margin for noise floor separation (see Phase 7)
+	// minSNRMargin is the minimum speech-to-noise-floor gap (dB) for a speech
+	// candidate; below it, spectral metrics measure noise rather than speech.
 	minSNRMargin = 20.0 // dB
 
 	// Crest factor scoring parameters

--- a/internal/processor/analyzer_metrics.go
+++ b/internal/processor/analyzer_metrics.go
@@ -942,11 +942,9 @@ var (
 	metaKeyEbur128TargetThresh = ffmpeg.GlobalCStr("lavfi.r128.target_threshold")
 )
 
-// metadataAccumulators holds all accumulator variables for frame metadata extraction.
-// Spectral stats (centroid, rolloff) are averaged across all frames.
-// astats and ebur128 values are cumulative, so we keep the latest.
 // baseMetadataAccumulators contains fields shared between input (Pass 1) and output (Pass 2) accumulators.
 // Embedded in both metadataAccumulators and outputMetadataAccumulators to avoid duplication.
+// Spectral stats are averaged across frames; astats and ebur128 values are cumulative, so the latest wins.
 type baseMetadataAccumulators struct {
 	// Spectral statistics from aspectralstats (averaged across frames)
 	spectral SpectralAccumulator
@@ -1345,9 +1343,8 @@ func extractFrameMetadata(metadata *ffmpeg.AVDictionary, acc *metadataAccumulato
 }
 
 // outputMetadataAccumulators holds accumulator variables for Pass 2 output measurement extraction.
-// Mirrors metadataAccumulators but without room tone detection fields.
-// outputMetadataAccumulators holds accumulator variables for Pass 2 output measurement extraction.
 // Uses baseMetadataAccumulators for spectral and astats fields shared with input analysis.
+// Mirrors metadataAccumulators but without room tone detection fields.
 type outputMetadataAccumulators struct {
 	// Embed shared spectral and astats fields
 	baseMetadataAccumulators

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -1054,8 +1054,8 @@ func TestFindBestRoomToneRegion_LaterCandidateWinsWhenGapExceedsTolerance(t *tes
 func TestFindBestRoomToneRegion_LateCandidateDiscoverable(t *testing.T) {
 	// A high-scoring candidate placed at 50% of totalDuration (1800s into a 3600s recording)
 	// is correctly elected when it is the only candidate above minAcceptableScore.
-	// Verifies that all three former restrictions (excludeFirstSeconds, silenceSearchPercent,
-	// candidateCutoffPercent) no longer prevent discovery.
+	// Selection evaluates candidates by score regardless of temporal position, with no
+	// excludeFirstSeconds, silenceSearchPercent, or candidateCutoffPercent gate.
 
 	regions := []RoomToneRegion{
 		{Start: 1800 * time.Second, End: 1810 * time.Second, Duration: 10 * time.Second},

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -39,7 +39,7 @@ const (
 // Pass1FilterOrder defines the filter chain for analysis pass.
 // Downmix → Analysis
 // No processing filters - just measurement for adaptive processing.
-// Silence detection is now performed in Go using 250ms interval sampling.
+// Silence detection runs in Go using 250ms interval sampling, not in the filter graph.
 var Pass1FilterOrder = []FilterID{
 	FilterDownmix,
 	FilterAnalysis,

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -531,7 +531,7 @@ func ApplyNormalisation(
 	// that Pass 4 will apply, closing the measurement mismatch.
 	limiter := planLimiterForLoudnorm(outputMeasurements, config)
 
-	// Pass 3: Run loudnorm measurement pass on Pass 2 output
+	// Pass 3: Run loudnorm measurement pass on Pass 2 output.
 	// When a prefix is active, loudnorm measures the post-limiter signal,
 	// so its InputI/InputTP already reflect pre-gain and limiting.
 	measurement, err := measureWithLoudnorm(inputPath, config, limiter.pass3Prefix, progressCallback)
@@ -911,7 +911,7 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 	// dual_mono=true: CRITICAL - treats mono as dual-mono for correct loudness measurement
 	// print_format=json: Outputs JSON with normalization_type, target_offset, output_i/tp/lra
 	//
-	// Pass 3 now measures with the same volume+alimiter prefix, so measurement.InputI
+	// Pass 3 measures through the same volume+alimiter prefix, so measurement.InputI
 	// and measurement.InputTP already reflect the post-limiter signal. No manual
 	// effectiveMeasuredI/effectiveMeasuredTP adjustment needed.
 	loudnormFilter := fmt.Sprintf(

--- a/internal/processor/normalise_statsfile_test.go
+++ b/internal/processor/normalise_statsfile_test.go
@@ -9,9 +9,8 @@ import (
 
 // TestParseLoudnormStatsFileParsesFixture proves the file-read parse yields the
 // correct LoudnormStats field values for the known loudnormCaptureTestJSON body.
-// The av_log capture path this once compared against was removed in Phase 3; its
-// field-for-field equivalence to the file parse was proven in Phase 1 before the
-// deletion, so this asserts the file parse against the fixture's known values.
+// The stats file is the sole source of loudnorm measurements, so this asserts the
+// file parse against the fixture's known values.
 func TestParseLoudnormStatsFileParsesFixture(t *testing.T) {
 	statsPath, err := createSiblingStatsPath(filepath.Join(t.TempDir(), "output.flac"), "loudnorm")
 	if err != nil {

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -1441,7 +1441,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 				TargetOffset: tt.targetOffset,
 			}
 
-			// Pre-compute values (caller's responsibility after Task 2.2)
+			// Pre-compute values (the caller's responsibility)
 			ceiling, needsLimiting, clamped := calculateLimiterCeiling(
 				tt.inputI, tt.inputTP, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)
@@ -1838,7 +1838,7 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 				TargetOffset: -2.5,
 			}
 
-			// Pre-compute values (caller's responsibility after Task 2.2)
+			// Pre-compute values (the caller's responsibility)
 			bCeiling, bNeeded, bClamped := calculateLimiterCeiling(
 				tt.measuredI, tt.measuredTP, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -262,7 +262,7 @@ func renderCompletedFile(file FileProgress) string {
 
 	icon := lipgloss.NewStyle().Foreground(lipgloss.Color("#00AA00")).Render("✓")
 
-	quality := "★★★★★" // Always 5 stars for now
+	quality := "★★★★★" // Always 5 stars
 
 	return fmt.Sprintf(" %s %s → %s\n"+
 		"   Before: %.1f LUFS | After: %.1f LUFS | Quality: %s\n"+


### PR DESCRIPTION
- Remove dev-process metadata, past-tense narration, and orphan doc lines
- Reword stale prose to present-tense design language for clarity
- Correct `anlmdn` filter parameters: `m=11` → `m=3` (m_strict), `r=0.0045` → `r=0.0020` (r_min)
- Consolidate and preserve why-focused comments in cmd/ and internal/

No functional changes; documentation and comments only.