### PR TITLE
ci(workflows): pass GITHUB_TOKEN to library downloads in test and build jobs

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -105,6 +105,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Download ffmpeg-statigo libraries
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd third_party/ffmpeg-statigo
           go run ./cmd/download-lib
@@ -194,6 +196,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Download ffmpeg-statigo libraries
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd third_party/ffmpeg-statigo
           go run ./cmd/download-lib


### PR DESCRIPTION
Completes the fix from 4997ad8 by propagating the token to the remaining jobs that download ffmpeg-statigo libraries, preventing GitHub API rate-limit failures across parallel matrix builds.