### PR TITLE
feat(processor): add parallel multi-file processing via bounded worker pool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ Go CLI tool for podcast audio preprocessing using embedded FFmpeg. Transforms ra
 ## Architecture
 
 ```
-cmd/jivetalking/main.go     # CLI entry, Kong flags, starts TUI + processing goroutine
+cmd/jivetalking/main.go     # CLI entry, Kong flags, resolveJobs(), ctx + cancel(), starts TUI
+cmd/jivetalking/pool.go     # runWorkerPool() - bounded concurrent multi-file processing
 internal/
 ├── audio/reader.go         # FFmpeg demuxer/decoder wrapper (Reader, Metadata, OpenAudioFile)
 ├── processor/
@@ -50,9 +51,9 @@ internal/
 └── cli/                    # Help styling, version output, error formatting
 ```
 
-**Data flow (processing):** `main.go` spawns goroutine → `ProcessAudio()` → Pass 1 (`AnalyzeAudio`) → `AdaptConfig()` → Pass 2 (filter chain) → Pass 3/4 (`ApplyNormalisation`) → `GenerateReport()` writes an always-on processing report → sends `ui.*Msg` to TUI via `tea.Program.Send()`.
+**Data flow (processing):** `main.go` resolves worker count via `resolveJobs()` (`--jobs`, default auto `min(4, NumCPU)`), creates a cancellable `ctx`, then launches `runWorkerPool()` (`pool.go`) → up to `jobs` files run concurrently, each a goroutine bounded by a semaphore, taking a `CloneForWorker()` config copy and `FileIndex`-routed TUI messages → `ProcessAudio(ctx, …)` → Pass 1 (`AnalyzeAudio`) → `AdaptConfig()` → Pass 2 (filter chain) → Pass 3/4 (`ApplyNormalisation`) → `GenerateReport()` writes an always-on processing report → sends `ui.*Msg` to TUI via `tea.Program.Send()`. After `WaitGroup` drains, the pool sends `ui.AllCompleteMsg`. `cancel()` fires after `p.Run()` returns; `runFilterGraph` checks `ctx.Err()` each frame so in-flight workers abort and run deferred temp cleanup.
 
-**Data flow (analysis-only):** `main.go` → `runAnalysisOnly()` → `AnalyzeOnlyDetailed()` → Pass 1 + `AdaptConfig()` → `AnalysisModel` TUI shows progress → `DisplayAnalysisResults()` prints report to console. No output files created.
+**Data flow (analysis-only):** `main.go` → `runAnalysisOnly()` → `AnalyzeOnlyDetailed()` → Pass 1 + `AdaptConfig()` → `AnalysisModel` TUI shows progress → `DisplayAnalysisResults()` prints report to console. No output files created. This path stays serial; the worker pool covers processing only.
 
 ## Audio processing pipeline
 
@@ -120,7 +121,7 @@ Two separate message sets exist for the two TUI modes.
 
 ## Adaptive processing
 
-`AdaptConfig()` in `adaptive.go` derives per-file filter state from Pass 1 `AudioMeasurements`: it accepts caller-owned `BaseFilterConfig` defaults, returns `EffectiveFilterConfig` for filter building, and returns `AdaptiveDiagnostics` for report-only adaptation explanations. Do not reintroduce `FilterChainConfig` or store pass execution state in config; use `ProcessingFilterContext` for pass-local state.
+`AdaptConfig()` in `adaptive.go` derives per-file filter state from Pass 1 `AudioMeasurements`: it accepts caller-owned `BaseFilterConfig` defaults, returns `EffectiveFilterConfig` for filter building, and returns `AdaptiveDiagnostics` for report-only adaptation explanations. Do not reintroduce `FilterChainConfig` or store pass execution state in config; use `ProcessingFilterContext` for pass-local state. Each pool worker calls `BaseFilterConfig.CloneForWorker()` (shallow copy + deep-copy `FilterOrder` + per-worker logger) so concurrent workers share no mutable config or logger.
 
 - **DS201 highpass frequency:** 60-120Hz based on spectral decrease (warm/thin voice detection) and room-tone noise floor; warm voices use gentler Q (0.5) and reduced wet/dry mix
 - **DS201 lowpass:** Enabled adaptively based on content type and HF noise indicators (rolloff/centroid ratio)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Raw microphone recordings into broadcast-ready audio in one command. No configur
 jivetalking presenter1.flac presenter2.flac
 ```
 
-Your files emerge at -16 LUFS, a common podcast target, with room rumble, background hiss, clicks, and harsh sibilance sorted automatically. Everything needed is embedded in the binary. This is not how audio tools usually work, and that is rather the point.
+Your files emerge at -16 LUFS, a common podcast target, with room rumble, background hiss, clicks, and harsh sibilance sorted automatically. Multiple files process in parallel, each with its own TUI progress row. Everything needed is embedded in the binary. This is not how audio tools usually work, and that is rather the point.
 
 ---
 
@@ -108,6 +108,7 @@ jivetalking [flags] <files...>
 | `-v, --version` | Show version and exit |
 | `-a, --analysis-only` | Run analysis only (Pass 1), display results, skip processing |
 | `-d, --debug` | Enable debug logging to `jivetalking-debug.log` |
+| `--jobs=N` | Number of files to process concurrently. `0` (default) means auto: `min(4, NumCPU)`; an explicit value is honoured with no upper cap |
 | `--room-tone-scan-duration=DURATION` | Cap room-tone candidate scan to the first `DURATION` of input (e.g. `30s`, `1m30s`). Default `0s` scans the whole file |
 | `--silence-scan-duration=DURATION` | Deprecated alias for `--room-tone-scan-duration`; still accepted for backwards compatibility |
 
@@ -115,8 +116,11 @@ jivetalking [flags] <files...>
 ### Examples
 
 ```bash
-# Process multiple presenters
+# Process multiple presenters in parallel (auto worker count)
 jivetalking presenter1.flac presenter2.flac presenter3.flac
+
+# Process all FLAC files with an explicit worker count
+jivetalking --jobs 4 *.flac
 
 # Inspect recordings without processing
 jivetalking -a presenter1.flac presenter2.flac

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -144,7 +144,7 @@ func main() {
 
 	jobs := resolveJobs(cliArgs.Jobs, runtime.NumCPU())
 
-	go runWorkerPool(runCtx, p, cliArgs.Files, config, log, jobs, reportWarnings)
+	poolDone := launchWorkerPool(runCtx, p, cliArgs.Files, config, log, jobs, reportWarnings)
 
 	_, runErr := p.Run()
 
@@ -153,6 +153,16 @@ func main() {
 	// already finished), and on user quit it stops in-flight workers via
 	// ctx.Done() so their deferred temp cleanup runs and wg.Wait() completes.
 	cancel()
+
+	// Wait for the pool to fully unwind before exiting on either path. After a
+	// user quit p.Run() returns immediately while in-flight workers still need
+	// to observe ctx.Done(), abort ProcessAudio, run their deferred temp
+	// cleanup, and call wg.Done(); exiting first would leave temp dotfiles and
+	// violate the no-residue-on-cancel guarantee. No deadlock: post-Run
+	// tea.Program.Send is a non-blocking no-op, so the pool's FileComplete/
+	// AllComplete sends do not block, and the acquire-time ctx.Done() select
+	// lets not-yet-started workers exit at once.
+	<-poolDone
 
 	if err := runErr; err != nil {
 		cli.PrintError(fmt.Sprintf("UI error: %v", err))

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -35,6 +37,7 @@ type CLI struct {
 	AnalysisOnly         bool          `short:"a" help:"Run analysis only (Pass 1), display results, skip processing"`
 	RoomToneScanDuration time.Duration `name:"room-tone-scan-duration" help:"Cap room-tone-candidate scan to the first DURATION of input (e.g. 30s, 1m30s). Faster on long files at the cost of coverage; loudness, true peak, LRA, spectral, and speech analysis remain whole-file. Fewer room-tone candidates also reach voice-activated detection when capped. 0s means scan the whole file." placeholder:"DURATION" default:"0s"`
 	SilenceScanDuration  time.Duration `name:"silence-scan-duration" help:"[deprecated alias for --room-tone-scan-duration] Cap room-tone-candidate scan to the first DURATION of input. Supplying both flags with different non-zero values is rejected. 0s means scan the whole file." placeholder:"DURATION" default:"0s"`
+	Jobs                 int           `name:"jobs" help:"Number of files to process concurrently. 0 means auto (min(4, NumCPU)); an explicit value is honoured with no upper cap." default:"0"`
 	Files                []string      `arg:"" name:"files" help:"Audio files to process" type:"existingfile" optional:""`
 }
 
@@ -61,6 +64,18 @@ func resolveRoomToneScanDuration(roomTone, silence time.Duration, deprecationOut
 		return roomTone, nil
 	}
 	return silence, nil
+}
+
+// resolveJobs resolves the effective worker count from the --jobs flag value
+// and the available CPU count. The flag default of 0 (unset) selects auto mode:
+// min(4, numCPU). Any other value is explicit, clamped to a floor of 1 and
+// honoured with no upper cap, so --jobs above NumCPU is respected. numCPU is a
+// parameter so the function is pure and table-testable.
+func resolveJobs(jobs, numCPU int) int {
+	if jobs == 0 {
+		return min(4, numCPU)
+	}
+	return max(1, jobs)
 }
 
 func main() {
@@ -125,58 +140,21 @@ func main() {
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	reportWarnings := make(chan string, len(cliArgs.Files))
 
-	go func() {
-		for i, inputPath := range cliArgs.Files {
-			fileStartTime := time.Now()
+	runCtx, cancel := context.WithCancel(context.Background())
 
-			log("[MAIN] Sending FileStartMsg for file %d: %s", i, inputPath)
-			p.Send(ui.FileStartMsg{
-				FileIndex: i,
-				FileName:  inputPath,
-			})
+	jobs := resolveJobs(cliArgs.Jobs, runtime.NumCPU())
 
-			ph := &progressHandler{
-				p:         p,
-				log:       log,
-				fileIndex: i,
-			}
+	go runWorkerPool(runCtx, p, cliArgs.Files, config, log, jobs, reportWarnings)
 
-			pass2Start := time.Now()
-			log("[MAIN] Starting ProcessAudio for %s", inputPath)
-			result, err := processor.ProcessAudio(inputPath, config, ph.callback)
-			if err != nil {
-				log("[MAIN] ProcessAudio failed: %v", err)
-				p.Send(ui.FileCompleteMsg{
-					FileIndex: i,
-					Error:     err,
-				})
-				continue
-			}
-			// ProcessAudio runs all four passes; isolate Pass 2 by subtracting the
-			// passes the progress handler timed directly.
-			pass2Time := time.Since(pass2Start) - ph.pass1Time - ph.pass3Time - ph.pass4Time
+	_, runErr := p.Run()
 
-			reportData := buildProcessingReportData(inputPath, fileStartTime, ph.timings(pass2Time), result)
-			if err := logging.GenerateReport(reportData); err != nil {
-				log("[MAIN] Failed to generate log file: %v", err)
-				reportWarnings <- fmt.Sprintf("Report was not written for %s: %v", inputPath, err)
-			}
+	// p.Run() blocks until tea.Quit, fired on q/ctrl+c and on AllCompleteMsg.
+	// Fire cancel() unconditionally: a no-op on natural completion (workers
+	// already finished), and on user quit it stops in-flight workers via
+	// ctx.Done() so their deferred temp cleanup runs and wg.Wait() completes.
+	cancel()
 
-			log("[MAIN] Sending FileCompleteMsg for file %d", i)
-			p.Send(ui.FileCompleteMsg{
-				FileIndex:  i,
-				InputLUFS:  result.InputLUFS,
-				OutputLUFS: result.OutputLUFS,
-				NoiseFloor: result.NoiseFloor,
-				OutputPath: result.OutputPath,
-			})
-		}
-
-		log("[MAIN] Sending AllCompleteMsg")
-		p.Send(ui.AllCompleteMsg{})
-	}()
-
-	if _, err := p.Run(); err != nil {
+	if err := runErr; err != nil {
 		cli.PrintError(fmt.Sprintf("UI error: %v", err))
 		if debugLog != nil {
 			debugLog.Close()
@@ -225,7 +203,7 @@ type analysisOnlyDeps struct {
 	hasTTY          func() bool
 	openMetadata    func(string) (*audio.Metadata, error)
 	runWithTUI      func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error)
-	analyzeDetailed func(string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)
+	analyzeDetailed func(context.Context, string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)
 	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.EffectiveFilterConfig, *processor.AdaptiveDiagnostics, ...logging.AnalysisTimings)
 	printError      func(string)
 }
@@ -337,7 +315,7 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 			// No terminal: skip the progress UI for non-interactive environments.
 			log("[ANALYSIS] No TTY available, running without progress UI")
 			fmt.Fprintf(deps.stdout, "Analysing: %s\n", filepath.Base(inputPath))
-			analysisResult, analysisErr = deps.analyzeDetailed(inputPath, config, nil)
+			analysisResult, analysisErr = deps.analyzeDetailed(context.Background(), inputPath, config, nil)
 		}
 
 		if analysisErr != nil {
@@ -389,7 +367,7 @@ func runAnalysisWithTUI(inputPath string, config *processor.BaseFilterConfig, lo
 			})
 		}
 
-		result, err := processor.AnalyzeOnlyDetailed(path, config, progressCallback)
+		result, err := processor.AnalyzeOnlyDetailed(context.Background(), path, config, progressCallback)
 
 		p.Send(ui.AnalysisCompleteMsg{
 			Result: result,

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -107,12 +108,12 @@ func TestProgressCallbackBoundariesUseProcessorEvent(t *testing.T) {
 	if analyzeDetailed.Type.Kind() != reflect.Func {
 		t.Fatalf("analysisOnlyDeps.analyzeDetailed = %s, want func", analyzeDetailed.Type)
 	}
-	if analyzeDetailed.Type.NumIn() != 3 {
-		t.Fatalf("analysisOnlyDeps.analyzeDetailed has %d parameters, want 3", analyzeDetailed.Type.NumIn())
+	if analyzeDetailed.Type.NumIn() != 4 {
+		t.Fatalf("analysisOnlyDeps.analyzeDetailed has %d parameters, want 4", analyzeDetailed.Type.NumIn())
 	}
-	if analyzeDetailed.Type.In(2) != progressCallbackType {
+	if analyzeDetailed.Type.In(3) != progressCallbackType {
 		t.Fatalf("analysisOnlyDeps.analyzeDetailed progress callback = %s, want %s",
-			analyzeDetailed.Type.In(2), progressCallbackType)
+			analyzeDetailed.Type.In(3), progressCallbackType)
 	}
 
 	callbackType := reflect.TypeOf((&progressHandler{}).callback)
@@ -149,7 +150,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 			t.Fatal("runWithTUI should not be called for non-TTY output")
 			return nil, nil
 		},
-		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		analyzeDetailed: func(_ context.Context, path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
 			if path != inputPath {
 				t.Fatalf("analyzeDetailed path = %q, want %q", path, inputPath)
 			}
@@ -227,7 +228,7 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 			t.Fatal("runWithTUI should not be called for non-TTY output")
 			return nil, nil
 		},
-		analyzeDetailed: func(path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		analyzeDetailed: func(_ context.Context, path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
 			if cfg != baseConfig {
 				t.Fatalf("analyzeDetailed config = %p, want shared base %p", cfg, baseConfig)
 			}
@@ -437,6 +438,44 @@ func TestResolveRoomToneScanDuration_NeitherSetReturnsZero(t *testing.T) {
 	}
 	if got != 0 {
 		t.Fatalf("got = %s, want 0s", got)
+	}
+}
+
+func TestResolveJobs(t *testing.T) {
+	tests := []struct {
+		name   string
+		jobs   int
+		numCPU int
+		want   int
+	}{
+		{name: "auto caps at 4 on 8 CPUs", jobs: 0, numCPU: 8, want: 4},
+		{name: "auto follows CPU count below 4", jobs: 0, numCPU: 2, want: 2},
+		{name: "explicit one stays one", jobs: 1, numCPU: 8, want: 1},
+		{name: "explicit huge value honoured uncapped", jobs: 1000, numCPU: 8, want: 1000},
+		{name: "negative floors to one", jobs: -3, numCPU: 8, want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveJobs(tt.jobs, tt.numCPU); got != tt.want {
+				t.Fatalf("resolveJobs(%d, %d) = %d, want %d", tt.jobs, tt.numCPU, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCLI_JobsFlag_ParsesIntoStructField(t *testing.T) {
+	fixture := makeFixtureFile(t)
+	cliArgs := parseCLIArgs(t, "--jobs", "8", fixture)
+	if cliArgs.Jobs != 8 {
+		t.Fatalf("Jobs = %d, want 8", cliArgs.Jobs)
+	}
+}
+
+func TestCLI_JobsFlag_OmittedDefaultsToZero(t *testing.T) {
+	fixture := makeFixtureFile(t)
+	cliArgs := parseCLIArgs(t, fixture)
+	if cliArgs.Jobs != 0 {
+		t.Fatalf("Jobs = %d, want 0", cliArgs.Jobs)
 	}
 }
 

--- a/cmd/jivetalking/pool.go
+++ b/cmd/jivetalking/pool.go
@@ -18,6 +18,20 @@ import (
 // seam idiom in internal/processor/normalise.go.
 var poolProcessAudio = processor.ProcessAudio
 
+// launchWorkerPool starts runWorkerPool in a goroutine and returns a channel
+// closed once the pool has fully unwound. Callers block on the channel after
+// cancelling the context so all workers' deferred temp cleanup runs before the
+// process exits, giving the no-residue-on-cancel guarantee. Keeping the launch
+// and join in one helper makes the wiring unit-testable apart from main().
+func launchWorkerPool(ctx context.Context, p *tea.Program, files []string, base *processor.BaseFilterConfig, sharedLog func(string, ...any), jobs int, reportWarnings chan<- string) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		runWorkerPool(ctx, p, files, base, sharedLog, jobs, reportWarnings)
+		close(done)
+	}()
+	return done
+}
+
 // runWorkerPool processes files concurrently under a bounded worker pool sharing
 // one tea.Program. A buffered semaphore of size jobs caps in-flight workers; a
 // sync.WaitGroup tracks completion. Each worker owns its file index, a per-file

--- a/cmd/jivetalking/pool.go
+++ b/cmd/jivetalking/pool.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/linuxmatters/jivetalking/internal/logging"
+	"github.com/linuxmatters/jivetalking/internal/processor"
+	"github.com/linuxmatters/jivetalking/internal/ui"
+)
+
+// poolProcessAudio is the processing entry point, a package var so tests can
+// substitute a fake to observe concurrency without running real FFmpeg. It
+// defaults to the real processor call, mirroring the loudnormRunFilterGraph
+// seam idiom in internal/processor/normalise.go.
+var poolProcessAudio = processor.ProcessAudio
+
+// runWorkerPool processes files concurrently under a bounded worker pool sharing
+// one tea.Program. A buffered semaphore of size jobs caps in-flight workers; a
+// sync.WaitGroup tracks completion. Each worker owns its file index, a per-file
+// prefixed logger, and a per-worker config clone, mirroring the serial loop's
+// per-file body. After all workers finish it sends ui.AllCompleteMsg. With
+// jobs == 1 the observable outcome matches the serial path.
+//
+// On cancellation a not-yet-started worker skips its work via the ctx.Done()
+// select at acquire, while an in-flight worker aborts mid-frame because ctx is
+// threaded into ProcessAudio. Either way wg.Done() fires so wg.Wait() returns
+// and ui.AllCompleteMsg is sent.
+func runWorkerPool(ctx context.Context, p *tea.Program, files []string, base *processor.BaseFilterConfig, sharedLog func(string, ...any), jobs int, reportWarnings chan<- string) {
+	sem := make(chan struct{}, jobs)
+	var wg sync.WaitGroup
+
+	for i, inputPath := range files {
+		wg.Add(1)
+		go func(i int, inputPath string) {
+			// Register wg.Done() before the acquire select so a worker skipped
+			// on a cancelled ctx still decrements the WaitGroup; otherwise
+			// wg.Wait() hangs.
+			defer wg.Done()
+
+			// Acquire the semaphore, but bail out if ctx is already cancelled so
+			// a not-yet-started worker skips its work cleanly. Only release the
+			// slot when this branch actually took one.
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+
+			fileStartTime := time.Now()
+
+			wlog := withFilePrefix(inputPath, sharedLog)
+
+			wlog("[POOL] Sending FileStartMsg for file %d: %s", i, inputPath)
+			p.Send(ui.FileStartMsg{
+				FileIndex: i,
+				FileName:  inputPath,
+			})
+
+			ph := &progressHandler{
+				p:         p,
+				log:       wlog,
+				fileIndex: i,
+			}
+
+			clone := base.CloneForWorker(wlog)
+
+			pass2Start := time.Now()
+			wlog("[POOL] Starting ProcessAudio for %s", inputPath)
+			result, err := poolProcessAudio(ctx, inputPath, clone, ph.callback)
+			if err != nil {
+				wlog("[POOL] ProcessAudio failed: %v", err)
+				p.Send(ui.FileCompleteMsg{
+					FileIndex: i,
+					Error:     err,
+				})
+				return
+			}
+
+			// ProcessAudio runs all four passes; isolate Pass 2 by subtracting the
+			// passes the progress handler timed directly.
+			pass2Time := time.Since(pass2Start) - ph.pass1Time - ph.pass3Time - ph.pass4Time
+
+			reportData := buildProcessingReportData(inputPath, fileStartTime, ph.timings(pass2Time), result)
+			if err := logging.GenerateReport(reportData); err != nil {
+				wlog("[POOL] Failed to generate log file: %v", err)
+				reportWarnings <- fmt.Sprintf("Report was not written for %s: %v", inputPath, err)
+			}
+
+			wlog("[POOL] Sending FileCompleteMsg for file %d", i)
+			p.Send(ui.FileCompleteMsg{
+				FileIndex:  i,
+				InputLUFS:  result.InputLUFS,
+				OutputLUFS: result.OutputLUFS,
+				NoiseFloor: result.NoiseFloor,
+				OutputPath: result.OutputPath,
+			})
+		}(i, inputPath)
+	}
+
+	wg.Wait()
+
+	sharedLog("[POOL] Sending AllCompleteMsg")
+	p.Send(ui.AllCompleteMsg{})
+}

--- a/cmd/jivetalking/pool_test.go
+++ b/cmd/jivetalking/pool_test.go
@@ -614,3 +614,91 @@ func TestRunWorkerPool_SerialParityJobs1(t *testing.T) {
 		t.Fatal("AllCompleteMsg did not fire")
 	}
 }
+
+// TestLaunchWorkerPool_DoneClosesAfterPoolUnwinds proves main()'s wiring: the
+// channel launchWorkerPool returns must stay open while workers run and close
+// only after the pool fully unwinds. Were main() not to wait on it, the process
+// could exit before workers' deferred temp cleanup ran. The fake gates on a
+// release channel so the test observes the not-yet-closed state deterministically
+// before letting the worker finish.
+func TestLaunchWorkerPool_DoneClosesAfterPoolUnwinds(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var once sync.Once
+
+	orig := poolProcessAudio
+	poolProcessAudio = func(_ context.Context, _ string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.ProcessingResult, error) {
+		once.Do(func() { close(started) })
+		<-release
+		return nil, errors.New("synthetic error to drive pool error branch")
+	}
+	t.Cleanup(func() { poolProcessAudio = orig })
+
+	model := recordingModel{mu: &sync.Mutex{}, fileComplete: new(int), allComplete: new(bool)}
+	p := tea.NewProgram(model, tea.WithoutRenderer(), tea.WithInput(nil))
+	go func() {
+		if _, err := p.Run(); err != nil {
+			t.Errorf("p.Run() error = %v", err)
+		}
+	}()
+
+	dir := t.TempDir()
+	files := []string{filepath.Join(dir, "fake.flac")}
+	base := processor.DefaultFilterConfig()
+	reportWarnings := make(chan string, len(files))
+
+	done := launchWorkerPool(context.Background(), p, files, base, func(string, ...any) {}, 1, reportWarnings)
+
+	<-started
+	select {
+	case <-done:
+		t.Fatal("done closed while a worker was still in-flight")
+	default:
+	}
+
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("done did not close after the pool unwound")
+	}
+}
+
+// TestLaunchWorkerPool_DoneClosesOnPreCancelledContext proves the wait main()
+// performs cannot wedge: with an already-cancelled context every worker either
+// skips at the acquire-time ctx.Done() select or runs and returns, so every
+// wg.Done() fires and launchWorkerPool's channel closes promptly. The fake
+// returns an error so any worker that does win the acquire race takes the pool's
+// error branch cleanly rather than the nil-result success path.
+func TestLaunchWorkerPool_DoneClosesOnPreCancelledContext(t *testing.T) {
+	orig := poolProcessAudio
+	poolProcessAudio = func(_ context.Context, _ string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.ProcessingResult, error) {
+		return nil, errors.New("synthetic error to drive pool error branch")
+	}
+	t.Cleanup(func() { poolProcessAudio = orig })
+
+	model := recordingModel{mu: &sync.Mutex{}, fileComplete: new(int), allComplete: new(bool)}
+	p := tea.NewProgram(model, tea.WithoutRenderer(), tea.WithInput(nil))
+	go func() {
+		if _, err := p.Run(); err != nil {
+			t.Errorf("p.Run() error = %v", err)
+		}
+	}()
+
+	dir := t.TempDir()
+	files := []string{filepath.Join(dir, "a.flac"), filepath.Join(dir, "b.flac")}
+	base := processor.DefaultFilterConfig()
+	reportWarnings := make(chan string, len(files))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := launchWorkerPool(ctx, p, files, base, func(string, ...any) {}, 1, reportWarnings)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("done did not close on pre-cancelled context")
+	}
+}

--- a/cmd/jivetalking/pool_test.go
+++ b/cmd/jivetalking/pool_test.go
@@ -649,7 +649,11 @@ func TestLaunchWorkerPool_DoneClosesAfterPoolUnwinds(t *testing.T) {
 
 	done := launchWorkerPool(context.Background(), p, files, base, func(string, ...any) {}, 1, reportWarnings)
 
-	<-started
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker never started")
+	}
 	select {
 	case <-done:
 		t.Fatal("done closed while a worker was still in-flight")
@@ -663,6 +667,9 @@ func TestLaunchWorkerPool_DoneClosesAfterPoolUnwinds(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("done did not close after the pool unwound")
 	}
+
+	p.Quit()
+	p.Wait()
 }
 
 // TestLaunchWorkerPool_DoneClosesOnPreCancelledContext proves the wait main()
@@ -701,4 +708,7 @@ func TestLaunchWorkerPool_DoneClosesOnPreCancelledContext(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("done did not close on pre-cancelled context")
 	}
+
+	p.Quit()
+	p.Wait()
 }

--- a/cmd/jivetalking/pool_test.go
+++ b/cmd/jivetalking/pool_test.go
@@ -1,0 +1,616 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/linuxmatters/jivetalking/internal/processor"
+	"github.com/linuxmatters/jivetalking/internal/ui"
+)
+
+// findPoolTestAudio locates a real testdata audio file for the pool tests,
+// mirroring the processor tests' skip-if-missing convention. It returns "" when
+// no audio is present so callers can t.Skipf (project convention: skip, never
+// fail, when testdata/ audio is absent).
+func findPoolTestAudio(t *testing.T) string {
+	t.Helper()
+
+	preferred := filepath.Join("..", "..", "testdata", "fixture-5m.flac")
+	if _, err := os.Stat(preferred); err == nil {
+		return preferred
+	}
+
+	matches, _ := filepath.Glob(filepath.Join("..", "..", "testdata", "*.flac"))
+	if len(matches) == 0 {
+		matches, _ = filepath.Glob(filepath.Join("..", "..", "testdata", "*.wav"))
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+// copyFixtureTo copies src into dir under name, returning the destination path.
+// Each worker needs a DISTINCT input file so it writes its own per-input output
+// without cross-worker contention.
+func copyFixtureTo(t *testing.T, src, dir, name string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", src, err)
+	}
+	dst := filepath.Join(dir, name)
+	if err := os.WriteFile(dst, data, 0o600); err != nil { // #nosec G703 -- test fixture copy into a t.TempDir() with a test-controlled name.
+		t.Fatalf("write fixture copy %s: %v", dst, err)
+	}
+	return dst
+}
+
+// TestRunWorkerPool_ConcurrentRaceClean drives runWorkerPool with jobs >= 2 over
+// two distinct fixture copies under one shared tea.Program and one shared
+// debugSink-backed logger. Run under -race it asserts no data race on the shared
+// tea.Program (p.Send), the shared debugSink, or the per-worker config clones,
+// and that each input produces its <name>-LUFS-NN-processed.<ext> output plus a
+// matching .log report.
+func TestRunWorkerPool_ConcurrentRaceClean(t *testing.T) {
+	src := findPoolTestAudio(t)
+	if src == "" {
+		t.Skip("no audio file found under testdata/; drop a .flac (e.g. testdata/fixture-5m.flac) to run this test")
+	}
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		t.Skipf("testdata audio not found: %s", src)
+	}
+
+	ext := filepath.Ext(src)
+	dir := t.TempDir()
+	files := []string{
+		copyFixtureTo(t, src, dir, "worker-a"+ext),
+		copyFixtureTo(t, src, dir, "worker-b"+ext),
+	}
+
+	// Shared debugSink backs the shared logger; every worker writes whole lines
+	// through it concurrently, exercising the sink's serialisation under -race.
+	sinkFile, err := os.CreateTemp(dir, "debug-*.log")
+	if err != nil {
+		t.Fatalf("create debug sink file: %v", err)
+	}
+	t.Cleanup(func() { sinkFile.Close() })
+	sink := newDebugSink(sinkFile)
+	sharedLog := sink.Logf
+
+	base := processor.DefaultFilterConfig()
+	base.SetLogger(sharedLog)
+
+	model := ui.NewModel(files)
+	// Headless program: no renderer, no input reader, so it runs cleanly under
+	// `go test` with no TTY. It still quits on ui.AllCompleteMsg.
+	p := tea.NewProgram(model, tea.WithoutRenderer(), tea.WithInput(nil))
+
+	reportWarnings := make(chan string, len(files))
+
+	// jobs == 2 so both workers run concurrently, forcing concurrent p.Send,
+	// sink writes, and CloneForWorker calls.
+	go runWorkerPool(context.Background(), p, files, base, sharedLog, 2, reportWarnings)
+
+	if _, err := p.Run(); err != nil {
+		t.Fatalf("p.Run() error = %v", err)
+	}
+
+	close(reportWarnings)
+	for warning := range reportWarnings {
+		t.Errorf("report warning: %s", warning)
+	}
+
+	// Each distinct input must produce its own <name>-LUFS-NN-processed.<ext>
+	// output plus a matching .log report.
+	for _, inputPath := range files {
+		assertProcessedOutput(t, inputPath, ext)
+	}
+}
+
+// TestProcessAudio_ConcurrentRaceClean launches >=2 ProcessAudio goroutines
+// directly, each with its own CloneForWorker clone writing through one shared
+// debugSink-backed logger, synchronised by a WaitGroup. Run under -race it
+// proves the clones and the shared sink carry no data race independent of the
+// tea.Program path, and that each input produces its processed output.
+func TestProcessAudio_ConcurrentRaceClean(t *testing.T) {
+	src := findPoolTestAudio(t)
+	if src == "" {
+		t.Skip("no audio file found under testdata/; drop a .flac (e.g. testdata/fixture-5m.flac) to run this test")
+	}
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		t.Skipf("testdata audio not found: %s", src)
+	}
+
+	ext := filepath.Ext(src)
+	dir := t.TempDir()
+	files := []string{
+		copyFixtureTo(t, src, dir, "direct-a"+ext),
+		copyFixtureTo(t, src, dir, "direct-b"+ext),
+	}
+
+	sinkFile, err := os.CreateTemp(dir, "debug-*.log")
+	if err != nil {
+		t.Fatalf("create debug sink file: %v", err)
+	}
+	t.Cleanup(func() { sinkFile.Close() })
+	sink := newDebugSink(sinkFile)
+	sharedLog := sink.Logf
+
+	base := processor.DefaultFilterConfig()
+	base.SetLogger(sharedLog)
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(files))
+	results := make([]*processor.ProcessingResult, len(files))
+
+	for i, inputPath := range files {
+		wg.Add(1)
+		go func(i int, inputPath string) {
+			defer wg.Done()
+			clone := base.CloneForWorker(withFilePrefix(inputPath, sharedLog))
+			results[i], errs[i] = processor.ProcessAudio(context.Background(), inputPath, clone, nil)
+		}(i, inputPath)
+	}
+	wg.Wait()
+
+	for i, inputPath := range files {
+		if errs[i] != nil {
+			t.Fatalf("ProcessAudio(%s) error = %v", inputPath, errs[i])
+		}
+		if results[i] == nil || results[i].OutputPath == "" {
+			t.Fatalf("ProcessAudio(%s) produced no output path", inputPath)
+		}
+		if _, err := os.Stat(results[i].OutputPath); err != nil {
+			t.Fatalf("output not found for %s: %v", inputPath, err)
+		}
+	}
+}
+
+// assertProcessedOutput asserts the input produced a sibling output matching
+// <name>-LUFS-NN-processed.<ext> and a matching .log report.
+func assertProcessedOutput(t *testing.T, inputPath, ext string) {
+	t.Helper()
+
+	dir := filepath.Dir(inputPath)
+	base := strings.TrimSuffix(filepath.Base(inputPath), ext)
+
+	pattern := filepath.Join(dir, base+"-LUFS-*-processed"+ext)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %s: %v", pattern, err)
+	}
+	if len(matches) != 1 {
+		entries, _ := filepath.Glob(filepath.Join(dir, "*"))
+		t.Fatalf("output for %s: matched %d files for %q, want 1; dir contents: %v",
+			inputPath, len(matches), pattern, entries)
+	}
+
+	logPath := strings.TrimSuffix(matches[0], ext) + ".log"
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("report log not found for %s: %v", inputPath, err)
+	}
+}
+
+// inflightFake substitutes poolProcessAudio to observe pool concurrency without
+// real FFmpeg. It tracks live in-flight workers and the high-water mark, sleeps
+// briefly to create overlap opportunity, records each processed path exactly
+// once, then returns an error so runWorkerPool takes the FileCompleteMsg{Error}
+// branch (no report/output path needed to drive the pool end-to-end).
+type inflightFake struct {
+	live    atomic.Int32
+	maxSeen atomic.Int32
+
+	mu        sync.Mutex
+	processed []string
+}
+
+func (f *inflightFake) fn(_ context.Context, inputPath string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.ProcessingResult, error) {
+	cur := f.live.Add(1)
+	for {
+		old := f.maxSeen.Load()
+		if cur <= old || f.maxSeen.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	f.mu.Lock()
+	f.processed = append(f.processed, inputPath)
+	f.mu.Unlock()
+
+	f.live.Add(-1)
+	return nil, errors.New("inflightFake: synthetic error to drive pool error branch")
+}
+
+// installInflightFake swaps poolProcessAudio for the fake and restores it after
+// the test. The seam var is test-only state; restoration keeps tests isolated.
+func installInflightFake(t *testing.T, f *inflightFake) {
+	t.Helper()
+	orig := poolProcessAudio
+	poolProcessAudio = f.fn
+	t.Cleanup(func() { poolProcessAudio = orig })
+}
+
+// recordingModel is a headless tea.Model that captures pool messages and quits
+// on ui.AllCompleteMsg, letting tests observe FileCompleteMsg/AllCompleteMsg
+// deterministically without touching the production rendering model.
+type recordingModel struct {
+	mu           *sync.Mutex
+	fileComplete *int
+	allComplete  *bool
+}
+
+func (m recordingModel) Init() tea.Cmd { return nil }
+
+func (m recordingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case ui.FileCompleteMsg:
+		m.mu.Lock()
+		*m.fileComplete++
+		m.mu.Unlock()
+	case ui.AllCompleteMsg:
+		m.mu.Lock()
+		*m.allComplete = true
+		m.mu.Unlock()
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m recordingModel) View() string { return "" }
+
+// runPoolWithFake drives runWorkerPool over n synthetic file paths under a
+// headless recording program, returning the fake plus observed completion
+// counts. It reuses 6.1's headless tea.Program setup (no renderer, nil input).
+func runPoolWithFake(t *testing.T, jobs, n int) (*inflightFake, int, bool) {
+	t.Helper()
+
+	fake := &inflightFake{}
+	installInflightFake(t, fake)
+
+	dir := t.TempDir()
+	files := make([]string, n)
+	for i := range files {
+		files[i] = filepath.Join(dir, "fake-"+string(rune('a'+i))+".flac")
+	}
+
+	var mu sync.Mutex
+	fileComplete := 0
+	allComplete := false
+	model := recordingModel{mu: &mu, fileComplete: &fileComplete, allComplete: &allComplete}
+	p := tea.NewProgram(model, tea.WithoutRenderer(), tea.WithInput(nil))
+
+	base := processor.DefaultFilterConfig()
+	reportWarnings := make(chan string, n)
+
+	go runWorkerPool(context.Background(), p, files, base, func(string, ...any) {}, jobs, reportWarnings)
+
+	if _, err := p.Run(); err != nil {
+		t.Fatalf("p.Run() error = %v", err)
+	}
+
+	close(reportWarnings)
+
+	mu.Lock()
+	defer mu.Unlock()
+	return fake, fileComplete, allComplete
+}
+
+// TestRunWorkerPool_InFlightBoundedToOne asserts jobs == 1 holds in-flight
+// workers to a single concurrent ProcessAudio call. The fake records the
+// high-water in-flight mark across 5 files; with jobs == 1 it must never exceed
+// 1, proving serial execution under the pool.
+func TestRunWorkerPool_InFlightBoundedToOne(t *testing.T) {
+	fake, fileComplete, allComplete := runPoolWithFake(t, 1, 5)
+
+	if got := fake.maxSeen.Load(); got != 1 {
+		t.Fatalf("max in-flight with jobs=1 = %d, want 1", got)
+	}
+	if fileComplete != 5 {
+		t.Fatalf("FileCompleteMsg count = %d, want 5", fileComplete)
+	}
+	if !allComplete {
+		t.Fatal("AllCompleteMsg did not fire")
+	}
+}
+
+// TestRunWorkerPool_BoundHonouredForN asserts jobs == 3 caps in-flight workers
+// at 3 over 8 files while still reaching real concurrency (>1), proving the
+// semaphore both bounds and permits parallelism.
+func TestRunWorkerPool_BoundHonouredForN(t *testing.T) {
+	fake, fileComplete, allComplete := runPoolWithFake(t, 3, 8)
+
+	maxSeen := fake.maxSeen.Load()
+	if maxSeen < 2 || maxSeen > 3 {
+		t.Fatalf("max in-flight with jobs=3 = %d, want in (1,3]", maxSeen)
+	}
+	if fileComplete != 8 {
+		t.Fatalf("FileCompleteMsg count = %d, want 8", fileComplete)
+	}
+	if !allComplete {
+		t.Fatal("AllCompleteMsg did not fire")
+	}
+}
+
+// isolationFake substitutes poolProcessAudio so exactly one designated input
+// path errors while every sibling succeeds. Successful calls return a
+// ProcessingResult whose OutputPath sits next to the (synthetic) input so the
+// pool's GenerateReport call writes its .log without a report warning. It mirrors
+// AC4: one failing input must leave siblings unaffected.
+type isolationFake struct {
+	failPath string
+}
+
+func (f *isolationFake) fn(_ context.Context, inputPath string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.ProcessingResult, error) {
+	if inputPath == f.failPath {
+		return nil, errors.New("isolationFake: synthetic unreadable input")
+	}
+	// Derive a sibling output path so GenerateReport writes its .log cleanly.
+	outputPath := strings.TrimSuffix(inputPath, filepath.Ext(inputPath)) + "-LUFS-16-processed" + filepath.Ext(inputPath)
+	if err := os.WriteFile(outputPath, []byte("synthetic"), 0o600); err != nil {
+		return nil, err
+	}
+	return &processor.ProcessingResult{
+		OutputPath: outputPath,
+		InputLUFS:  -23.0,
+		OutputLUFS: -16.0,
+		NoiseFloor: -60.0,
+	}, nil
+}
+
+// isolationModel records per-file completion detail: how many FileCompleteMsg
+// arrived, which file indices carried an Error, and whether AllCompleteMsg fired.
+// It is a richer sibling of recordingModel for AC4 assertions.
+type isolationModel struct {
+	mu          *sync.Mutex
+	completed   *int
+	erroredIdx  *map[int]bool
+	allComplete *bool
+}
+
+func (m isolationModel) Init() tea.Cmd { return nil }
+
+func (m isolationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch v := msg.(type) {
+	case ui.FileCompleteMsg:
+		m.mu.Lock()
+		*m.completed++
+		if v.Error != nil {
+			(*m.erroredIdx)[v.FileIndex] = true
+		}
+		m.mu.Unlock()
+	case ui.AllCompleteMsg:
+		m.mu.Lock()
+		*m.allComplete = true
+		m.mu.Unlock()
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m isolationModel) View() string { return "" }
+
+// TestRunWorkerPool_FailureIsolation drives the pool over several files where one
+// designated input errors and the rest succeed. It asserts AC4: every sibling
+// completes with no error, the failing file's FileCompleteMsg carries its Error,
+// AllCompleteMsg still fires (the partial-failure run completes), and all N files
+// report exactly once (no early abort). Seam-based, so no real audio is needed.
+func TestRunWorkerPool_FailureIsolation(t *testing.T) {
+	const n = 5
+	const failIdx = 2
+
+	dir := t.TempDir()
+	files := make([]string, n)
+	for i := range files {
+		files[i] = filepath.Join(dir, "iso-"+string(rune('a'+i))+".flac")
+	}
+
+	fake := &isolationFake{failPath: files[failIdx]}
+	orig := poolProcessAudio
+	poolProcessAudio = fake.fn
+	t.Cleanup(func() { poolProcessAudio = orig })
+
+	var mu sync.Mutex
+	completed := 0
+	erroredIdx := map[int]bool{}
+	allComplete := false
+	model := isolationModel{mu: &mu, completed: &completed, erroredIdx: &erroredIdx, allComplete: &allComplete}
+	p := tea.NewProgram(model, tea.WithoutRenderer(), tea.WithInput(nil))
+
+	base := processor.DefaultFilterConfig()
+	reportWarnings := make(chan string, n)
+
+	go runWorkerPool(context.Background(), p, files, base, func(string, ...any) {}, 3, reportWarnings)
+
+	if _, err := p.Run(); err != nil {
+		t.Fatalf("p.Run() error = %v", err)
+	}
+
+	close(reportWarnings)
+	for warning := range reportWarnings {
+		t.Errorf("unexpected report warning: %s", warning)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if completed != n {
+		t.Fatalf("FileCompleteMsg count = %d, want %d (every file reports exactly once)", completed, n)
+	}
+	if !allComplete {
+		t.Fatal("AllCompleteMsg did not fire on a partial-failure run")
+	}
+	if !erroredIdx[failIdx] {
+		t.Fatalf("failing file index %d did not carry an Error in its FileCompleteMsg", failIdx)
+	}
+	if len(erroredIdx) != 1 {
+		t.Fatalf("errored file indices = %v, want only {%d} (siblings must be unaffected)", erroredIdx, failIdx)
+	}
+
+	// Each sibling must have produced its output (proof it ran to completion).
+	for i, path := range files {
+		if i == failIdx {
+			continue
+		}
+		out := strings.TrimSuffix(path, filepath.Ext(path)) + "-LUFS-16-processed" + filepath.Ext(path)
+		if _, err := os.Stat(out); err != nil {
+			t.Fatalf("sibling %s did not produce output: %v", path, err)
+		}
+	}
+}
+
+// TestRunWorkerPool_CancellationNoTempResidue exercises AC5 against REAL audio:
+// the real processor creates the .processing-* / .loudnorm-* temp dotfiles, so
+// the seam fake cannot stand in here. It copies a fixture into a dedicated input
+// dir, launches the pool with jobs >= 2, cancels mid-run, waits for the pool to
+// unwind, then lists the input dir to prove no temp dotfile residue remains.
+// The invariant (zero temp residue) holds regardless of when cancel lands, so
+// the test is robust to cancellation timing.
+func TestRunWorkerPool_CancellationNoTempResidue(t *testing.T) {
+	src := findPoolTestAudio(t)
+	if src == "" {
+		t.Skip("no audio file found under testdata/; drop a .flac (e.g. testdata/fixture-5m.flac) to run this test")
+	}
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		t.Skipf("testdata audio not found: %s", src)
+	}
+
+	ext := filepath.Ext(src)
+	// Dedicated input dir so the residue glob inspects exactly these files.
+	dir := t.TempDir()
+	const copies = 3
+	files := make([]string, copies)
+	for i := range files {
+		files[i] = copyFixtureTo(t, src, dir, "cancel-"+string(rune('a'+i))+ext)
+	}
+
+	sinkFile, err := os.CreateTemp(dir, "debug-*.log")
+	if err != nil {
+		t.Fatalf("create debug sink file: %v", err)
+	}
+	t.Cleanup(func() { sinkFile.Close() })
+	sink := newDebugSink(sinkFile)
+	sharedLog := sink.Logf
+
+	base := processor.DefaultFilterConfig()
+	base.SetLogger(sharedLog)
+
+	// Observe the first FileStartMsg, then cancel so at least one worker is
+	// in-flight. AllCompleteMsg releases p.Run() once the pool has unwound.
+	started := make(chan struct{}, copies)
+	model := cancelObserverModel{started: started}
+	p := tea.NewProgram(model, tea.WithoutRenderer(), tea.WithInput(nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reportWarnings := make(chan string, copies)
+
+	poolDone := make(chan struct{})
+	go func() {
+		runWorkerPool(ctx, p, files, base, sharedLog, 2, reportWarnings)
+		close(poolDone)
+	}()
+
+	// Cancel after the first worker has started (in-flight) or, defensively,
+	// after a short delay so the test never wedges if no start arrives.
+	go func() {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+		}
+		cancel()
+	}()
+
+	if _, err := p.Run(); err != nil {
+		t.Fatalf("p.Run() error = %v", err)
+	}
+
+	// Ensure the pool goroutine has fully returned (all wg.Done + deferred temp
+	// cleanup) before listing the dir; mirror cancel's no-op on natural finish.
+	cancel()
+	<-poolDone
+
+	close(reportWarnings)
+	for warning := range reportWarnings {
+		t.Logf("report warning (non-fatal): %s", warning)
+	}
+
+	// Hard AC5 requirement: zero temp dotfiles remain in the input dir.
+	for _, pattern := range []string{
+		filepath.Join(dir, ".processing-*.tmp.flac"),
+		filepath.Join(dir, ".loudnorm-*.tmp.flac"),
+		filepath.Join(dir, ".loudnorm-*.tmp.json"),
+	} {
+		residue, globErr := filepath.Glob(pattern)
+		if globErr != nil {
+			t.Fatalf("glob %s: %v", pattern, globErr)
+		}
+		if len(residue) != 0 {
+			t.Fatalf("temp residue remains after cancel for %q: %v", pattern, residue)
+		}
+	}
+}
+
+// cancelObserverModel signals on the first FileStartMsg (to trigger a mid-run
+// cancel) and quits p.Run() on AllCompleteMsg once the pool unwinds.
+type cancelObserverModel struct {
+	started chan<- struct{}
+}
+
+func (m cancelObserverModel) Init() tea.Cmd { return nil }
+
+func (m cancelObserverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case ui.FileStartMsg:
+		select {
+		case m.started <- struct{}{}:
+		default:
+		}
+	case ui.AllCompleteMsg:
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m cancelObserverModel) View() string { return "" }
+
+// TestRunWorkerPool_SerialParityJobs1 asserts jobs == 1 yields the serial
+// outcome: every submitted file is processed exactly once, every file emits a
+// FileCompleteMsg, and AllCompleteMsg fires. Parity is proven by the fake's
+// per-path record matching the submission set with no duplicates or omissions.
+func TestRunWorkerPool_SerialParityJobs1(t *testing.T) {
+	const n = 5
+	fake, fileComplete, allComplete := runPoolWithFake(t, 1, n)
+
+	if len(fake.processed) != n {
+		t.Fatalf("processed %d files, want %d", len(fake.processed), n)
+	}
+	seen := make(map[string]int, n)
+	for _, p := range fake.processed {
+		seen[p]++
+	}
+	for p, count := range seen {
+		if count != 1 {
+			t.Fatalf("file %s processed %d times, want exactly 1", p, count)
+		}
+	}
+	if len(seen) != n {
+		t.Fatalf("distinct files processed = %d, want %d", len(seen), n)
+	}
+	if fileComplete != n {
+		t.Fatalf("FileCompleteMsg count = %d, want %d", fileComplete, n)
+	}
+	if !allComplete {
+		t.Fatal("AllCompleteMsg did not fire")
+	}
+}

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -2,6 +2,7 @@
 package processor
 
 import (
+	stdcontext "context"
 	"fmt"
 	"math"
 	"time"
@@ -261,12 +262,12 @@ type OutputMeasurements struct {
 //
 // The noise floor and silence threshold are computed from interval data after the full pass,
 // avoiding the need for a separate pre-scan phase.
-func AnalyzeAudio(filename string, config *BaseFilterConfig, progressCallback ProgressCallback) (*AudioMeasurements, error) {
+func AnalyzeAudio(ctx stdcontext.Context, filename string, config *BaseFilterConfig, progressCallback ProgressCallback) (*AudioMeasurements, error) {
 	// Default fallback threshold if interval analysis yields insufficient data
 	const defaultNoiseFloor = -50.0
 
 	analysisContext := &ProcessingFilterContext{Pass: PassAnalysis}
-	collection, err := collectAnalysisFrames(filename, config, analysisContext, progressCallback)
+	collection, err := collectAnalysisFrames(ctx, filename, config, analysisContext, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +482,7 @@ type analysisFrameCollection struct {
 	silenceMedians   silenceMedians
 }
 
-func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *ProcessingFilterContext, progressCallback ProgressCallback) (*analysisFrameCollection, error) {
+func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *BaseFilterConfig, context *ProcessingFilterContext, progressCallback ProgressCallback) (*analysisFrameCollection, error) {
 	reader, metadata, err := audio.OpenAudioFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open audio file: %w", err)
@@ -523,7 +524,7 @@ func collectAnalysisFrames(filename string, config *BaseFilterConfig, context *P
 	var inputSamplesProcessed int64
 	inputSampleRate := float64(reader.GetDecoderContext().SampleRate())
 
-	if err := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	if err := runFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnReadError: func(err error) error {
 			return fmt.Errorf("failed to read frame: %w", err)
 		},

--- a/internal/processor/analyzer_output.go
+++ b/internal/processor/analyzer_output.go
@@ -2,6 +2,7 @@
 package processor
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -35,7 +36,7 @@ type regionMeasurements struct {
 // metrics for a time region in an already-opened audio file. This is the
 // shared implementation behind measureOutputRoomToneRegionFromReader and
 // measureOutputSpeechRegionFromReader.
-func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Duration, log debugLogger) (*regionMeasurements, error) {
+func measureOutputRegionFromReader(ctx context.Context, reader *audio.Reader, start, duration time.Duration, log debugLogger) (*regionMeasurements, error) {
 	if start < 0 {
 		return nil, fmt.Errorf("invalid region: negative start time")
 	}
@@ -106,7 +107,7 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 	}
 
 	lenientHandler := func(err error) error { return nil }
-	_ = runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	_ = runFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnPushError: lenientHandler,
 		OnPullError: lenientHandler,
 		OnFrame:     extractMeasurements,
@@ -165,11 +166,11 @@ func measureOutputRegionFromReader(reader *audio.Reader, start, duration time.Du
 
 // measureOutputRoomToneRegionFromReader measures a room tone region and maps
 // the result to RoomToneCandidateMetrics.
-func measureOutputRoomToneRegionFromReader(reader *audio.Reader, region RoomToneRegion, log debugLogger) (*RoomToneCandidateMetrics, error) {
+func measureOutputRoomToneRegionFromReader(ctx context.Context, reader *audio.Reader, region RoomToneRegion, log debugLogger) (*RoomToneCandidateMetrics, error) {
 	log.Logf("=== measureOutputRoomToneRegion: start=%.3fs, duration=%.3fs ===",
 		region.Start.Seconds(), region.Duration.Seconds())
 
-	result, err := measureOutputRegionFromReader(reader, region.Start, region.Duration, log)
+	result, err := measureOutputRegionFromReader(ctx, reader, region.Start, region.Duration, log)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func extractRegionPair(m *AudioMeasurements) (*RoomToneRegion, *SpeechRegion) {
 //
 // Either region parameter may be nil to skip that measurement. Returns nil for
 // any skipped or failed measurement (non-fatal - matches existing behaviour).
-func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, speechRegion *SpeechRegion, log debugLogger) (*RoomToneCandidateMetrics, *SpeechCandidateMetrics) {
+func MeasureOutputRegions(ctx context.Context, outputPath string, roomToneRegion *RoomToneRegion, speechRegion *SpeechRegion, log debugLogger) (*RoomToneCandidateMetrics, *SpeechCandidateMetrics) {
 	if roomToneRegion == nil && speechRegion == nil {
 		return nil, nil
 	}
@@ -234,7 +235,7 @@ func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, spe
 	// Measure room tone region first (if requested)
 	var roomToneMetrics *RoomToneCandidateMetrics
 	if roomToneRegion != nil {
-		roomToneMetrics, err = measureOutputRoomToneRegionFromReader(reader, *roomToneRegion, log)
+		roomToneMetrics, err = measureOutputRoomToneRegionFromReader(ctx, reader, *roomToneRegion, log)
 		if err != nil {
 			log.Logf("Warning: Failed to measure room tone region: %v", err)
 			// Non-fatal - continue to speech measurement
@@ -251,7 +252,7 @@ func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, spe
 			}
 		}
 
-		speechMetrics, err := measureOutputSpeechRegionFromReader(reader, *speechRegion, log)
+		speechMetrics, err := measureOutputSpeechRegionFromReader(ctx, reader, *speechRegion, log)
 		if err != nil {
 			log.Logf("Warning: Failed to measure speech region: %v", err)
 			return roomToneMetrics, nil
@@ -264,11 +265,11 @@ func MeasureOutputRegions(outputPath string, roomToneRegion *RoomToneRegion, spe
 
 // measureOutputSpeechRegionFromReader measures a speech region and maps
 // the result to SpeechCandidateMetrics.
-func measureOutputSpeechRegionFromReader(reader *audio.Reader, region SpeechRegion, log debugLogger) (*SpeechCandidateMetrics, error) {
+func measureOutputSpeechRegionFromReader(ctx context.Context, reader *audio.Reader, region SpeechRegion, log debugLogger) (*SpeechCandidateMetrics, error) {
 	log.Logf("=== measureOutputSpeechRegion: start=%.3fs, duration=%.3fs ===",
 		region.Start.Seconds(), region.Duration.Seconds())
 
-	result, err := measureOutputRegionFromReader(reader, region.Start, region.Duration, log)
+	result, err := measureOutputRegionFromReader(ctx, reader, region.Start, region.Duration, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/processor/analyzer_output_test.go
+++ b/internal/processor/analyzer_output_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -21,7 +22,7 @@ func measureOutputRoomToneRegion(outputPath string, region RoomToneRegion) (*Roo
 	}
 	defer reader.Close()
 
-	return measureOutputRoomToneRegionFromReader(reader, region, nil)
+	return measureOutputRoomToneRegionFromReader(context.Background(), reader, region, nil)
 }
 
 // measureOutputSpeechRegion analyses a speech region in the output file
@@ -37,7 +38,7 @@ func measureOutputSpeechRegion(outputPath string, region SpeechRegion) (*SpeechC
 	}
 	defer reader.Close()
 
-	return measureOutputSpeechRegionFromReader(reader, region, nil)
+	return measureOutputSpeechRegionFromReader(context.Background(), reader, region, nil)
 }
 
 func TestExtractRegionPair(t *testing.T) {

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"context"
 	"encoding/json"
 	"math"
 	"testing"
@@ -348,7 +349,7 @@ func TestAnalyzeAudio(t *testing.T) {
 			}
 		}
 
-		measurements, err := AnalyzeAudio(testFile, config, progressCallback)
+		measurements, err := AnalyzeAudio(context.Background(), testFile, config, progressCallback)
 		if err != nil {
 			t.Fatalf("AnalyzeAudio failed: %v", err)
 		}
@@ -412,7 +413,7 @@ func TestAnalyzeAudioDoesNotMutateCallerConfig(t *testing.T) {
 	originalOrder := append([]FilterID(nil), config.FilterOrder...)
 	originalRoomToneScanDuration := config.Analysis.RoomToneScanDuration
 
-	if _, err := AnalyzeAudio(testFile, config, nil); err != nil {
+	if _, err := AnalyzeAudio(context.Background(), testFile, config, nil); err != nil {
 		t.Fatalf("AnalyzeAudio failed: %v", err)
 	}
 
@@ -2624,7 +2625,7 @@ func TestRunFilterGraph(t *testing.T) {
 	var inputFrameCount int
 	var filteredFrameCount int
 
-	err = runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	err = runFilterGraph(context.Background(), reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnInputFrame: func(_ *ffmpeg.AVFrame) {
 			inputFrameCount++
 		},
@@ -2678,7 +2679,7 @@ func TestRunFilterGraphLenientErrors(t *testing.T) {
 
 	// Run with lenient push errors (continue on push failure) and discard-only
 	var frameCount int
-	err = runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	err = runFilterGraph(context.Background(), reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnPushError: func(_ error) error { return nil }, // lenient: continue
 		OnFrame: func(_, _ *ffmpeg.AVFrame) error {
 			frameCount++
@@ -2881,7 +2882,7 @@ func TestAnalyzeAudio_RoomToneScanDuration(t *testing.T) {
 	baselineConfig := newTestBaseConfig()
 	baselineConfig.Analysis.Enabled = true
 
-	baseline, err := AnalyzeAudio(testFile, baselineConfig, nil)
+	baseline, err := AnalyzeAudio(context.Background(), testFile, baselineConfig, nil)
 	if err != nil {
 		t.Fatalf("baseline AnalyzeAudio failed: %v", err)
 	}
@@ -2923,7 +2924,7 @@ func TestAnalyzeAudio_RoomToneScanDuration(t *testing.T) {
 		config.Analysis.Enabled = true
 		config.Analysis.RoomToneScanDuration = 0
 
-		got, err := AnalyzeAudio(testFile, config, nil)
+		got, err := AnalyzeAudio(context.Background(), testFile, config, nil)
 		if err != nil {
 			t.Fatalf("AnalyzeAudio failed: %v", err)
 		}
@@ -2952,7 +2953,7 @@ func TestAnalyzeAudio_RoomToneScanDuration(t *testing.T) {
 		config.Analysis.Enabled = true
 		config.Analysis.RoomToneScanDuration = 2 * time.Second
 
-		got, err := AnalyzeAudio(testFile, config, nil)
+		got, err := AnalyzeAudio(context.Background(), testFile, config, nil)
 		if err != nil {
 			t.Fatalf("AnalyzeAudio failed: %v", err)
 		}
@@ -2974,7 +2975,7 @@ func TestAnalyzeAudio_RoomToneScanDuration(t *testing.T) {
 		config.Analysis.Enabled = true
 		config.Analysis.RoomToneScanDuration = 60 * time.Second
 
-		got, err := AnalyzeAudio(testFile, config, nil)
+		got, err := AnalyzeAudio(context.Background(), testFile, config, nil)
 		if err != nil {
 			t.Fatalf("AnalyzeAudio failed: %v", err)
 		}
@@ -3002,7 +3003,7 @@ func TestAnalyzeAudio_RoomToneScanDuration(t *testing.T) {
 		config.Analysis.Enabled = true
 		config.Analysis.RoomToneScanDuration = 60 * time.Second
 
-		got, err := AnalyzeAudio(testFile, config, nil)
+		got, err := AnalyzeAudio(context.Background(), testFile, config, nil)
 		if err != nil {
 			t.Fatalf("AnalyzeAudio failed: %v", err)
 		}

--- a/internal/processor/benchmark_test.go
+++ b/internal/processor/benchmark_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func BenchmarkAnalyzeAudioSynthetic5m(b *testing.B) {
 	for range b.N {
 		config := newTestBaseConfig()
 		config.Analysis.Enabled = true
-		if _, err := AnalyzeAudio(inputPath, config, nil); err != nil {
+		if _, err := AnalyzeAudio(context.Background(), inputPath, config, nil); err != nil {
 			b.Fatalf("AnalyzeAudio failed: %v", err)
 		}
 	}
@@ -31,7 +32,7 @@ func BenchmarkProcessAudioDefaultSynthetic5m(b *testing.B) {
 	b.ResetTimer()
 	for range b.N {
 		config := DefaultFilterConfig()
-		result, err := ProcessAudio(inputPath, config, nil)
+		result, err := ProcessAudio(context.Background(), inputPath, config, nil)
 		if err != nil {
 			b.Fatalf("ProcessAudio failed: %v", err)
 		}
@@ -56,7 +57,7 @@ func BenchmarkProcessAudioManualFixture(b *testing.B) {
 	b.ResetTimer()
 	for range b.N {
 		config := DefaultFilterConfig()
-		result, err := ProcessAudio(inputPath, config, nil)
+		result, err := ProcessAudio(context.Background(), inputPath, config, nil)
 		if err != nil {
 			b.Fatalf("ProcessAudio failed: %v", err)
 		}
@@ -86,7 +87,7 @@ func BenchmarkMeasureOutputRegions(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		MeasureOutputRegions(inputPath, roomToneRegion, speechRegion, nil)
+		MeasureOutputRegions(context.Background(), inputPath, roomToneRegion, speechRegion, nil)
 	}
 }
 

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -196,7 +197,7 @@ func runFullbenchFilterSpecCore(tb testing.TB, inputPath, outputPath, filterSpec
 		outputAcc = &outputMetadataAccumulators{}
 	}
 
-	if err := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	if err := runFilterGraph(context.Background(), reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnReadError: func(err error) error {
 			return fmt.Errorf("failed to read frame: %w", err)
 		},
@@ -910,7 +911,7 @@ func setupFullbenchAdaptedConfig(tb testing.TB, inputPath string) *fullbenchAdap
 	tb.Helper()
 
 	config := DefaultFilterConfig()
-	analysisResult, err := AnalyzeOnlyDetailed(inputPath, config, nil)
+	analysisResult, err := AnalyzeOnlyDetailed(context.Background(), inputPath, config, nil)
 	if err != nil {
 		tb.Fatalf("failed to prepare fullbench adapted config: %v", err)
 	}
@@ -967,7 +968,7 @@ func setupFullbenchLoudnormMeasurement(tb testing.TB, seed *fullbenchPass2Seed) 
 
 	config := *seed.Config
 	limiter := planLimiterForLoudnorm(seed.OutputMeasurements, &config)
-	measurement, err := measureWithLoudnorm(seed.OutputPath, &config, limiter.pass3Prefix, nil)
+	measurement, err := measureWithLoudnorm(context.Background(), seed.OutputPath, &config, limiter.pass3Prefix, nil)
 	if err != nil {
 		tb.Fatalf("failed to prepare fullbench loudnorm measurement: %v", err)
 	}

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -323,6 +323,17 @@ func (cfg *BaseFilterConfig) SetLogger(l func(format string, args ...any)) {
 	cfg.logger = debugLogger(l)
 }
 
+// CloneForWorker returns a per-worker config that shares no mutable state with
+// cfg. It shallow-copies the value, deep-copies the sole reference field
+// FilterOrder, and installs the per-worker logger. Concurrent workers may each
+// own and process their clone without racing on the base.
+func (cfg *BaseFilterConfig) CloneForWorker(logger func(format string, args ...any)) *BaseFilterConfig {
+	wc := *cfg
+	wc.FilterOrder = cloneFilterOrder(cfg.FilterOrder)
+	wc.SetLogger(logger)
+	return &wc
+}
+
 func defaultFilterConfigDefaults() filterConfigDefaults {
 	return assembleFilterDefaults(
 		defaultDownmixConfig(),

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -1281,6 +1281,72 @@ func staleFlatConfigFieldNames() []string {
 	}
 }
 
+func TestCloneForWorkerIsolatesStateAcrossClones(t *testing.T) {
+	base := DefaultFilterConfig()
+	base.FilterOrder = []FilterID{FilterDownmix, FilterAnalysis, FilterResample}
+
+	var sinkA, sinkB []string
+	cloneA := base.CloneForWorker(func(format string, args ...any) {
+		sinkA = append(sinkA, fmt.Sprintf(format, args...))
+	})
+	cloneB := base.CloneForWorker(func(format string, args ...any) {
+		sinkB = append(sinkB, fmt.Sprintf(format, args...))
+	})
+
+	// (a) FilterOrder independence: clones and base must not share a backing array.
+	baseOrderBefore := append([]FilterID(nil), base.FilterOrder...)
+	cloneBOrderBefore := append([]FilterID(nil), cloneB.FilterOrder...)
+
+	cloneA.FilterOrder[0] = FilterDeesser                                 // overwrite element
+	cloneA.FilterOrder = append(cloneA.FilterOrder, FilterLA2ACompressor) // grow slice
+
+	if !reflect.DeepEqual(base.FilterOrder, baseOrderBefore) {
+		t.Errorf("clone A FilterOrder mutation changed base: got %v, want %v",
+			base.FilterOrder, baseOrderBefore)
+	}
+	if !reflect.DeepEqual(cloneB.FilterOrder, cloneBOrderBefore) {
+		t.Errorf("clone A FilterOrder mutation changed clone B: got %v, want %v",
+			cloneB.FilterOrder, cloneBOrderBefore)
+	}
+
+	// Mutating clone B must not bleed into clone A or the base either.
+	cloneA.FilterOrder = append([]FilterID(nil), cloneA.FilterOrder...)
+	cloneAOrderBefore := append([]FilterID(nil), cloneA.FilterOrder...)
+	cloneB.FilterOrder[1] = FilterDS201Gate
+	if !reflect.DeepEqual(base.FilterOrder, baseOrderBefore) {
+		t.Errorf("clone B FilterOrder mutation changed base: got %v, want %v",
+			base.FilterOrder, baseOrderBefore)
+	}
+	if !reflect.DeepEqual(cloneA.FilterOrder, cloneAOrderBefore) {
+		t.Errorf("clone B FilterOrder mutation changed clone A: got %v, want %v",
+			cloneA.FilterOrder, cloneAOrderBefore)
+	}
+
+	// (b) Logger independence: each clone's logger writes only to its own sink.
+	cloneA.logger.Logf("from A %d", 1)
+	if got := len(sinkA); got != 1 {
+		t.Fatalf("clone A logger wrote %d lines to sink A, want 1", got)
+	}
+	if got := len(sinkB); got != 0 {
+		t.Fatalf("clone A logger leaked %d lines into sink B, want 0", got)
+	}
+
+	cloneB.logger.Logf("from B %d", 2)
+	if got := len(sinkB); got != 1 {
+		t.Fatalf("clone B logger wrote %d lines to sink B, want 1", got)
+	}
+	if got := len(sinkA); got != 1 {
+		t.Fatalf("clone B logger leaked into sink A: sink A now has %d lines, want 1", got)
+	}
+
+	if sinkA[0] != "from A 1" {
+		t.Errorf("sink A = %q, want %q", sinkA[0], "from A 1")
+	}
+	if sinkB[0] != "from B 2" {
+		t.Errorf("sink B = %q, want %q", sinkB[0], "from B 2")
+	}
+}
+
 func TestDbToLinear(t *testing.T) {
 	// Test 6 from PLAN.md: dB/Linear conversion accuracy
 	tests := []struct {

--- a/internal/processor/frame_processor.go
+++ b/internal/processor/frame_processor.go
@@ -2,6 +2,7 @@
 package processor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -47,6 +48,7 @@ type FrameLoopConfig struct {
 //
 // The caller owns the filter graph lifetime - runFilterGraph does NOT free it.
 func runFilterGraph(
+	ctx context.Context,
 	reader *audio.Reader,
 	bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
 	config FrameLoopConfig,
@@ -86,6 +88,10 @@ func runFilterGraph(
 
 	// Main read loop
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		frame, err := reader.ReadFrame()
 		if err != nil {
 			if config.OnReadError != nil {

--- a/internal/processor/frame_processor_test.go
+++ b/internal/processor/frame_processor_test.go
@@ -1,0 +1,130 @@
+package processor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
+	"github.com/linuxmatters/jivetalking/internal/audio"
+)
+
+// openTestFilterGraph opens a real testdata audio file and builds a passthrough
+// (anull) filter graph for driving runFilterGraph. It skips the test gracefully
+// when no testdata audio is present (project convention). The returned cleanup
+// frees the graph and closes the reader.
+func openTestFilterGraph(t *testing.T) (
+	reader *audio.Reader,
+	src, sink *ffmpeg.AVFilterContext,
+	cleanup func(),
+) {
+	t.Helper()
+
+	inputPath := findProbeAudioFile()
+	if inputPath == "" {
+		t.Skip("no audio file found under testdata/; drop a .flac (e.g. testdata/fixture-5m.flac) to run this test")
+	}
+	if _, err := os.Stat(inputPath); os.IsNotExist(err) {
+		t.Skipf("testdata audio not found: %s", inputPath)
+	}
+
+	r, _, err := audio.OpenAudioFile(inputPath)
+	if err != nil {
+		t.Fatalf("failed to open test audio %s: %v", inputPath, err)
+	}
+
+	graph, srcCtx, sinkCtx, err := setupFilterGraph(r.GetDecoderContext(), "anull")
+	if err != nil {
+		r.Close()
+		t.Fatalf("failed to create filter graph: %v", err)
+	}
+
+	return r, srcCtx, sinkCtx, func() {
+		ffmpeg.AVFilterGraphFree(&graph)
+		r.Close()
+	}
+}
+
+// TestRunFilterGraphContextCancellation proves runFilterGraph honours ctx
+// cancellation promptly: it returns context.Canceled before draining the whole
+// file rather than only after EOF.
+func TestRunFilterGraphContextCancellation(t *testing.T) {
+	// Baseline: count total input frames in the file so "promptly" can be
+	// asserted as a frame-count bound well below the full length.
+	totalFrames := func() int {
+		reader, src, sink, cleanup := openTestFilterGraph(t)
+		defer cleanup()
+
+		var count int
+		err := runFilterGraph(context.Background(), reader, src, sink, FrameLoopConfig{
+			OnInputFrame: func(_ *ffmpeg.AVFrame) { count++ },
+		})
+		if err != nil {
+			t.Fatalf("baseline runFilterGraph failed: %v", err)
+		}
+		if count == 0 {
+			t.Fatal("baseline read zero frames; cannot assert a cancellation bound")
+		}
+		return count
+	}()
+	t.Logf("baseline total input frames: %d", totalFrames)
+
+	t.Run("pre-cancelled ctx processes ~0 frames", func(t *testing.T) {
+		reader, src, sink, cleanup := openTestFilterGraph(t)
+		defer cleanup()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var processed int
+		err := runFilterGraph(ctx, reader, src, sink, FrameLoopConfig{
+			OnInputFrame: func(_ *ffmpeg.AVFrame) { processed++ },
+		})
+
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		// The ctx.Err() check sits at the top of the read loop, before the
+		// first ReadFrame, so a pre-cancelled ctx must process zero frames.
+		if processed != 0 {
+			t.Errorf("processed %d frames with pre-cancelled ctx, want 0", processed)
+		}
+	})
+
+	t.Run("ctx cancelled after N frames stops well before EOF", func(t *testing.T) {
+		reader, src, sink, cleanup := openTestFilterGraph(t)
+		defer cleanup()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		const cancelAfter = 5
+		var processed int
+		err := runFilterGraph(ctx, reader, src, sink, FrameLoopConfig{
+			OnInputFrame: func(_ *ffmpeg.AVFrame) {
+				processed++
+				if processed == cancelAfter {
+					cancel()
+				}
+			},
+		})
+
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		// After cancel() fires inside OnInputFrame at frame N, the loop pushes
+		// and pulls that frame, then re-checks ctx.Err() at the top of the next
+		// iteration and returns. At most one extra frame is processed beyond N.
+		if processed > cancelAfter+1 {
+			t.Errorf("processed %d frames after cancel-at-%d, want <= %d",
+				processed, cancelAfter, cancelAfter+1)
+		}
+		// Prompt stop: must abort well before draining the whole file.
+		if processed >= totalFrames {
+			t.Errorf("processed %d frames; cancellation did not stop before EOF (total %d)",
+				processed, totalFrames)
+		}
+		t.Logf("cancelled after %d frames; processed %d of %d total", cancelAfter, processed, totalFrames)
+	})
+}

--- a/internal/processor/loudnorm_logprobe_test.go
+++ b/internal/processor/loudnorm_logprobe_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -117,7 +118,7 @@ func TestLoudnormLogProbe(t *testing.T) {
 	phase = "loop"
 	mu.Unlock()
 
-	if err := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	if err := runFilterGraph(context.Background(), reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnReadError: func(err error) error { return err },
 		OnPushError: func(err error) error { return err },
 		OnPullError: func(err error) error { return err },

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -2,6 +2,7 @@
 package processor
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -113,7 +114,7 @@ type LoudnormMeasurement struct {
 // Returns:
 //   - measurement: Loudnorm measurements for second pass
 //   - err: Error if measurement failed
-func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filterPrefix string, progressCallback ProgressCallback) (*LoudnormMeasurement, error) {
+func measureWithLoudnorm(ctx context.Context, inputPath string, config *EffectiveFilterConfig, filterPrefix string, progressCallback ProgressCallback) (*LoudnormMeasurement, error) {
 	// Open input file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
@@ -167,7 +168,7 @@ func measureWithLoudnorm(inputPath string, config *EffectiveFilterConfig, filter
 
 	// Process all frames through loudnorm (no encoding - just measurement)
 	lenientHandler := func(err error) error { return nil }
-	loopErr := loudnormRunFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	loopErr := loudnormRunFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnPushError: lenientHandler,
 		OnPullError: lenientHandler,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
@@ -506,6 +507,7 @@ type NormalisationResult struct {
 //   - result: Normalisation outcome with before/after measurements
 //   - err: Error if normalisation failed
 func ApplyNormalisation(
+	ctx context.Context,
 	inputPath string,
 	config *EffectiveFilterConfig,
 	outputMeasurements *OutputMeasurements,
@@ -534,7 +536,7 @@ func ApplyNormalisation(
 	// Pass 3: Run loudnorm measurement pass on Pass 2 output.
 	// When a prefix is active, loudnorm measures the post-limiter signal,
 	// so its InputI/InputTP already reflect pre-gain and limiting.
-	measurement, err := measureWithLoudnorm(inputPath, config, limiter.pass3Prefix, progressCallback)
+	measurement, err := measureWithLoudnorm(ctx, inputPath, config, limiter.pass3Prefix, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("loudnorm measurement pass failed: %w", err)
 	}
@@ -576,7 +578,7 @@ func ApplyNormalisation(
 	effectiveConfig.Loudnorm.TargetI = effectiveTargetI
 
 	// Pass 4: Apply loudnorm with linear=true and the measurements
-	application, err := applyLoudnormAndMeasure(loudnormApplicationRequest{
+	application, err := applyLoudnormAndMeasure(ctx, loudnormApplicationRequest{
 		inputPath:         inputPath,
 		config:            &effectiveConfig,
 		measurement:       measurement,
@@ -636,8 +638,8 @@ func ApplyNormalisation(
 //
 // Returns the measured integrated loudness, true peak, full output measurements,
 // and loudnorm diagnostic stats.
-func applyLoudnormAndMeasure(request loudnormApplicationRequest, log debugLogger) (*loudnormApplicationResult, error) {
-	prep, err := prepareLoudnormApplication(request)
+func applyLoudnormAndMeasure(ctx context.Context, request loudnormApplicationRequest, log debugLogger) (*loudnormApplicationResult, error) {
+	prep, err := prepareLoudnormApplication(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -661,17 +663,22 @@ func applyLoudnormAndMeasure(request loudnormApplicationRequest, log debugLogger
 		return stats
 	}
 
-	execution, err := executeAndPublishLoudnormApplication(prep, request, freeGraphAndReadStats, removeTemp)
+	execution, err := executeAndPublishLoudnormApplication(ctx, prep, request, freeGraphAndReadStats, removeTemp)
 	if err != nil {
 		return &loudnormApplicationResult{loudnormStats: execution.loudnormStats}, err
 	}
 
 	stats := freeGraphAndReadStats()
 
-	return finalizeLoudnormApplicationResult(request, execution, stats, log), nil
+	return finalizeLoudnormApplicationResult(ctx, request, execution, stats, log), nil
 }
 
-func prepareLoudnormApplication(request loudnormApplicationRequest) (*loudnormApplicationPreparation, error) {
+func prepareLoudnormApplication(ctx context.Context, request loudnormApplicationRequest) (*loudnormApplicationPreparation, error) {
+	// Abort before opening the input and allocating a filter graph if cancelled.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	reader, metadata, err := audio.OpenAudioFile(request.inputPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open input: %w", err)
@@ -727,6 +734,7 @@ func prepareLoudnormApplication(request loudnormApplicationRequest) (*loudnormAp
 }
 
 func executeAndPublishLoudnormApplication(
+	ctx context.Context,
 	prep *loudnormApplicationPreparation,
 	request loudnormApplicationRequest,
 	captureGraphStats func() *LoudnormStats,
@@ -755,7 +763,7 @@ func executeAndPublishLoudnormApplication(
 	const progressUpdateInterval = 100 // Send progress update every N frames
 
 	lenientHandler := func(err error) error { return nil }
-	loopErr := loudnormRunFilterGraph(prep.reader, prep.bufferSrcCtx, prep.bufferSinkCtx, FrameLoopConfig{
+	loopErr := loudnormRunFilterGraph(ctx, prep.reader, prep.bufferSrcCtx, prep.bufferSinkCtx, FrameLoopConfig{
 		OnPushError: lenientHandler,
 		OnPullError: lenientHandler,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
@@ -824,12 +832,14 @@ func executeAndPublishLoudnormApplication(
 }
 
 func finalizeLoudnormApplicationResult(
+	ctx context.Context,
 	request loudnormApplicationRequest,
 	execution *loudnormApplicationExecutionResult,
 	stats *LoudnormStats,
 	log debugLogger,
 ) *loudnormApplicationResult {
 	finalMeasurements, regionMeasurementTime := finalizeLoudnormOutputMeasurements(
+		ctx,
 		request.inputPath,
 		request.inputMeasurements,
 		&execution.acc,
@@ -846,6 +856,7 @@ func finalizeLoudnormApplicationResult(
 }
 
 func finalizeLoudnormOutputMeasurements(
+	ctx context.Context,
 	inputPath string,
 	inputMeasurements *AudioMeasurements,
 	acc *outputMetadataAccumulators,
@@ -864,7 +875,7 @@ func finalizeLoudnormOutputMeasurements(
 	}
 
 	regionStart := time.Now()
-	roomToneSample, spSample := MeasureOutputRegions(inputPath, roomToneRegion, spRegion, log)
+	roomToneSample, spSample := MeasureOutputRegions(ctx, inputPath, roomToneRegion, spRegion, log)
 	regionMeasurementTime = time.Since(regionStart)
 	finalMeasurements.RoomToneSample = roomToneSample
 	finalMeasurements.SpeechSample = spSample

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -2,6 +2,7 @@
 package processor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -40,6 +41,7 @@ func injectLoudnormStatsViaRun(
 
 	oldRun := loudnormRunFilterGraph
 	loudnormRunFilterGraph = func(
+		_ context.Context,
 		_ *audio.Reader,
 		_, _ *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -58,7 +60,7 @@ func injectLoudnormStatsViaRun(
 }
 
 func TestMeasureWithLoudnormReturnsOpenError(t *testing.T) {
-	_, err := measureWithLoudnorm("/does/not/exist.wav", defaultNormalisationTestConfig(), "", nil)
+	_, err := measureWithLoudnorm(context.Background(), "/does/not/exist.wav", defaultNormalisationTestConfig(), "", nil)
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want open error")
 	}
@@ -70,7 +72,7 @@ func TestMeasureWithLoudnormReturnsOpenError(t *testing.T) {
 func TestMeasureWithLoudnormReturnsSetupError(t *testing.T) {
 	testFile := generateLoudnormApplicationTestAudio(t)
 
-	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "not_a_real_filter", nil)
+	_, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "not_a_real_filter", nil)
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want setup error")
 	}
@@ -93,6 +95,7 @@ func TestMeasureWithLoudnormLoopErrorTakesPrecedenceOverStats(t *testing.T) {
 	runErr := errors.New("injected frame loop failure")
 	oldRun := loudnormRunFilterGraph
 	loudnormRunFilterGraph = func(
+		_ context.Context,
 		reader *audio.Reader,
 		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -103,7 +106,7 @@ func TestMeasureWithLoudnormLoopErrorTakesPrecedenceOverStats(t *testing.T) {
 		loudnormRunFilterGraph = oldRun
 	})
 
-	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	_, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "", nil)
 	if !errors.Is(err, runErr) {
 		t.Fatalf("measureWithLoudnorm() error = %v, want wrapped run error", err)
 	}
@@ -120,7 +123,7 @@ func TestMeasureWithLoudnormEmptyStatsFileFails(t *testing.T) {
 	testFile := generateLoudnormApplicationTestAudio(t)
 	injectLoudnormStatsViaRun(t, testFile, "", nil)
 
-	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	_, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "", nil)
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want missing JSON error")
 	}
@@ -137,7 +140,7 @@ func TestMeasureWithLoudnormMalformedStatsFileFails(t *testing.T) {
 	testFile := generateLoudnormApplicationTestAudio(t)
 	injectLoudnormStatsViaRun(t, testFile, "{not-json}", nil)
 
-	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	_, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "", nil)
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want malformed JSON error")
 	}
@@ -154,7 +157,7 @@ func TestMeasureWithLoudnormParsesStatsFile(t *testing.T) {
 	testFile := generateLoudnormApplicationTestAudio(t)
 	injectLoudnormStatsViaRun(t, testFile, loudnormCaptureTestJSON, nil)
 
-	measurement, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	measurement, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "", nil)
 	if err != nil {
 		t.Fatalf("measureWithLoudnorm() error = %v", err)
 	}
@@ -172,7 +175,7 @@ func TestMeasureWithLoudnormRejectsInvalidNumericField(t *testing.T) {
 	badJSON := strings.Replace(loudnormCaptureTestJSON, `"input_i":"-23.0"`, `"input_i":"not-a-number"`, 1)
 	injectLoudnormStatsViaRun(t, testFile, badJSON, nil)
 
-	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	_, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "", nil)
 	if err == nil {
 		t.Fatal("measureWithLoudnorm() error = nil, want invalid numeric field error")
 	}
@@ -196,7 +199,7 @@ func TestMeasureWithLoudnormStatsFileYieldsFiniteMeasurement(t *testing.T) {
 
 	injectLoudnormStatsViaRun(t, testFile, loudnormCaptureTestJSON, nil)
 
-	measurement, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", nil)
+	measurement, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "", nil)
 	if err != nil {
 		t.Fatalf("measureWithLoudnorm() error = %v", err)
 	}
@@ -233,7 +236,7 @@ func TestMeasureWithLoudnormProgressCadenceCapsAt099(t *testing.T) {
 	})
 
 	var events []loudnormProgressEvent
-	_, err := measureWithLoudnorm(testFile, defaultNormalisationTestConfig(), "", func(update ProgressUpdate) {
+	_, err := measureWithLoudnorm(context.Background(), testFile, defaultNormalisationTestConfig(), "", func(update ProgressUpdate) {
 		events = append(events, loudnormProgressEvent{pass: update.Pass, passName: update.PassName, progress: update.Progress})
 	})
 	if err != nil {
@@ -292,6 +295,7 @@ func injectPass4StatsViaRun(t *testing.T, inputPath, body string) {
 
 	oldRun := loudnormRunFilterGraph
 	loudnormRunFilterGraph = func(
+		_ context.Context,
 		_ *audio.Reader,
 		_, _ *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -442,7 +446,7 @@ func replaceApplyLoudnormRename(t *testing.T, rename func(string, string) error)
 
 func replaceLoudnormRunFilterGraph(
 	t *testing.T,
-	run func(*audio.Reader, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, FrameLoopConfig) error,
+	run func(context.Context, *audio.Reader, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, FrameLoopConfig) error,
 ) {
 	t.Helper()
 
@@ -585,7 +589,7 @@ func applyLoudnormTest(
 ) (*loudnormApplicationResult, error) {
 	t.Helper()
 
-	return applyLoudnormAndMeasure(loudnormApplicationRequest{
+	return applyLoudnormAndMeasure(context.Background(), loudnormApplicationRequest{
 		inputPath:   inputPath,
 		config:      loudnormApplicationTestConfig(),
 		measurement: loudnormApplicationTestMeasurement(),
@@ -673,6 +677,7 @@ func TestApplyLoudnormAndMeasureLoopErrorRemovesTemp(t *testing.T) {
 	runErr := errors.New("injected application loop failure")
 	oldRun := loudnormRunFilterGraph
 	loudnormRunFilterGraph = func(
+		_ context.Context,
 		reader *audio.Reader,
 		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -718,6 +723,7 @@ func TestApplyLoudnormAndMeasureFlushErrorRemovesTemp(t *testing.T) {
 
 	oldRun := loudnormRunFilterGraph
 	loudnormRunFilterGraph = func(
+		_ context.Context,
 		reader *audio.Reader,
 		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -766,6 +772,7 @@ func TestApplyLoudnormAndMeasureCloseErrorRemovesTemp(t *testing.T) {
 
 	oldRun := loudnormRunFilterGraph
 	loudnormRunFilterGraph = func(
+		_ context.Context,
 		reader *audio.Reader,
 		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -809,6 +816,7 @@ func TestApplyLoudnormAndMeasureRenameErrorRemovesTemp(t *testing.T) {
 
 	oldRun := loudnormRunFilterGraph
 	loudnormRunFilterGraph = func(
+		_ context.Context,
 		reader *audio.Reader,
 		bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -980,6 +988,7 @@ func TestApplyNormalisationProgressCadenceGuard(t *testing.T) {
 
 	var runCalls int
 	replaceLoudnormRunFilterGraph(t, func(
+		_ context.Context,
 		_ *audio.Reader,
 		_, _ *ffmpeg.AVFilterContext,
 		config FrameLoopConfig,
@@ -1005,6 +1014,7 @@ func TestApplyNormalisationProgressCadenceGuard(t *testing.T) {
 
 	var events []loudnormProgressEvent
 	_, err := ApplyNormalisation(
+		context.Background(),
 		testFile,
 		defaultNormalisationTestConfig(),
 		&OutputMeasurements{OutputI: -20.0, OutputTP: -10.0},

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -2,6 +2,7 @@
 package processor
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -25,7 +26,7 @@ type AnalysisResult struct {
 }
 
 // AnalyzeOnlyDetailed performs Pass 1 analysis and returns stage timing details.
-func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
+func AnalyzeOnlyDetailed(ctx context.Context, inputPath string, config *BaseFilterConfig,
 	progressCallback ProgressCallback,
 ) (*AnalysisResult, error) {
 	// Pass 1: Analysis
@@ -37,7 +38,7 @@ func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 	}
 
 	analysisStart := time.Now()
-	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
+	measurements, err := AnalyzeAudio(ctx, inputPath, config, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("analysis failed: %w", err)
 	}
@@ -73,7 +74,7 @@ func AnalyzeOnlyDetailed(inputPath string, config *BaseFilterConfig,
 //
 // The output file will be named <basename>-LUFS-NN-processed.<ext> in the same directory as the input
 // If progressCallback is not nil, it will be called with progress updates
-func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback ProgressCallback) (*ProcessingResult, error) {
+func ProcessAudio(ctx context.Context, inputPath string, config *BaseFilterConfig, progressCallback ProgressCallback) (*ProcessingResult, error) {
 	// Pass 1: Analysis
 	if progressCallback != nil {
 		progressCallback(ProgressUpdate{
@@ -82,7 +83,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 		})
 	}
 
-	measurements, err := AnalyzeAudio(inputPath, config, progressCallback)
+	measurements, err := AnalyzeAudio(ctx, inputPath, config, progressCallback)
 	if err != nil {
 		return nil, fmt.Errorf("pass 1 failed: %w", err)
 	}
@@ -111,6 +112,10 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 		})
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	outputPath, err := processorCreateSiblingTempPath(inputPath, "processing")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pass 2 temp output: %w", err)
@@ -129,7 +134,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 	var filteredMeasurements *OutputMeasurements
 	var regionTimings RegionMeasurementTimings
 
-	inputMetadata, err := processWithFilters(inputPath, outputPath, effectiveConfig, progressCallback, measurements, &filteredMeasurements)
+	inputMetadata, err := processWithFilters(ctx, inputPath, outputPath, effectiveConfig, progressCallback, measurements, &filteredMeasurements)
 	if err != nil {
 		return nil, fmt.Errorf("pass 2 failed: %w", err)
 	}
@@ -148,7 +153,7 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 		roomToneRegion, spRegion := extractRegionPair(measurements)
 		if roomToneRegion != nil || spRegion != nil {
 			regionStart := time.Now()
-			roomToneSample, spSample := MeasureOutputRegions(outputPath, roomToneRegion, spRegion, config.logger)
+			roomToneSample, spSample := MeasureOutputRegions(ctx, outputPath, roomToneRegion, spRegion, config.logger)
 			regionTimings.FilteredOutput = time.Since(regionStart)
 			filteredMeasurements.RoomToneSample = roomToneSample
 			filteredMeasurements.SpeechSample = spSample
@@ -159,7 +164,10 @@ func ProcessAudio(inputPath string, config *BaseFilterConfig, progressCallback P
 	// The FinalMeasurements in the result include region measurements captured in Pass 4
 	var normResult *NormalisationResult
 	if filteredMeasurements != nil {
-		normResult, err = ApplyNormalisation(outputPath, effectiveConfig, filteredMeasurements, measurements, progressCallback, config.logger)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		normResult, err = ApplyNormalisation(ctx, outputPath, effectiveConfig, filteredMeasurements, measurements, progressCallback, config.logger)
 		if err != nil {
 			return nil, fmt.Errorf("pass 3 failed: %w", err)
 		}
@@ -239,7 +247,7 @@ type ProcessingResult struct {
 // Applies the filter chain built by BuildFilterSpec() which includes asendcmd for noise profile learning
 // when NoiseProfileStart/End timestamps are set in the config.
 // If outputMeasurements is non-nil, populates it with Pass 2 output analysis.
-func processWithFilters(inputPath, outputPath string, config *EffectiveFilterConfig, progressCallback ProgressCallback, measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) (InputMetadata, error) {
+func processWithFilters(ctx context.Context, inputPath, outputPath string, config *EffectiveFilterConfig, progressCallback ProgressCallback, measurements *AudioMeasurements, outputMeasurements **OutputMeasurements) (InputMetadata, error) {
 	// Open input audio file
 	reader, metadata, err := audio.OpenAudioFile(inputPath)
 	if err != nil {
@@ -291,7 +299,7 @@ func processWithFilters(inputPath, outputPath string, config *EffectiveFilterCon
 	currentLevel := 0.0
 
 	// Process all frames through the filter chain using runFilterGraph
-	if err := runFilterGraph(reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
+	if err := runFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnReadError: func(err error) error {
 			return fmt.Errorf("failed to read frame: %w", err)
 		},

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -467,44 +468,44 @@ func TestProcessorSeedAndProgressCallbackBoundaries(t *testing.T) {
 		{
 			name:        "ProcessAudio",
 			fn:          ProcessAudio,
-			configArg:   1,
-			progressArg: 2,
-			parameters:  3,
-		},
-		{
-			name:        "AnalyzeOnlyDetailed",
-			fn:          AnalyzeOnlyDetailed,
-			configArg:   1,
-			progressArg: 2,
-			parameters:  3,
-		},
-		{
-			name:        "AnalyzeAudio",
-			fn:          AnalyzeAudio,
-			configArg:   1,
-			progressArg: 2,
-			parameters:  3,
-		},
-		{
-			name:        "processWithFilters",
-			fn:          processWithFilters,
 			configArg:   2,
-			progressArg: 3,
-			parameters:  6,
-		},
-		{
-			name:        "measureWithLoudnorm",
-			fn:          measureWithLoudnorm,
-			configArg:   1,
 			progressArg: 3,
 			parameters:  4,
 		},
 		{
+			name:        "AnalyzeOnlyDetailed",
+			fn:          AnalyzeOnlyDetailed,
+			configArg:   2,
+			progressArg: 3,
+			parameters:  4,
+		},
+		{
+			name:        "AnalyzeAudio",
+			fn:          AnalyzeAudio,
+			configArg:   2,
+			progressArg: 3,
+			parameters:  4,
+		},
+		{
+			name:        "processWithFilters",
+			fn:          processWithFilters,
+			configArg:   3,
+			progressArg: 4,
+			parameters:  7,
+		},
+		{
+			name:        "measureWithLoudnorm",
+			fn:          measureWithLoudnorm,
+			configArg:   2,
+			progressArg: 4,
+			parameters:  5,
+		},
+		{
 			name:        "ApplyNormalisation",
 			fn:          ApplyNormalisation,
-			configArg:   1,
-			progressArg: 4,
-			parameters:  6,
+			configArg:   2,
+			progressArg: 5,
+			parameters:  7,
 		},
 	}
 
@@ -655,7 +656,7 @@ func TestProcessAudio(t *testing.T) {
 	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
 
 	// Process the audio with a no-op progress callback
-	result, err := ProcessAudio(testFile, config, func(update ProgressUpdate) {
+	result, err := ProcessAudio(context.Background(), testFile, config, func(update ProgressUpdate) {
 		// No-op for tests
 	})
 	if err != nil {
@@ -846,7 +847,7 @@ func TestProcessAudioFinalCollisionPreservesOutputAndCleansTemp(t *testing.T) {
 		processorCreateSiblingTempPath = oldCreateSiblingTempPath
 	})
 
-	firstResult, err := ProcessAudio(testFile, config, nil)
+	firstResult, err := ProcessAudio(context.Background(), testFile, config, nil)
 	if err != nil {
 		t.Fatalf("first ProcessAudio() failed: %v", err)
 	}
@@ -859,7 +860,7 @@ func TestProcessAudioFinalCollisionPreservesOutputAndCleansTemp(t *testing.T) {
 		t.Fatalf("failed to read first output: %v", err)
 	}
 
-	secondResult, err := ProcessAudio(testFile, config, nil)
+	secondResult, err := ProcessAudio(context.Background(), testFile, config, nil)
 	if err == nil {
 		if secondResult != nil && secondResult.OutputPath != "" {
 			_ = os.Remove(secondResult.OutputPath)
@@ -929,7 +930,7 @@ func TestAnalyzeOnlyDetailedTimings(t *testing.T) {
 	config.DS201HighPass.Frequency = 95.0
 	baseFilterOrder := append([]FilterID(nil), config.FilterOrder...)
 
-	result, err := AnalyzeOnlyDetailed(testFile, config, nil)
+	result, err := AnalyzeOnlyDetailed(context.Background(), testFile, config, nil)
 	if err != nil {
 		t.Fatalf("AnalyzeOnlyDetailed failed: %v", err)
 	}


### PR DESCRIPTION
- Implement semaphore-based worker pool (default min(4, NumCPU), configurable via --jobs)
- Thread context/cancellation throughout processor: ProcessAudio, AnalyzeAudio, ApplyNormalisation, runFilterGraph, MeasureOutputRegions, AnalyzeOnlyDetailed
- Add per-worker config cloning (CloneForWorker) to isolate filter state; shallow copy + deep-copy FilterOrder + per-worker logger
- Frame loop checks ctx.Err() for prompt cancellation; temp cleanup runs deferred on cancel
- Race-clean: all paths tested with ≥2 concurrent workers, in-flight bounds, serial parity, failure isolation, zero temp residue on cancel
- Scope: processing path only; analysis-only mode (-a) remains serial