### PR TITLE
feat(cli): add parallel analysis via bounded worker pool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@ Go CLI tool for podcast audio preprocessing using embedded FFmpeg. Transforms ra
 ## Architecture
 
 ```
-cmd/jivetalking/main.go     # CLI entry, Kong flags, resolveJobs(), ctx + cancel(), starts TUI
-cmd/jivetalking/pool.go     # runWorkerPool() - bounded concurrent multi-file processing
+cmd/jivetalking/main.go          # CLI entry, Kong flags, resolveJobs(), ctx + cancel(), starts TUI; runAnalysisOnly() / runAnalysisOnlyWithDeps()
+cmd/jivetalking/pool.go          # runWorkerPool() - bounded concurrent multi-file processing
+cmd/jivetalking/analysispool.go  # runAnalysisPool() - bounded concurrent multi-file analysis (mirrors pool.go)
 internal/
 ├── audio/reader.go         # FFmpeg demuxer/decoder wrapper (Reader, Metadata, OpenAudioFile)
 ├── processor/
@@ -53,7 +54,7 @@ internal/
 
 **Data flow (processing):** `main.go` resolves worker count via `resolveJobs()` (`--jobs`, default auto `min(4, NumCPU)`), creates a cancellable `ctx`, then launches `runWorkerPool()` (`pool.go`) → up to `jobs` files run concurrently, each a goroutine bounded by a semaphore, taking a `CloneForWorker()` config copy and `FileIndex`-routed TUI messages → `ProcessAudio(ctx, …)` → Pass 1 (`AnalyzeAudio`) → `AdaptConfig()` → Pass 2 (filter chain) → Pass 3/4 (`ApplyNormalisation`) → `GenerateReport()` writes an always-on processing report → sends `ui.*Msg` to TUI via `tea.Program.Send()`. After `WaitGroup` drains, the pool sends `ui.AllCompleteMsg`. `cancel()` fires after `p.Run()` returns; `runFilterGraph` checks `ctx.Err()` each frame so in-flight workers abort and run deferred temp cleanup.
 
-**Data flow (analysis-only):** `main.go` → `runAnalysisOnly()` → `AnalyzeOnlyDetailed()` → Pass 1 + `AdaptConfig()` → `AnalysisModel` TUI shows progress → `DisplayAnalysisResults()` prints report to console. No output files created. This path stays serial; the worker pool covers processing only.
+**Data flow (analysis-only):** `main.go` → `runAnalysisOnly()` → `runAnalysisOnlyWithDeps()` (passes `jobs` from `resolveJobs()`) → spawns `runAnalysisPool()` (`analysispool.go`) with a buffered semaphore of size `jobs` and a `sync.WaitGroup`. Up to `jobs` files analyse concurrently; each worker owns its index slot in pre-allocated `results`, `metas`, and `errs` slices (no sharing), calls `CloneForWorker()` for an independent config copy, and sends `ui.AnalysisStartMsg` / `ui.AnalysisProgressMsg` / `ui.AnalysisCompleteMsg` keyed by `FileIndex`. After `wg.Wait()` drains, the pool sends `ui.AllCompleteMsg`. Two branches: TTY path launches a `tea.Program` (using `ui.NewAnalysisModel`) in a goroutine alongside the pool; no-TTY path prints an up-front banner then calls the pool synchronously with `p == nil` (all `p.Send` calls are gated). After the pool returns, `runAnalysisOnlyWithDeps()` prints results in input order, skipping cancelled or nil slots. No output files are created.
 
 ## Audio processing pipeline
 
@@ -114,10 +115,11 @@ Two separate message sets exist for the two TUI modes.
 - `ui.FileCompleteMsg` - processing finished with result (or error in `Error` field)
 - `ui.AllCompleteMsg` - all files finished
 
-**Analysis-only mode** (`ui/analysis_model.go`) - sent by `runAnalysisWithTUI()`:
-- `ui.AnalysisStartMsg` - analysis started for a file
-- `ui.AnalysisProgressMsg` - progress and level update
-- `ui.AnalysisCompleteMsg` - analysis finished with measurements, config, or error
+**Analysis-only mode** (`ui/analysis_model.go`) - sent by `runAnalysisPool()` goroutines, routed by `FileIndex`:
+- `ui.AnalysisStartMsg` - analysis started; carries `FileIndex`, `FileName`, `FilePath`
+- `ui.AnalysisProgressMsg` - progress (0.0-1.0) and level update; carries `FileIndex`
+- `ui.AnalysisCompleteMsg` - analysis finished; carries `FileIndex`, `Result`, and `Error`
+- `ui.AllCompleteMsg` - all files finished (shared with processing mode; sent once after `wg.Wait()`)
 
 ## Adaptive processing
 

--- a/cmd/jivetalking/analysispool.go
+++ b/cmd/jivetalking/analysispool.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/linuxmatters/jivetalking/internal/audio"
+	"github.com/linuxmatters/jivetalking/internal/processor"
+	"github.com/linuxmatters/jivetalking/internal/ui"
+)
+
+// analysisPoolAnalyze is the analysis-only entry point, a package var so tests
+// can substitute a fake to observe concurrency without running real FFmpeg. It
+// defaults to the real processor call, mirroring the poolProcessAudio seam in
+// cmd/jivetalking/pool.go.
+var analysisPoolAnalyze = processor.AnalyzeOnlyDetailed
+
+// runAnalysisPool analyses files concurrently under a bounded worker pool
+// sharing one tea.Program. A buffered semaphore of size jobs caps in-flight
+// workers; a sync.WaitGroup tracks completion. Each worker owns its file index,
+// a per-file prefixed logger, and a per-worker config clone, mirroring
+// runWorkerPool in pool.go. After all workers finish it sends ui.AllCompleteMsg.
+// With jobs == 1 the observable outcome matches the serial path.
+//
+// The caller pre-allocates results, metas, and errs to len(files); each worker
+// writes only its own results[i], metas[i], and errs[i] slot, so no slot is
+// shared. Ordered printing happens in the caller after this returns.
+//
+// When p is nil the same body runs the no-TTY path with no p.Send calls: every
+// p.Send is gated by a p != nil check.
+//
+// On cancellation a not-yet-started worker skips its work via the ctx.Done()
+// select at acquire, while an in-flight worker aborts mid-frame because ctx is
+// threaded into AnalyzeOnlyDetailed. Either way wg.Done() fires so wg.Wait()
+// returns and ui.AllCompleteMsg is sent.
+func runAnalysisPool(ctx context.Context, p *tea.Program, files []string, base *processor.BaseFilterConfig, sharedLog func(string, ...any), jobs int, results []*processor.AnalysisResult, metas []*audio.Metadata, errs []error, openMetadata func(string) (*audio.Metadata, error)) {
+	sem := make(chan struct{}, jobs)
+	var wg sync.WaitGroup
+
+	for i, inputPath := range files {
+		wg.Add(1)
+		go func(i int, inputPath string) {
+			// Register wg.Done() before the acquire select so a worker skipped
+			// on a cancelled ctx still decrements the WaitGroup; otherwise
+			// wg.Wait() hangs.
+			defer wg.Done()
+
+			// Acquire the semaphore, but bail out if ctx is already cancelled so
+			// a not-yet-started worker skips its work cleanly. Only release the
+			// slot when this branch actually took one.
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+
+			wlog := withFilePrefix(inputPath, sharedLog)
+
+			if p != nil {
+				wlog("[ANALYSIS-POOL] Sending AnalysisStartMsg for file %d: %s", i, inputPath)
+				p.Send(ui.AnalysisStartMsg{
+					FileIndex: i,
+					FileName:  inputPath,
+					FilePath:  inputPath,
+				})
+			}
+
+			meta, err := openMetadata(inputPath)
+			metas[i] = meta
+			if err != nil {
+				wlog("[ANALYSIS-POOL] openMetadata failed: %v", err)
+				errs[i] = err
+				if p != nil {
+					p.Send(ui.AnalysisCompleteMsg{
+						FileIndex: i,
+						Error:     err,
+					})
+				}
+				return
+			}
+
+			clone := base.CloneForWorker(wlog)
+
+			var cb processor.ProgressCallback
+			if p != nil {
+				cb = func(update processor.ProgressUpdate) {
+					wlog("[ANALYSIS-POOL] Progress: Pass %d (%s), %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
+					p.Send(ui.AnalysisProgressMsg{
+						FileIndex: i,
+						Progress:  update.Progress,
+						Level:     update.Level,
+					})
+				}
+			}
+
+			wlog("[ANALYSIS-POOL] Starting AnalyzeOnlyDetailed for %s", inputPath)
+			results[i], errs[i] = analysisPoolAnalyze(ctx, inputPath, clone, cb)
+
+			if p != nil {
+				wlog("[ANALYSIS-POOL] Sending AnalysisCompleteMsg for file %d", i)
+				p.Send(ui.AnalysisCompleteMsg{
+					FileIndex: i,
+					Result:    results[i],
+					Error:     errs[i],
+				})
+			}
+		}(i, inputPath)
+	}
+
+	wg.Wait()
+
+	if p != nil {
+		sharedLog("[ANALYSIS-POOL] Sending AllCompleteMsg")
+		p.Send(ui.AllCompleteMsg{})
+	}
+}

--- a/cmd/jivetalking/analysispool_test.go
+++ b/cmd/jivetalking/analysispool_test.go
@@ -1,0 +1,507 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/linuxmatters/jivetalking/internal/audio"
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+// analysisIndexFromPath parses the trailing integer of a synthetic "fileN" path
+// so the seam fake and the stub openMetadata can recover a worker's index from
+// the only argument they receive (the input path). runAnalysisPool passes the
+// path, not the index, so the index is encoded in the filename instead.
+func analysisIndexFromPath(t *testing.T, path string) int {
+	t.Helper()
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	digits := strings.TrimPrefix(base, "file")
+	idx, err := strconv.Atoi(digits)
+	if err != nil {
+		t.Fatalf("parse index from %q: %v", path, err)
+	}
+	return idx
+}
+
+// makeAnalysisFiles builds n distinct synthetic input paths named file0..fileN-1
+// under a temp dir. The trailing number carries each worker's index for the
+// fake and stub openMetadata to read back.
+func makeAnalysisFiles(t *testing.T, n int) []string {
+	t.Helper()
+	dir := t.TempDir()
+	files := make([]string, n)
+	for i := range files {
+		files[i] = filepath.Join(dir, "file"+strconv.Itoa(i)+".wav")
+	}
+	return files
+}
+
+// stubOpenMetadata returns metadata whose SampleRate encodes the path's index
+// (48000+index), letting tests assert metas[i] landed in slot i. It never opens
+// a real file.
+func stubOpenMetadata(t *testing.T) func(string) (*audio.Metadata, error) {
+	return func(path string) (*audio.Metadata, error) {
+		idx := analysisIndexFromPath(t, path)
+		return &audio.Metadata{
+			Duration:   120,
+			SampleRate: 48000 + idx,
+			Channels:   1,
+		}, nil
+	}
+}
+
+// installAnalysisFake swaps analysisPoolAnalyze for fn and restores it after the
+// test, mirroring pool_test.go's installInflightFake save/restore so tests stay
+// isolated from each other and from main_test.go's swaps.
+func installAnalysisFake(t *testing.T, fn func(context.Context, string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)) {
+	t.Helper()
+	orig := analysisPoolAnalyze
+	analysisPoolAnalyze = fn
+	t.Cleanup(func() { analysisPoolAnalyze = orig })
+}
+
+// inflightAnalysisFake observes pool concurrency without real FFmpeg. It tracks
+// live in-flight workers and the high-water mark (compare-and-update), sleeps to
+// create overlap opportunity, then returns a per-index sentinel AnalysisResult
+// whose AdaptationDuration encodes the index. It mirrors pool_test.go's
+// inflightFake atomic.Int32 high-water idiom.
+type inflightAnalysisFake struct {
+	t       *testing.T
+	live    atomic.Int32
+	maxSeen atomic.Int32
+}
+
+func (f *inflightAnalysisFake) fn(_ context.Context, inputPath string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
+	cur := f.live.Add(1)
+	for {
+		old := f.maxSeen.Load()
+		if cur <= old || f.maxSeen.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	f.live.Add(-1)
+	idx := analysisIndexFromPath(f.t, inputPath)
+	return &processor.AnalysisResult{AdaptationDuration: time.Duration(idx)}, nil
+}
+
+// TestRunAnalysisPool_InFlightBoundedToJobs asserts jobs == 3 caps in-flight
+// analysis workers at 3 over 8 files while still reaching real concurrency (>1),
+// proving the semaphore both bounds and permits parallelism. Drives the pool
+// with p == nil (no real tea.Program). [AC3 / 2.3(a)]
+func TestRunAnalysisPool_InFlightBoundedToJobs(t *testing.T) {
+	const n = 8
+	const jobs = 3
+
+	fake := &inflightAnalysisFake{t: t}
+	installAnalysisFake(t, fake.fn)
+
+	files := makeAnalysisFiles(t, n)
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
+	base := processor.DefaultFilterConfig()
+
+	runAnalysisPool(context.Background(), nil, files, base, func(string, ...any) {}, jobs, results, metas, errs, stubOpenMetadata(t))
+
+	maxSeen := fake.maxSeen.Load()
+	if maxSeen < 2 || maxSeen > jobs {
+		t.Fatalf("max in-flight with jobs=%d = %d, want in (1,%d]", jobs, maxSeen, jobs)
+	}
+	for i := range files {
+		if errs[i] != nil {
+			t.Fatalf("errs[%d] = %v, want nil", i, errs[i])
+		}
+		if results[i] == nil {
+			t.Fatalf("results[%d] = nil, want populated", i)
+		}
+	}
+}
+
+// TestRunAnalysisPool_SerialParityJobs1 asserts jobs == 1 holds in-flight
+// analysis workers to a single concurrent call (high-water == 1), the serial
+// outcome under the pool. [AC3 / 2.3(b)]
+func TestRunAnalysisPool_SerialParityJobs1(t *testing.T) {
+	const n = 8
+
+	fake := &inflightAnalysisFake{t: t}
+	installAnalysisFake(t, fake.fn)
+
+	files := makeAnalysisFiles(t, n)
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
+	base := processor.DefaultFilterConfig()
+
+	runAnalysisPool(context.Background(), nil, files, base, func(string, ...any) {}, 1, results, metas, errs, stubOpenMetadata(t))
+
+	if got := fake.maxSeen.Load(); got != 1 {
+		t.Fatalf("max in-flight with jobs=1 = %d, want 1", got)
+	}
+	for i := range files {
+		if results[i] == nil {
+			t.Fatalf("results[%d] = nil, want populated", i)
+		}
+	}
+}
+
+// TestRunAnalysisPool_JobsAboveFileCountNoCap asserts a jobs value far above both
+// the file count and NumCPU does NOT cap in-flight workers below the file count:
+// jobs == 64 over 3 files must reach high-water == 3 (all three run at once). The
+// semaphore of 64 leaves every worker free to start, and runAnalysisPool applies
+// no NumCPU cap of its own (that is resolveJobs's job, tested in main_test.go).
+//
+// A sync.WaitGroup barrier sized to the file count makes the assertion
+// deterministic, not timing-dependent: each worker arrives, decrements the
+// barrier, then blocks on barrier.Wait(), so no worker proceeds until all three
+// are simultaneously in-flight. high-water therefore reaches exactly 3 every run.
+// Were the pool to cap below 3, fewer than 3 workers would enter, barrier.Wait()
+// would never release, and the test would hang rather than flake. [AC3 / 5.2]
+func TestRunAnalysisPool_JobsAboveFileCountNoCap(t *testing.T) {
+	const n = 3
+	const jobs = 64 // > n and > any realistic NumCPU
+
+	var barrier sync.WaitGroup
+	barrier.Add(n)
+
+	fake := &inflightAnalysisFake{t: t}
+	installAnalysisFake(t, func(ctx context.Context, inputPath string, base *processor.BaseFilterConfig, cb processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		// Mark this worker in-flight and record the high-water mark before the
+		// barrier so maxSeen reflects all simultaneously-live workers.
+		cur := fake.live.Add(1)
+		for {
+			old := fake.maxSeen.Load()
+			if cur <= old || fake.maxSeen.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+
+		// Hold every worker until all n have entered, forcing genuine overlap.
+		barrier.Done()
+		barrier.Wait()
+
+		fake.live.Add(-1)
+		idx := analysisIndexFromPath(t, inputPath)
+		return &processor.AnalysisResult{AdaptationDuration: time.Duration(idx)}, nil
+	})
+
+	files := makeAnalysisFiles(t, n)
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
+	base := processor.DefaultFilterConfig()
+
+	runAnalysisPool(context.Background(), nil, files, base, func(string, ...any) {}, jobs, results, metas, errs, stubOpenMetadata(t))
+
+	if got := fake.maxSeen.Load(); got != n {
+		t.Fatalf("max in-flight with jobs=%d over %d files = %d, want %d (no cap below file count)", jobs, n, got, n)
+	}
+	for i := range files {
+		if errs[i] != nil {
+			t.Fatalf("errs[%d] = %v, want nil", i, errs[i])
+		}
+		if results[i] == nil {
+			t.Fatalf("results[%d] = nil, want populated", i)
+		}
+	}
+}
+
+// TestRunAnalysisPool_OrderedSlots proves results land in submission-index slots
+// regardless of completion order. The fake sleeps for an index-derived duration
+// where EARLIER indices sleep LONGER, forcing later-submitted indices to finish
+// first, so completion order is the reverse of submission order. With jobs >= n
+// every worker runs concurrently, so the staggered delays decide completion
+// order. Each slot must still carry its own index (encoded in
+// AdaptationDuration and in metas' SampleRate). [AC1 / 2.3(c)]
+func TestRunAnalysisPool_OrderedSlots(t *testing.T) {
+	const n = 6
+
+	var completionOrder []int
+	completion := make(chan int, n)
+
+	installAnalysisFake(t, func(_ context.Context, inputPath string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		idx := analysisIndexFromPath(t, inputPath)
+		// Earlier index sleeps longer, so index 0 finishes last and index n-1
+		// finishes first: completion order is the reverse of submission order.
+		time.Sleep(time.Duration(n-idx) * 10 * time.Millisecond)
+		completion <- idx
+		return &processor.AnalysisResult{AdaptationDuration: time.Duration(idx)}, nil
+	})
+
+	files := makeAnalysisFiles(t, n)
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
+	base := processor.DefaultFilterConfig()
+
+	// jobs >= n so all workers run concurrently and the index-derived delays
+	// alone decide completion order.
+	runAnalysisPool(context.Background(), nil, files, base, func(string, ...any) {}, n, results, metas, errs, stubOpenMetadata(t))
+
+	close(completion)
+	for idx := range completion {
+		completionOrder = append(completionOrder, idx)
+	}
+
+	// Prove the test actually exercised out-of-order completion: the first to
+	// complete must NOT be the first submitted.
+	if len(completionOrder) != n {
+		t.Fatalf("completion count = %d, want %d", len(completionOrder), n)
+	}
+	if completionOrder[0] == 0 {
+		t.Fatalf("first completion was index 0; staggered delays failed to reorder completion (order=%v)", completionOrder)
+	}
+	if completionOrder[0] != n-1 {
+		t.Fatalf("first completion = index %d, want %d (last submitted finishes first); order=%v", completionOrder[0], n-1, completionOrder)
+	}
+
+	// Despite reversed completion, each slot carries its own submission index.
+	for i := range files {
+		if errs[i] != nil {
+			t.Fatalf("errs[%d] = %v, want nil", i, errs[i])
+		}
+		if results[i] == nil {
+			t.Fatalf("results[%d] = nil, want populated", i)
+		}
+		if got := int(results[i].AdaptationDuration); got != i {
+			t.Fatalf("results[%d] carries index %d, want %d (slot mismatch)", i, got, i)
+		}
+		if metas[i] == nil {
+			t.Fatalf("metas[%d] = nil, want populated", i)
+		}
+		if got := metas[i].SampleRate - 48000; got != i {
+			t.Fatalf("metas[%d] carries index %d, want %d (slot mismatch)", i, got, i)
+		}
+	}
+}
+
+// TestRunAnalysisPool_FailureIsolation drives the pool where one index errors and
+// the rest succeed. It asserts errs[failIdx] is set, sibling results are non-nil
+// with nil errs, and (with p == nil) runAnalysisPool returns only after ALL
+// workers finish (no early abort). [AC4 / 2.3(d)]
+func TestRunAnalysisPool_FailureIsolation(t *testing.T) {
+	const n = 6
+	const failIdx = 1
+
+	sentinel := errors.New("analysisFake: synthetic analysis failure")
+
+	installAnalysisFake(t, func(_ context.Context, inputPath string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		idx := analysisIndexFromPath(t, inputPath)
+		if idx == failIdx {
+			return nil, sentinel
+		}
+		return &processor.AnalysisResult{AdaptationDuration: time.Duration(idx)}, nil
+	})
+
+	files := makeAnalysisFiles(t, n)
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
+	base := processor.DefaultFilterConfig()
+
+	runAnalysisPool(context.Background(), nil, files, base, func(string, ...any) {}, 3, results, metas, errs, stubOpenMetadata(t))
+
+	// The failing slot carries its error.
+	if !errors.Is(errs[failIdx], sentinel) {
+		t.Fatalf("errs[%d] = %v, want sentinel", failIdx, errs[failIdx])
+	}
+
+	// Every sibling ran to completion (no early abort): non-nil result, nil err.
+	for j := range files {
+		if j == failIdx {
+			continue
+		}
+		if errs[j] != nil {
+			t.Fatalf("sibling errs[%d] = %v, want nil", j, errs[j])
+		}
+		if results[j] == nil {
+			t.Fatalf("sibling results[%d] = nil, want populated (proof it ran)", j)
+		}
+		if got := int(results[j].AdaptationDuration); got != j {
+			t.Fatalf("sibling results[%d] carries index %d, want %d", j, got, j)
+		}
+	}
+}
+
+// TestRunAnalysisPool_CancellationAbortsPromptly drives runAnalysisPool with a
+// ctx cancelled mid-run and proves two things deterministically: queued workers
+// skip via the acquire select, and the pool unwinds promptly once in-flight
+// workers abort. jobs < file count (jobs=2, files=6) guarantees the remaining 4
+// workers are still queued at the acquire select when ctx is cancelled.
+//
+// Determinism hinges on holding the semaphore slots occupied across the skip
+// assertion. The fake signals an entry channel, then blocks on a release gate,
+// returning only after the gate opens. Blocking on the gate alone (not ctx.Done())
+// keeps the slots held while ctx is cancelled, which is what makes the skip
+// deterministic: were the in-flight fake to release on ctx.Done(), it would free
+// its slot the instant cancel fired and a queued worker could win that freed slot
+// before observing ctx.Done(). The test waits for the jobs entries via a barrier
+// (no sleep), so the queued workers are provably stuck at the acquire select with
+// no free slot. Cancelling ctx then leaves each queued worker's select with
+// sem-send still blocked (slots held by the gated in-flight workers) and
+// ctx.Done() ready, forcing the ctx.Done() skip branch. With slots held, started
+// can never exceed jobs: every queued worker skips, never running the fake. The
+// test asserts started == jobs while the gate is still closed, then opens the
+// gate so the in-flight workers return and the pool unwinds.
+//
+// Prompt return is then asserted via the done channel against a bounded 2s
+// deadline: every worker's wg.Done() must fire so wg.Wait() returns.
+//
+// Driven with p == nil so no real terminal is needed. Production sends
+// ui.AllCompleteMsg after wg.Wait() unconditionally when p != nil; that TTY path
+// is covered by the model quit tests (1.5 / 5.1). [AC5 / 5.6]
+func TestRunAnalysisPool_CancellationAbortsPromptly(t *testing.T) {
+	const n = 6
+	const jobs = 2 // < n so the other n-jobs workers stay queued at the acquire select
+
+	var started atomic.Int32
+	entered := make(chan struct{}, n)
+	gate := make(chan struct{})
+
+	installAnalysisFake(t, func(ctx context.Context, _ string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		started.Add(1)
+		entered <- struct{}{}
+		// Hold the semaphore slot until the gate opens so queued workers cannot
+		// acquire a freed slot during the skip assertion. Blocking on the gate
+		// alone (not ctx.Done()) keeps the slots occupied while ctx is cancelled,
+		// making the queued workers' skip deterministic. The in-flight ctx abort
+		// is the production analysisPoolAnalyze's job and is covered separately by
+		// the seam returning context.Canceled; here the gate stands in so the slot
+		// stays held across the assertion.
+		<-gate
+		return nil, ctx.Err()
+	})
+
+	files := makeAnalysisFiles(t, n)
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
+	base := processor.DefaultFilterConfig()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runAnalysisPool(ctx, nil, files, base, func(string, ...any) {}, jobs, results, metas, errs, stubOpenMetadata(t))
+		close(done)
+	}()
+
+	// Wait until exactly the jobs in-flight workers have entered the fake. The
+	// queued workers are now provably stuck at the acquire select (no free slot).
+	for range jobs {
+		<-entered
+	}
+
+	cancel()
+
+	// The in-flight workers hold their slots (still in the gated select), so a
+	// queued worker's acquire select cannot send on sem and must take the
+	// ctx.Done() skip branch. Confirm no further entry appears: started stays at
+	// jobs because every queued worker skips without running the fake. A short
+	// settle gives any erroneously-admitted worker time to bump the counter; the
+	// gate stays closed throughout so a correct skip cannot be undone.
+	if extra := waitForExtraEntry(entered, 100*time.Millisecond); extra {
+		t.Fatalf("a queued worker entered the fake after cancel; it must skip via the acquire select (started=%d)", started.Load())
+	}
+	if got := started.Load(); got != jobs {
+		t.Fatalf("started = %d, want %d (queued workers must skip via the acquire select, never running the fake)", got, jobs)
+	}
+
+	// Release the gated in-flight workers so they return and the pool unwinds.
+	close(gate)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runAnalysisPool did not return promptly after cancel (every wg.Done() must fire so wg.Wait() unwinds)")
+	}
+}
+
+// waitForExtraEntry reports whether another worker signals the entered channel
+// within d, used to detect a queued worker erroneously running the fake after
+// cancel instead of skipping at the acquire select.
+func waitForExtraEntry(entered <-chan struct{}, d time.Duration) bool {
+	select {
+	case <-entered:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// TestRunAnalysisPool_ConcurrentRaceClean drives runAnalysisPool with jobs >= 2
+// over two distinct REAL fixture copies through the REAL
+// processor.AnalyzeOnlyDetailed and the REAL openAudioMetadata opener. Unlike the
+// seam-based 2.3 tests, it runs actual concurrent FFmpeg analysis so `-race`
+// observes the genuine concurrent paths: the shared debugSink-backed logger
+// (whole-line atomic writes), the per-worker CloneForWorker config clones, and the
+// pre-allocated results/metas/errs slots each worker writes only its own slot of.
+// It drives with p == nil (no tea.Program, no TTY) to keep the race test focused
+// on the pool internals. After the run every slot must be populated
+// (results[i] != nil, errs[i] == nil, metas[i] != nil). [AC2 / 5.1]
+func TestRunAnalysisPool_ConcurrentRaceClean(t *testing.T) {
+	src := findPoolTestAudio(t)
+	if src == "" {
+		t.Skip("no audio file found under testdata/; drop a .flac (e.g. testdata/fixture-5m.flac) to run this test")
+	}
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		t.Skipf("testdata audio not found: %s", src)
+	}
+
+	// Pin the seam to the REAL analyze path. installAnalysisFake save/restores it,
+	// so a parallel seam-swapping test cannot leak its fake into this run.
+	installAnalysisFake(t, processor.AnalyzeOnlyDetailed)
+
+	ext := filepath.Ext(src)
+	dir := t.TempDir()
+	files := []string{
+		copyFixtureTo(t, src, dir, "analysis-a"+ext),
+		copyFixtureTo(t, src, dir, "analysis-b"+ext),
+	}
+
+	// Shared debugSink backs the shared logger; every worker writes whole lines
+	// through it concurrently, exercising the sink's serialisation under -race.
+	sinkFile, err := os.CreateTemp(dir, "debug-*.log")
+	if err != nil {
+		t.Fatalf("create debug sink file: %v", err)
+	}
+	t.Cleanup(func() { sinkFile.Close() })
+	sink := newDebugSink(sinkFile)
+	sharedLog := sink.Logf
+
+	base := processor.DefaultFilterConfig()
+	base.SetLogger(sharedLog)
+
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
+
+	// jobs == len(files) so both real analyses run concurrently, forcing
+	// concurrent sink writes, CloneForWorker calls, and slot writes. p == nil so
+	// no real terminal is needed. openAudioMetadata is the production opener used
+	// by defaultAnalysisOnlyDeps.
+	runAnalysisPool(context.Background(), nil, files, base, sharedLog, len(files), results, metas, errs, openAudioMetadata)
+
+	for i := range files {
+		if errs[i] != nil {
+			t.Fatalf("errs[%d] = %v, want nil", i, errs[i])
+		}
+		if results[i] == nil {
+			t.Fatalf("results[%d] = nil, want populated", i)
+		}
+		if metas[i] == nil {
+			t.Fatalf("metas[%d] = nil, want populated", i)
+		}
+	}
+}

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime"
 	"time"
 
@@ -23,8 +22,6 @@ import (
 // version is injected via ldflags at build time. Local dev builds keep "dev";
 // release builds carry the git tag (e.g. "0.1.0").
 var version = "dev"
-
-var errCancelledByUser = errors.New("cancelled by user")
 
 const debugLogPath = "jivetalking-debug.log"
 
@@ -131,7 +128,7 @@ func main() {
 	config.SetLogger(log)
 
 	if cliArgs.AnalysisOnly {
-		runAnalysisOnly(cliArgs.Files, config, log)
+		runAnalysisOnly(cliArgs.Files, config, log, resolveJobs(cliArgs.Jobs, runtime.NumCPU()))
 		return
 	}
 
@@ -212,7 +209,6 @@ type analysisOnlyDeps struct {
 	stdout          io.Writer
 	hasTTY          func() bool
 	openMetadata    func(string) (*audio.Metadata, error)
-	runWithTUI      func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error)
 	analyzeDetailed func(context.Context, string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)
 	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.EffectiveFilterConfig, *processor.AdaptiveDiagnostics, ...logging.AnalysisTimings)
 	printError      func(string)
@@ -223,7 +219,6 @@ func defaultAnalysisOnlyDeps() analysisOnlyDeps {
 		stdout:          os.Stdout,
 		hasTTY:          isTTY,
 		openMetadata:    openAudioMetadata,
-		runWithTUI:      runAnalysisWithTUI,
 		analyzeDetailed: processor.AnalyzeOnlyDetailed,
 		displayResults:  logging.DisplayAnalysisResultsWithDiagnostics,
 		printError:      cli.PrintError,
@@ -292,58 +287,76 @@ func (ph *progressHandler) callback(update processor.ProgressUpdate) {
 	})
 }
 
-// runAnalysisOnly performs Pass 1 analysis on each file with a progress UI,
-// then displays results to console. Skips full 4-pass processing.
-func runAnalysisOnly(files []string, config *processor.BaseFilterConfig, log func(string, ...any)) {
-	runAnalysisOnlyWithDeps(files, config, log, defaultAnalysisOnlyDeps())
+// runAnalysisOnly performs Pass 1 analysis on each file under a bounded worker
+// pool, then displays results to console in input order. Skips full 4-pass
+// processing.
+func runAnalysisOnly(files []string, config *processor.BaseFilterConfig, log func(string, ...any), jobs int) {
+	runAnalysisOnlyWithDeps(files, config, log, jobs, defaultAnalysisOnlyDeps())
 }
 
-func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig, log func(string, ...any), deps analysisOnlyDeps) {
-	hasTTY := deps.hasTTY()
+func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig, log func(string, ...any), jobs int, deps analysisOnlyDeps) {
+	results := make([]*processor.AnalysisResult, len(files))
+	metas := make([]*audio.Metadata, len(files))
+	errs := make([]error, len(files))
 
-	for i, inputPath := range files {
-		// Blank line separates consecutive file reports.
-		if i > 0 {
+	runCtx, cancel := context.WithCancel(context.Background())
+
+	if deps.hasTTY() {
+		model := ui.NewAnalysisModel(files)
+		p := tea.NewProgram(model)
+
+		go runAnalysisPool(runCtx, p, files, config, log, jobs, results, metas, errs, deps.openMetadata)
+
+		if _, err := p.Run(); err != nil {
+			deps.printError(fmt.Sprintf("UI error: %v", err))
+		}
+
+		// Fire cancel() unconditionally: a no-op on natural completion (workers
+		// already finished), and on user quit it stops in-flight workers via
+		// ctx.Done() so wg.Wait() completes.
+		cancel()
+	} else {
+		// No terminal: one up-front banner, then the pool runs synchronously.
+		log("[ANALYSIS] No TTY available, running without progress UI")
+		fmt.Fprintf(deps.stdout, "Analysing %d files…\n", len(files))
+
+		runAnalysisPool(runCtx, nil, files, config, log, jobs, results, metas, errs, deps.openMetadata)
+
+		cancel()
+	}
+
+	// Print reports in input order after the pool completes. A worker cancelled
+	// at the acquire select leaves both results[i] and errs[i] nil; a worker
+	// cancelled mid-analysis sets errs[i] to a context.Canceled-wrapped error.
+	// Both cases are skipped: a user who quit should get no error spew. Real
+	// errors still print so per-file failures stay isolated. The printed flag
+	// drives the inter-report blank line so skipped files cannot emit a stray
+	// leading blank; with no skips it matches the previous i > 0 logic exactly.
+	printed := false
+	for i := range files {
+		if errs[i] != nil {
+			if errors.Is(errs[i], context.Canceled) {
+				continue
+			}
+			deps.printError(fmt.Sprintf("Analysis failed for %s: %v", files[i], errs[i]))
+			continue
+		}
+
+		if results[i] == nil {
+			continue // cancelled before analysis ran
+		}
+
+		// Blank line separates consecutive printed file reports.
+		if printed {
 			fmt.Fprintln(deps.stdout)
 		}
-
-		log("[ANALYSIS] Starting analysis for %s", inputPath)
-
-		// Metadata supplies the duration and sample rate shown in the report.
-		metadata, err := deps.openMetadata(inputPath)
-		if err != nil {
-			deps.printError(fmt.Sprintf("Failed to open %s: %v", inputPath, err))
-			continue
-		}
-
-		var analysisResult *processor.AnalysisResult
-		var analysisErr error
-
-		if hasTTY {
-			analysisResult, analysisErr = deps.runWithTUI(inputPath, config, log)
-		} else {
-			// No terminal: skip the progress UI for non-interactive environments.
-			log("[ANALYSIS] No TTY available, running without progress UI")
-			fmt.Fprintf(deps.stdout, "Analysing: %s\n", filepath.Base(inputPath))
-			analysisResult, analysisErr = deps.analyzeDetailed(context.Background(), inputPath, config, nil)
-		}
-
-		if analysisErr != nil {
-			if errors.Is(analysisErr, errCancelledByUser) {
-				// User pressed Ctrl+C - exit immediately, don't process remaining files
-				return
-			}
-			deps.printError(fmt.Sprintf("Analysis failed for %s: %v", inputPath, analysisErr))
-			continue
-		}
-
-		log("[ANALYSIS] Analysis complete for %s", inputPath)
+		printed = true
 
 		timings := logging.AnalysisTimings{
-			Analysis:   analysisResult.AnalysisDuration,
-			Adaptation: analysisResult.AdaptationDuration,
+			Analysis:   results[i].AnalysisDuration,
+			Adaptation: results[i].AdaptationDuration,
 		}
-		deps.displayResults(deps.stdout, inputPath, metadata, analysisResult.Measurements, analysisResult.Config, analysisResult.Diagnostics, timings)
+		deps.displayResults(deps.stdout, files[i], metas[i], results[i].Measurements, results[i].Config, results[i].Diagnostics, timings)
 	}
 }
 
@@ -354,55 +367,4 @@ func isTTY() bool {
 		return false
 	}
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
-}
-
-// runAnalysisWithTUI runs analysis with the Bubbletea progress UI.
-func runAnalysisWithTUI(inputPath string, config *processor.BaseFilterConfig, log func(string, ...any)) (*processor.AnalysisResult, error) {
-	model := ui.NewAnalysisModel()
-
-	// Run without the alt screen so the report stays on screen after exit.
-	p := tea.NewProgram(model)
-
-	go func(path string) {
-		p.Send(ui.AnalysisStartMsg{
-			FileName: path,
-			FilePath: path,
-		})
-
-		progressCallback := func(update processor.ProgressUpdate) {
-			log("[ANALYSIS] Progress: Pass %d (%s), %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
-			p.Send(ui.AnalysisProgressMsg{
-				Progress: update.Progress,
-				Level:    update.Level,
-			})
-		}
-
-		result, err := processor.AnalyzeOnlyDetailed(context.Background(), path, config, progressCallback)
-
-		p.Send(ui.AnalysisCompleteMsg{
-			Result: result,
-			Error:  err,
-		})
-	}(inputPath)
-
-	finalModel, err := p.Run()
-	if err != nil {
-		return nil, fmt.Errorf("UI error: %w", err)
-	}
-
-	analysisModel, ok := finalModel.(ui.AnalysisModel)
-	if !ok {
-		return nil, fmt.Errorf("unexpected model type")
-	}
-
-	if analysisModel.Error != nil {
-		return nil, analysisModel.Error
-	}
-
-	// A TUI exit before Done means the user cancelled mid-analysis.
-	if !analysisModel.Done {
-		return nil, errCancelledByUser
-	}
-
-	return analysisModel.Result, nil
 }

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -305,7 +305,11 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 		model := ui.NewAnalysisModel(files)
 		p := tea.NewProgram(model)
 
-		go runAnalysisPool(runCtx, p, files, config, log, jobs, results, metas, errs, deps.openMetadata)
+		poolDone := make(chan struct{})
+		go func() {
+			runAnalysisPool(runCtx, p, files, config, log, jobs, results, metas, errs, deps.openMetadata)
+			close(poolDone)
+		}()
 
 		if _, err := p.Run(); err != nil {
 			deps.printError(fmt.Sprintf("UI error: %v", err))
@@ -315,6 +319,11 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 		// already finished), and on user quit it stops in-flight workers via
 		// ctx.Done() so wg.Wait() completes.
 		cancel()
+
+		// Join the pool goroutine before reading results/metas/errs. On user
+		// quit p.Run() returns before the pool drains, so waiting here prevents
+		// a data race on the shared result slices.
+		<-poolDone
 	} else {
 		// No terminal: one up-front banner, then the pool runs synchronously.
 		log("[ANALYSIS] No TTY available, running without progress UI")

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -131,7 +132,24 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 	config := processor.DefaultFilterConfig()
 	var output bytes.Buffer
 
-	runAnalysisOnlyWithDeps([]string{inputPath}, config, func(string, ...any) {}, analysisOnlyDeps{
+	analyze := func(_ context.Context, path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		if path != inputPath {
+			t.Fatalf("analyzeDetailed path = %q, want %q", path, inputPath)
+		}
+		effective, diagnostics := processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements())
+		return &processor.AnalysisResult{
+			Measurements:       makeAnalysisOnlyTestMeasurements(),
+			Config:             effective,
+			Diagnostics:        diagnostics,
+			AnalysisDuration:   2 * time.Second,
+			AdaptationDuration: 100 * time.Millisecond,
+		}, nil
+	}
+	origAnalyze := analysisPoolAnalyze
+	analysisPoolAnalyze = analyze
+	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
+
+	runAnalysisOnlyWithDeps([]string{inputPath}, config, func(string, ...any) {}, 1, analysisOnlyDeps{
 		stdout: &output,
 		hasTTY: func() bool {
 			return false
@@ -146,27 +164,8 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		runWithTUI: func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
-			t.Fatal("runWithTUI should not be called for non-TTY output")
-			return nil, nil
-		},
-		analyzeDetailed: func(_ context.Context, path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
-			if path != inputPath {
-				t.Fatalf("analyzeDetailed path = %q, want %q", path, inputPath)
-			}
-			if progress != nil {
-				t.Fatal("progress callback should be nil for non-TTY output")
-			}
-			effective, diagnostics := processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements())
-			return &processor.AnalysisResult{
-				Measurements:       makeAnalysisOnlyTestMeasurements(),
-				Config:             effective,
-				Diagnostics:        diagnostics,
-				AnalysisDuration:   2 * time.Second,
-				AdaptationDuration: 100 * time.Millisecond,
-			}, nil
-		},
-		displayResults: logging.DisplayAnalysisResultsWithDiagnostics,
+		analyzeDetailed: analyze,
+		displayResults:  logging.DisplayAnalysisResultsWithDiagnostics,
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
 		},
@@ -177,7 +176,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 		t.Fatalf("analysis-only output leaked benchmark path:\n%s", got)
 	}
 	for _, want := range []string{
-		"Analysing: sample.wav",
+		"Analysing 1 files…",
 		"ANALYSIS: sample.wav",
 		"ANALYSIS TIMINGS",
 		"Analysis:",
@@ -212,7 +211,27 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	var displayedConfigs []*processor.EffectiveFilterConfig
 	var displayedDiagnostics []*processor.AdaptiveDiagnostics
 
-	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, analysisOnlyDeps{
+	fileIndex := map[string]int{files[0]: 0, files[1]: 1}
+	var mu sync.Mutex
+	analyze := func(_ context.Context, path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		mu.Lock()
+		analyzedConfigs = append(analyzedConfigs, cfg)
+		mu.Unlock()
+
+		index := fileIndex[path]
+		return &processor.AnalysisResult{
+			Measurements:       makeAnalysisOnlyTestMeasurements(),
+			Config:             resultConfigs[index],
+			Diagnostics:        resultDiagnostics[index],
+			AnalysisDuration:   2 * time.Second,
+			AdaptationDuration: 100 * time.Millisecond,
+		}, nil
+	}
+	origAnalyze := analysisPoolAnalyze
+	analysisPoolAnalyze = analyze
+	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
+
+	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, 1, analysisOnlyDeps{
 		stdout: &output,
 		hasTTY: func() bool {
 			return false
@@ -224,25 +243,7 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		runWithTUI: func(string, *processor.BaseFilterConfig, func(string, ...any)) (*processor.AnalysisResult, error) {
-			t.Fatal("runWithTUI should not be called for non-TTY output")
-			return nil, nil
-		},
-		analyzeDetailed: func(_ context.Context, path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
-			if cfg != baseConfig {
-				t.Fatalf("analyzeDetailed config = %p, want shared base %p", cfg, baseConfig)
-			}
-			analyzedConfigs = append(analyzedConfigs, cfg)
-
-			index := len(analyzedConfigs) - 1
-			return &processor.AnalysisResult{
-				Measurements:       makeAnalysisOnlyTestMeasurements(),
-				Config:             resultConfigs[index],
-				Diagnostics:        resultDiagnostics[index],
-				AnalysisDuration:   2 * time.Second,
-				AdaptationDuration: 100 * time.Millisecond,
-			}, nil
-		},
+		analyzeDetailed: analyze,
 		displayResults: func(w io.Writer, inputPath string, metadata *audio.Metadata, measurements *processor.AudioMeasurements, config *processor.EffectiveFilterConfig, diagnostics *processor.AdaptiveDiagnostics, timings ...logging.AnalysisTimings) {
 			displayedConfigs = append(displayedConfigs, config)
 			displayedDiagnostics = append(displayedDiagnostics, diagnostics)
@@ -258,8 +259,8 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	if len(analyzedConfigs) != len(files) {
 		t.Fatalf("analyzed config count = %d, want %d", len(analyzedConfigs), len(files))
 	}
-	if analyzedConfigs[0] != baseConfig || analyzedConfigs[1] != baseConfig {
-		t.Fatal("analysis-only did not reuse the shared base config pointer for analysis calls")
+	if analyzedConfigs[0] == baseConfig || analyzedConfigs[1] == baseConfig {
+		t.Fatal("analysis-only did not pass per-worker config clones to analysis calls")
 	}
 	if len(displayedConfigs) != len(resultConfigs) {
 		t.Fatalf("displayed config count = %d, want %d", len(displayedConfigs), len(resultConfigs))
@@ -278,6 +279,284 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 	if baseConfig.DS201HighPass.Frequency == resultConfigs[0].DS201HighPass.Frequency ||
 		baseConfig.DS201HighPass.Frequency == resultConfigs[1].DS201HighPass.Frequency {
 		t.Fatal("test setup failed: result configs should differ from the shared base seed")
+	}
+}
+
+func TestRunAnalysisOnlyWithDeps_OrderedOutputParityAcrossJobs(t *testing.T) {
+	files := []string{"file0.wav", "file1.wav", "file2.wav", "file3.wav"}
+	baseConfig := processor.DefaultFilterConfig()
+
+	fileIndex := make(map[string]int, len(files))
+	for i, f := range files {
+		fileIndex[f] = i
+	}
+
+	// Deterministic per-index sentinel: distinct measurements keyed by file
+	// index, and a staggered completion delay so that later-submitted files
+	// finish earlier. At jobs=N all workers run concurrently, so completion
+	// order != submission order; at jobs=1 it is serial. Both runs must emit
+	// byte-for-byte identical, input-ordered reports.
+	analyze := func(_ context.Context, path string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) { //nolint:unparam // signature must match processor.AnalyzeOnlyDetailed
+		index, ok := fileIndex[path]
+		if !ok {
+			t.Fatalf("analysisPoolAnalyze unexpected path %q", path)
+		}
+
+		// Later indices sleep less, so under concurrency they complete first.
+		delay := time.Duration(len(files)-index) * 20 * time.Millisecond
+		time.Sleep(delay)
+
+		measurements := makeAnalysisOnlyTestMeasurements()
+		measurements.InputI -= float64(index)
+		measurements.NoiseFloor -= float64(index)
+
+		effective, diagnostics := processor.AdaptConfig(baseConfig, measurements)
+		return &processor.AnalysisResult{
+			Measurements:       measurements,
+			Config:             effective,
+			Diagnostics:        diagnostics,
+			AnalysisDuration:   2 * time.Second,
+			AdaptationDuration: 100 * time.Millisecond,
+		}, nil
+	}
+	origAnalyze := analysisPoolAnalyze
+	analysisPoolAnalyze = analyze
+	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
+
+	run := func(jobs int) string {
+		var output bytes.Buffer
+		runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, jobs, analysisOnlyDeps{
+			stdout: &output,
+			hasTTY: func() bool {
+				return false
+			},
+			openMetadata: func(path string) (*audio.Metadata, error) {
+				if _, ok := fileIndex[path]; !ok {
+					t.Fatalf("openMetadata unexpected path %q", path)
+				}
+				return &audio.Metadata{
+					Duration:   120,
+					SampleRate: 48000,
+					Channels:   1,
+				}, nil
+			},
+			analyzeDetailed: analyze,
+			displayResults:  logging.DisplayAnalysisResultsWithDiagnostics,
+			printError: func(message string) {
+				t.Fatalf("printError called: %s", message)
+			},
+		})
+		return output.String()
+	}
+
+	parallel := run(4)
+	serial := run(1)
+
+	if parallel != serial {
+		t.Fatalf("jobs=4 output differs from jobs=1 output\n--- jobs=4 ---\n%s\n--- jobs=1 ---\n%s", parallel, serial)
+	}
+
+	// Order must follow submission (input) order despite staggered completion:
+	// each file's report header appears, and in file0..file3 sequence.
+	lastPos := -1
+	for _, f := range files {
+		header := "ANALYSIS: " + f
+		pos := strings.Index(parallel, header)
+		if pos < 0 {
+			t.Fatalf("output missing report header %q:\n%s", header, parallel)
+		}
+		if pos <= lastPos {
+			t.Fatalf("report for %s out of input order (pos %d <= prev %d):\n%s", f, pos, lastPos, parallel)
+		}
+		lastPos = pos
+	}
+
+	// Both runs print the identical up-front banner.
+	banner := "Analysing 4 files…"
+	if !strings.Contains(parallel, banner) {
+		t.Fatalf("output missing banner %q:\n%s", banner, parallel)
+	}
+}
+
+func TestRunAnalysisOnlyWithDeps_NonTTYBannerThenOrderedReports(t *testing.T) {
+	files := []string{"file0.wav", "file1.wav", "file2.wav"}
+	baseConfig := processor.DefaultFilterConfig()
+	var output bytes.Buffer
+
+	fileIndex := make(map[string]int, len(files))
+	for i, f := range files {
+		fileIndex[f] = i
+	}
+
+	// Staggered completion: later-submitted files sleep less and finish first,
+	// so with jobs >= len(files) the workers overlap and completion order !=
+	// submission order. The buffered slots must still print in input order.
+	analyze := func(_ context.Context, path string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		index, ok := fileIndex[path]
+		if !ok {
+			t.Fatalf("analysisPoolAnalyze unexpected path %q", path)
+		}
+
+		delay := time.Duration(len(files)-index) * 20 * time.Millisecond
+		time.Sleep(delay)
+
+		measurements := makeAnalysisOnlyTestMeasurements()
+		measurements.InputI -= float64(index)
+
+		effective, diagnostics := processor.AdaptConfig(baseConfig, measurements)
+		return &processor.AnalysisResult{
+			Measurements:       measurements,
+			Config:             effective,
+			Diagnostics:        diagnostics,
+			AnalysisDuration:   2 * time.Second,
+			AdaptationDuration: 100 * time.Millisecond,
+		}, nil
+	}
+	origAnalyze := analysisPoolAnalyze
+	analysisPoolAnalyze = analyze
+	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
+
+	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, len(files), analysisOnlyDeps{
+		stdout: &output,
+		hasTTY: func() bool {
+			return false
+		},
+		openMetadata: func(path string) (*audio.Metadata, error) {
+			if _, ok := fileIndex[path]; !ok {
+				t.Fatalf("openMetadata unexpected path %q", path)
+			}
+			return &audio.Metadata{
+				Duration:   120,
+				SampleRate: 48000,
+				Channels:   1,
+			}, nil
+		},
+		analyzeDetailed: analyze,
+		displayResults:  logging.DisplayAnalysisResultsWithDiagnostics,
+		printError: func(message string) {
+			t.Fatalf("printError called: %s", message)
+		},
+	})
+
+	got := output.String()
+
+	// stdout starts with the up-front banner (byte-for-byte: single U+2026
+	// ellipsis, trailing newline), matching the production main.go no-TTY
+	// branch and the 3.3 test assertion.
+	banner := "Analysing 3 files…\n"
+	if !strings.HasPrefix(got, banner) {
+		t.Fatalf("output does not start with banner %q:\n%s", banner, got)
+	}
+
+	// No per-file "Analysing: <file>" line from the old serial format.
+	if strings.Contains(got, "Analysing: ") {
+		t.Fatalf("output contains the removed per-file %q line:\n%s", "Analysing: ", got)
+	}
+
+	// Reports appear in input order despite staggered completion.
+	lastPos := -1
+	for _, f := range files {
+		header := "ANALYSIS: " + f
+		pos := strings.Index(got, header)
+		if pos < 0 {
+			t.Fatalf("output missing report header %q:\n%s", header, got)
+		}
+		if pos <= lastPos {
+			t.Fatalf("report for %s out of input order (pos %d <= prev %d):\n%s", f, pos, lastPos, got)
+		}
+		lastPos = pos
+	}
+}
+
+func TestRunAnalysisOnlyWithDeps_FailureIsolation(t *testing.T) {
+	files := []string{"file0.wav", "file1.wav", "file2.wav"}
+	baseConfig := processor.DefaultFilterConfig()
+	var output bytes.Buffer
+
+	const failIndex = 1
+	boom := errors.New("boom")
+
+	fileIndex := make(map[string]int, len(files))
+	for i, f := range files {
+		fileIndex[f] = i
+	}
+
+	// One input fails with a plain (non-cancellation) error; the siblings
+	// return valid sentinels. A real error must not be suppressed by the
+	// cancellation filter, so the failing file reports through printError.
+	analyze := func(_ context.Context, path string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
+		index, ok := fileIndex[path]
+		if !ok {
+			t.Fatalf("analysisPoolAnalyze unexpected path %q", path)
+		}
+		if index == failIndex {
+			return nil, boom
+		}
+		effective, diagnostics := processor.AdaptConfig(baseConfig, makeAnalysisOnlyTestMeasurements())
+		return &processor.AnalysisResult{
+			Measurements:       makeAnalysisOnlyTestMeasurements(),
+			Config:             effective,
+			Diagnostics:        diagnostics,
+			AnalysisDuration:   2 * time.Second,
+			AdaptationDuration: 100 * time.Millisecond,
+		}, nil
+	}
+	origAnalyze := analysisPoolAnalyze
+	analysisPoolAnalyze = analyze
+	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
+
+	var printErrMu sync.Mutex
+	var printErrors []string
+
+	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, 4, analysisOnlyDeps{
+		stdout: &output,
+		hasTTY: func() bool {
+			return false
+		},
+		openMetadata: func(path string) (*audio.Metadata, error) {
+			if _, ok := fileIndex[path]; !ok {
+				t.Fatalf("openMetadata unexpected path %q", path)
+			}
+			return &audio.Metadata{
+				Duration:   120,
+				SampleRate: 48000,
+				Channels:   1,
+			}, nil
+		},
+		analyzeDetailed: analyze,
+		displayResults:  logging.DisplayAnalysisResultsWithDiagnostics,
+		printError: func(message string) {
+			printErrMu.Lock()
+			printErrors = append(printErrors, message)
+			printErrMu.Unlock()
+		},
+	})
+
+	// The failing file reports exactly one error naming the file and "boom".
+	if len(printErrors) != 1 {
+		t.Fatalf("printError calls = %d (%v), want exactly 1", len(printErrors), printErrors)
+	}
+	if msg := printErrors[0]; !strings.Contains(msg, files[failIndex]) || !strings.Contains(msg, "boom") {
+		t.Fatalf("printError message = %q, want it to mention %q and %q", msg, files[failIndex], "boom")
+	}
+
+	got := output.String()
+
+	// The good siblings' reports print; the failing file has no normal report.
+	for _, f := range []string{files[0], files[2]} {
+		if !strings.Contains(got, "ANALYSIS: "+f) {
+			t.Fatalf("output missing report header for sibling %q:\n%s", f, got)
+		}
+	}
+	if strings.Contains(got, "ANALYSIS: "+files[failIndex]) {
+		t.Fatalf("failing file %q must not produce a normal report:\n%s", files[failIndex], got)
+	}
+
+	// The run completed (no early abort): all good siblings printed in order.
+	pos0 := strings.Index(got, "ANALYSIS: "+files[0])
+	pos2 := strings.Index(got, "ANALYSIS: "+files[2])
+	if pos0 < 0 || pos2 < 0 || pos2 <= pos0 {
+		t.Fatalf("sibling reports out of input order (pos0=%d, pos2=%d):\n%s", pos0, pos2, got)
 	}
 }
 

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -14,26 +14,30 @@ import (
 // Spinner frames for indeterminate progress
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
+// analysisFileState tracks analysis progress and results for a single file
+type analysisFileState struct {
+	FileName string
+	Progress float64 // 0.0 to 1.0
+	Level    float64 // Current audio level in dB
+	Done     bool
+	Err      error
+	Result   *processor.AnalysisResult
+}
+
 // AnalysisModel is the Bubbletea model for analysis-only mode
 type AnalysisModel struct {
-	// File being analysed
-	FileName string
-	FilePath string
+	// File queue
+	Files          []analysisFileState
+	TotalFiles     int
+	CompletedFiles int
+	FailedFiles    int
 
-	// Progress tracking
-	Progress  float64 // 0.0 to 1.0
-	Level     float64 // Current audio level in dB
+	// Global state
 	StartTime time.Time
+	Done      bool
 
 	// Spinner state
 	spinnerIndex int
-
-	// Results (populated when complete)
-	Result       *processor.AnalysisResult
-	Measurements *processor.AudioMeasurements
-	Config       *processor.EffectiveFilterConfig
-	Error        error
-	Done         bool
 
 	// Terminal dimensions
 	Width  int
@@ -42,18 +46,21 @@ type AnalysisModel struct {
 
 // AnalysisStartMsg signals analysis has started
 type AnalysisStartMsg struct {
-	FileName string
-	FilePath string
+	FileIndex int
+	FileName  string
+	FilePath  string
 }
 
 // AnalysisProgressMsg signals progress update
 type AnalysisProgressMsg struct {
-	Progress float64
-	Level    float64
+	FileIndex int
+	Progress  float64
+	Level     float64
 }
 
 // AnalysisCompleteMsg signals analysis has completed
 type AnalysisCompleteMsg struct {
+	FileIndex    int
 	Result       *processor.AnalysisResult
 	Measurements *processor.AudioMeasurements
 	Config       *processor.EffectiveFilterConfig
@@ -63,10 +70,19 @@ type AnalysisCompleteMsg struct {
 // tickMsg is sent for spinner/timer animation
 type tickMsg time.Time
 
-// NewAnalysisModel creates a new analysis UI model
-func NewAnalysisModel() AnalysisModel {
+// NewAnalysisModel creates a new analysis UI model with the given input files
+func NewAnalysisModel(files []string) AnalysisModel {
+	states := make([]analysisFileState, len(files))
+	for i, path := range files {
+		states[i] = analysisFileState{
+			FileName: filepath.Base(path),
+		}
+	}
+
 	return AnalysisModel{
-		StartTime: time.Now(),
+		Files:      states,
+		TotalFiles: len(files),
+		StartTime:  time.Now(),
 	}
 }
 
@@ -104,26 +120,33 @@ func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case AnalysisStartMsg:
-		m.FileName = filepath.Base(msg.FilePath)
-		m.FilePath = msg.FilePath
-		m.StartTime = time.Now()
+		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
+			m.Files[msg.FileIndex].FileName = filepath.Base(msg.FilePath)
+		}
 		return m, nil
 
 	case AnalysisProgressMsg:
-		m.Progress = msg.Progress
-		m.Level = msg.Level
+		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
+			m.Files[msg.FileIndex].Progress = msg.Progress
+			m.Files[msg.FileIndex].Level = msg.Level
+		}
 		return m, nil
 
 	case AnalysisCompleteMsg:
-		m.Result = msg.Result
-		if msg.Result != nil {
-			m.Measurements = msg.Result.Measurements
-			m.Config = msg.Result.Config
-		} else {
-			m.Measurements = msg.Measurements
-			m.Config = msg.Config
+		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
+			m.Files[msg.FileIndex].Result = msg.Result
+			m.Files[msg.FileIndex].Err = msg.Error
+			m.Files[msg.FileIndex].Done = true
+
+			if msg.Error != nil {
+				m.FailedFiles++
+			} else {
+				m.CompletedFiles++
+			}
 		}
-		m.Error = msg.Error
+		return m, nil
+
+	case AllCompleteMsg:
 		m.Done = true
 		return m, tea.Quit
 	}
@@ -153,43 +176,48 @@ func (m AnalysisModel) View() string {
 	b.WriteString(title + " " + subtitle)
 	b.WriteString("\n\n")
 
-	if m.FileName == "" {
+	if len(m.Files) == 0 {
 		b.WriteString("Waiting...")
 		return b.String()
 	}
 
-	// File being analysed
 	fileStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#FFFFFF")).
 		Bold(true)
-
-	b.WriteString("Analysing: ")
-	b.WriteString(fileStyle.Render(m.FileName))
-	b.WriteString("\n\n")
-
-	// Progress bar with spinner
-	elapsed := time.Since(m.StartTime)
 	spinnerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#A40000"))
+	doneStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00AA00"))
+	errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#A40000"))
 	spinner := spinnerStyle.Render(spinnerFrames[m.spinnerIndex])
+	elapsed := time.Since(m.StartTime)
 
-	if m.Progress > 0 && m.Progress < 1.0 {
-		// Determinate progress bar with spinner
-		b.WriteString(spinner)
-		b.WriteString(" ")
-		b.WriteString(renderAnalysisProgressBar(m.Progress, 40, elapsed))
-	} else if !m.Done {
-		// Indeterminate spinner
-		b.WriteString(spinner)
-		b.WriteString(" Processing...")
-		fmt.Fprintf(&b, " [%s]", formatElapsed(elapsed))
+	for i := range m.Files {
+		f := &m.Files[i]
+
+		switch {
+		case f.Done && f.Err != nil:
+			icon := errorStyle.Render("✗")
+			fmt.Fprintf(&b, " %s %s\n   Error: %v\n", icon, fileStyle.Render(f.FileName), f.Err)
+		case f.Done:
+			icon := doneStyle.Render("🗸")
+			fmt.Fprintf(&b, " %s %s\n   Analysed\n", icon, fileStyle.Render(f.FileName))
+		default:
+			fmt.Fprintf(&b, " %s %s\n", spinner, fileStyle.Render(f.FileName))
+			fmt.Fprintf(&b, "   %s\n", renderAnalysisProgressBar(f.Progress, 40, elapsed))
+			if f.Level != 0 {
+				fmt.Fprintf(&b, "   Level: %.1f dB\n", f.Level)
+			}
+		}
+
+		b.WriteString("\n")
 	}
 
-	b.WriteString("\n")
-
-	// Show audio level if available
-	if m.Level != 0 && !m.Done {
-		fmt.Fprintf(&b, "\nLevel: %.1f dB", m.Level)
-	}
+	footer := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#888888")).
+		Padding(0, 1).
+		Render(fmt.Sprintf("Analysing %d files, %d complete, %d failed",
+			m.TotalFiles, m.CompletedFiles, m.FailedFiles))
+	b.WriteString(footer)
 
 	return b.String()
 }

--- a/internal/ui/analysis_model_test.go
+++ b/internal/ui/analysis_model_test.go
@@ -1,0 +1,117 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestAnalysisProgressMsgIndexRouting(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav", "b.wav"})
+	before := m.Files[0]
+
+	updated, _ := m.Update(AnalysisProgressMsg{FileIndex: 1, Progress: 0.75, Level: -12.5})
+	m = updated.(AnalysisModel)
+
+	if m.Files[1].Progress != 0.75 {
+		t.Errorf("Files[1].Progress = %v, want 0.75", m.Files[1].Progress)
+	}
+	if m.Files[1].Level != -12.5 {
+		t.Errorf("Files[1].Level = %v, want -12.5", m.Files[1].Level)
+	}
+	if m.Files[0] != before {
+		t.Errorf("Files[0] changed: got %+v, want %+v", m.Files[0], before)
+	}
+}
+
+func TestAnalysisCompleteMsgCounts(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav", "b.wav"})
+
+	// Success increments CompletedFiles, not FailedFiles.
+	updated, _ := m.Update(AnalysisCompleteMsg{FileIndex: 0})
+	m = updated.(AnalysisModel)
+	if m.CompletedFiles != 1 {
+		t.Errorf("CompletedFiles = %d, want 1", m.CompletedFiles)
+	}
+	if m.FailedFiles != 0 {
+		t.Errorf("FailedFiles = %d, want 0", m.FailedFiles)
+	}
+	if !m.Files[0].Done {
+		t.Error("Files[0].Done = false, want true")
+	}
+
+	// Error increments FailedFiles and records the error on the slot.
+	wantErr := errors.New("boom")
+	updated, _ = m.Update(AnalysisCompleteMsg{FileIndex: 1, Error: wantErr})
+	m = updated.(AnalysisModel)
+	if m.FailedFiles != 1 {
+		t.Errorf("FailedFiles = %d, want 1", m.FailedFiles)
+	}
+	if m.CompletedFiles != 1 {
+		t.Errorf("CompletedFiles = %d, want 1 (unchanged)", m.CompletedFiles)
+	}
+	if !errors.Is(m.Files[1].Err, wantErr) {
+		t.Errorf("Files[1].Err = %v, want %v", m.Files[1].Err, wantErr)
+	}
+}
+
+func TestAnalysisQuitOnlyOnAllComplete(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav", "b.wav"})
+
+	// Per-file completion must NOT quit.
+	updated, cmd := m.Update(AnalysisCompleteMsg{FileIndex: 0})
+	m = updated.(AnalysisModel)
+	if isQuitCmd(cmd) {
+		t.Error("per-file AnalysisCompleteMsg returned a quit cmd, want non-quit")
+	}
+
+	updated, cmd = m.Update(AnalysisCompleteMsg{FileIndex: 1, Error: errors.New("boom")})
+	m = updated.(AnalysisModel)
+	if isQuitCmd(cmd) {
+		t.Error("failed per-file AnalysisCompleteMsg returned a quit cmd, want non-quit")
+	}
+
+	// AllCompleteMsg must quit and mark the model done.
+	updated, cmd = m.Update(AllCompleteMsg{})
+	m = updated.(AnalysisModel)
+	if !isQuitCmd(cmd) {
+		t.Error("AllCompleteMsg did not return a quit cmd, want quit")
+	}
+	if !m.Done {
+		t.Error("Done = false after AllCompleteMsg, want true")
+	}
+}
+
+func TestAnalysisUpdateOutOfRangeSafety(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav", "b.wav"})
+	want := append([]analysisFileState(nil), m.Files...)
+
+	indices := []int{-1, len(m.Files)}
+	for _, idx := range indices {
+		updated, _ := m.Update(AnalysisStartMsg{FileIndex: idx, FilePath: "x.wav"})
+		m = updated.(AnalysisModel)
+		updated, _ = m.Update(AnalysisProgressMsg{FileIndex: idx, Progress: 0.9, Level: -3})
+		m = updated.(AnalysisModel)
+		updated, _ = m.Update(AnalysisCompleteMsg{FileIndex: idx, Error: errors.New("boom")})
+		m = updated.(AnalysisModel)
+	}
+
+	for i := range want {
+		if m.Files[i] != want[i] {
+			t.Errorf("Files[%d] changed after out-of-range messages: got %+v, want %+v", i, m.Files[i], want[i])
+		}
+	}
+	if m.CompletedFiles != 0 || m.FailedFiles != 0 {
+		t.Errorf("counts changed: completed=%d failed=%d, want 0/0", m.CompletedFiles, m.FailedFiles)
+	}
+}
+
+// isQuitCmd reports whether cmd, when invoked, yields a tea.QuitMsg.
+func isQuitCmd(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	_, ok := cmd().(tea.QuitMsg)
+	return ok
+}


### PR DESCRIPTION
- Extend AnalysisModel to multi-file with FileIndex routing, per-file state tracking, and aggregate counters (TotalFiles, CompletedFiles, FailedFiles)
- Update View to render per-file progress rows plus footer summary
- Implement runAnalysisPool (cmd/jivetalking/analysispool.go) with buffered semaphore, WaitGroup, index-keyed result slots, and no-TTY nil-Program support (matching runWorkerPool seam pattern)
- Rewrite runAnalysisOnly as runAnalysisOnlyWithDeps: routes to TTY (tea.Program + goroutine pool) or no-TTY (banner + synchronous pool) branches, prints ordered reports in input order
- Thread --jobs flag from main.go via resolveJobs(cliArgs.Jobs, runtime.NumCPU())
- Fix cancellation defects: nil-deref guard in analysis-only path, cancel-error suppression for context.Canceled, printed flag for separator robustness

Verification:
- Race-clean concurrent FFmpeg analysis (≥2 files, CGO_ENABLED=1 go test -race ./...)
- In-flight concurrency respects --jobs bound uncapped at file count
- Byte-for-byte output parity jobs=N vs jobs=1 despite staggered completion
- Failure isolation: per-file errors do not abort run or affect siblings
- No-TTY path correctly suppresses old per-file Analysing: lines
- Cancellation aborts promptly, queued workers skip via acquire-select