### PR TITLE
feat(ui): adopt Charm v2 components for TUI primitives

### DIFF
--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/colorprofile"
 	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
@@ -222,6 +224,7 @@ type analysisOnlyDeps struct {
 	analyzeDetailed func(context.Context, string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)
 	displayResults  func(io.Writer, string, *audio.Metadata, *processor.AudioMeasurements, *processor.EffectiveFilterConfig, *processor.AdaptiveDiagnostics, ...logging.AnalysisTimings)
 	printError      func(string)
+	createLog       func(string) (io.WriteCloser, error)
 }
 
 func defaultAnalysisOnlyDeps() analysisOnlyDeps {
@@ -232,7 +235,13 @@ func defaultAnalysisOnlyDeps() analysisOnlyDeps {
 		analyzeDetailed: processor.AnalyzeOnlyDetailed,
 		displayResults:  logging.DisplayAnalysisResultsWithDiagnostics,
 		printError:      cli.PrintError,
+		createLog:       createAnalysisLogFile,
 	}
+}
+
+// createAnalysisLogFile creates (or truncates) the analysis log file at path.
+func createAnalysisLogFile(path string) (io.WriteCloser, error) {
+	return os.Create(path)
 }
 
 func openAudioMetadata(inputPath string) (*audio.Metadata, error) {
@@ -345,14 +354,17 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 		cancel()
 	}
 
-	// Print reports in input order after the pool completes. A worker cancelled
-	// at the acquire select leaves both results[i] and errs[i] nil; a worker
-	// cancelled mid-analysis sets errs[i] to a context.Canceled-wrapped error.
-	// Both cases are skipped: a user who quit should get no error spew. Real
-	// errors still print so per-file failures stay isolated. The printed flag
-	// drives the inter-report blank line so skipped files cannot emit a stray
-	// leading blank; with no skips it matches the previous i > 0 logic exactly.
-	printed := false
+	// Write each file's report to <source-name>-analysis.log in input order
+	// after the pool completes. A worker cancelled at the acquire select leaves
+	// both results[i] and errs[i] nil; a worker cancelled mid-analysis sets
+	// errs[i] to a context.Canceled-wrapped error. Both cases are skipped: a
+	// user who quit should get no error spew. Real errors still print so
+	// per-file failures stay isolated.
+	//
+	// In no-TTY mode the post-loop prints the one-line confirmation to stdout;
+	// in TTY mode the persisted analysis TUI already shows it, so we skip the
+	// stdout print to avoid doubling up. The .log file is written in both modes.
+	noTTY := !deps.hasTTY()
 	for i := range files {
 		if errs[i] != nil {
 			if errors.Is(errs[i], context.Canceled) {
@@ -366,18 +378,36 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 			continue // cancelled before analysis ran
 		}
 
-		// Blank line separates consecutive printed file reports.
-		if printed {
-			fmt.Fprintln(deps.stdout)
-		}
-		printed = true
-
 		timings := logging.AnalysisTimings{
 			Analysis:   results[i].AnalysisDuration,
 			Adaptation: results[i].AdaptationDuration,
 		}
-		deps.displayResults(deps.stdout, files[i], metas[i], results[i].Measurements, results[i].Config, results[i].Diagnostics, timings)
+
+		logPath := logging.AnalysisLogPath(files[i])
+		logFile, err := deps.createLog(logPath)
+		if err != nil {
+			deps.printError(fmt.Sprintf("Failed to create analysis log for %s: %v", files[i], err))
+			continue
+		}
+		deps.displayResults(logFile, files[i], metas[i], results[i].Measurements, results[i].Config, results[i].Diagnostics, timings)
+		if err := logFile.Close(); err != nil {
+			deps.printError(fmt.Sprintf("Failed to write analysis log for %s: %v", files[i], err))
+			continue
+		}
+
+		if noTTY {
+			printAnalysisConfirmation(deps.stdout, files[i], logPath)
+		}
 	}
+}
+
+// printAnalysisConfirmation writes a single styled confirmation line
+// "🗸 <source-basename> → <log-basename>" through a colour-aware writer so the
+// green check downgrades cleanly on non-colour stdout.
+func printAnalysisConfirmation(w io.Writer, inputPath, logPath string) {
+	icon := lipgloss.NewStyle().Foreground(cli.ColorGreen).Render("🗸")
+	cw := colorprofile.NewWriter(w, os.Environ())
+	fmt.Fprintf(cw, "%s %s → %s\n", icon, filepath.Base(inputPath), filepath.Base(logPath))
 }
 
 // isTTY reports whether stdout is connected to a terminal.

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -11,6 +11,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/alecthomas/kong"
+	"github.com/charmbracelet/colorprofile"
 	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
 	"github.com/linuxmatters/jivetalking/internal/audio"
 	"github.com/linuxmatters/jivetalking/internal/cli"
@@ -144,7 +145,7 @@ func main() {
 
 	poolDone := launchWorkerPool(runCtx, p, cliArgs.Files, config, log, jobs, reportWarnings)
 
-	_, runErr := p.Run()
+	finalModel, runErr := p.Run()
 
 	// p.Run() blocks until tea.Quit, fired on q/ctrl+c and on AllCompleteMsg.
 	// Fire cancel() unconditionally: a no-op on natural completion (workers
@@ -168,6 +169,14 @@ func main() {
 			debugLog.Close()
 		}
 		os.Exit(1) //nolint:gocritic // exitAfterDefer: debugLog explicitly closed above
+	}
+
+	// Persist the completion summary to the normal screen so it survives the
+	// alt-screen restore on exit. Only on natural completion (Done == true); an
+	// early user quit (q/ctrl+c) leaves Done == false and must skip the print to
+	// avoid a misleading "complete" summary. A non-ui.Model also skips.
+	if m, ok := finalModel.(ui.Model); ok && m.Done {
+		fmt.Fprintln(colorprofile.NewWriter(os.Stdout, os.Environ()), ui.FinalSummary(m))
 	}
 
 	for {

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -284,6 +284,7 @@ func (ph *progressHandler) callback(update processor.ProgressUpdate) {
 		PassName:     update.PassName,
 		Progress:     update.Progress,
 		Level:        update.Level,
+		Duration:     update.Duration,
 		Measurements: update.Measurements,
 	})
 }

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -185,7 +185,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Analysing 1 files…",
-		"🗸 sample.wav → sample-analysis.log",
+		"🗸 sample.wav → sample-wav-analysis.log",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("analysis-only stdout missing %q:\n%s", want, got)
@@ -193,7 +193,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 	}
 
 	// The full report lands in <source-name>-analysis.log beside the source.
-	logPath := ".bench/analysis/input/sample-analysis.log"
+	logPath := ".bench/analysis/input/sample-wav-analysis.log"
 	report, ok := logs.content(logPath)
 	if !ok {
 		t.Fatalf("no analysis log written at %q (have %v)", logPath, logs.logs)

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -149,6 +150,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 	analysisPoolAnalyze = analyze
 	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
 
+	logs := newLogCapture()
 	runAnalysisOnlyWithDeps([]string{inputPath}, config, func(string, ...any) {}, 1, analysisOnlyDeps{
 		stdout: &output,
 		hasTTY: func() bool {
@@ -169,22 +171,42 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
 		},
+		createLog: logs.create,
 	})
 
 	got := output.String()
+	// stdout carries the banner plus the one-line confirmation, never the
+	// report body or any benchmark path.
+	if strings.Contains(got, "ANALYSIS: sample.wav") {
+		t.Fatalf("report body leaked to stdout instead of the log file:\n%s", got)
+	}
 	if strings.Contains(got, ".bench/") {
-		t.Fatalf("analysis-only output leaked benchmark path:\n%s", got)
+		t.Fatalf("analysis-only stdout leaked benchmark path:\n%s", got)
 	}
 	for _, want := range []string{
 		"Analysing 1 files…",
+		"🗸 sample.wav → sample-analysis.log",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("analysis-only stdout missing %q:\n%s", want, got)
+		}
+	}
+
+	// The full report lands in <source-name>-analysis.log beside the source.
+	logPath := ".bench/analysis/input/sample-analysis.log"
+	report, ok := logs.content(logPath)
+	if !ok {
+		t.Fatalf("no analysis log written at %q (have %v)", logPath, logs.logs)
+	}
+	for _, want := range []string{
 		"ANALYSIS: sample.wav",
 		"ANALYSIS TIMINGS",
 		"Analysis:",
 		"Adaptation:",
 		"Report Output:",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("analysis-only output missing %q:\n%s", want, got)
+		if !strings.Contains(report, want) {
+			t.Fatalf("analysis log missing %q:\n%s", want, report)
 		}
 	}
 }
@@ -254,6 +276,7 @@ func TestRunAnalysisOnlyWithDeps_UsesPerFileResultConfig(t *testing.T) {
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
 		},
+		createLog: newLogCapture().create,
 	})
 
 	if len(analyzedConfigs) != len(files) {
@@ -323,8 +346,9 @@ func TestRunAnalysisOnlyWithDeps_OrderedOutputParityAcrossJobs(t *testing.T) {
 	analysisPoolAnalyze = analyze
 	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
 
-	run := func(jobs int) string {
+	run := func(jobs int) (string, *logCapture) {
 		var output bytes.Buffer
+		logs := newLogCapture()
 		runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, jobs, analysisOnlyDeps{
 			stdout: &output,
 			hasTTY: func() bool {
@@ -345,36 +369,50 @@ func TestRunAnalysisOnlyWithDeps_OrderedOutputParityAcrossJobs(t *testing.T) {
 			printError: func(message string) {
 				t.Fatalf("printError called: %s", message)
 			},
+			createLog: logs.create,
 		})
-		return output.String()
+		return output.String(), logs
 	}
 
-	parallel := run(4)
-	serial := run(1)
+	parallel, parallelLogs := run(4)
+	serial, _ := run(1)
 
 	if parallel != serial {
-		t.Fatalf("jobs=4 output differs from jobs=1 output\n--- jobs=4 ---\n%s\n--- jobs=1 ---\n%s", parallel, serial)
+		t.Fatalf("jobs=4 stdout differs from jobs=1 stdout\n--- jobs=4 ---\n%s\n--- jobs=1 ---\n%s", parallel, serial)
 	}
 
-	// Order must follow submission (input) order despite staggered completion:
-	// each file's report header appears, and in file0..file3 sequence.
+	// Confirmation lines must follow submission (input) order despite staggered
+	// completion: each file's "🗸 <file> → " line appears in file0..file3 order.
+	plain := stripANSI(parallel)
 	lastPos := -1
 	for _, f := range files {
-		header := "ANALYSIS: " + f
-		pos := strings.Index(parallel, header)
+		line := "🗸 " + f + " → "
+		pos := strings.Index(plain, line)
 		if pos < 0 {
-			t.Fatalf("output missing report header %q:\n%s", header, parallel)
+			t.Fatalf("stdout missing confirmation %q:\n%s", line, plain)
 		}
 		if pos <= lastPos {
-			t.Fatalf("report for %s out of input order (pos %d <= prev %d):\n%s", f, pos, lastPos, parallel)
+			t.Fatalf("confirmation for %s out of input order (pos %d <= prev %d):\n%s", f, pos, lastPos, plain)
 		}
 		lastPos = pos
+	}
+
+	// Each file's full report lands in its own <name>-analysis.log.
+	for _, f := range files {
+		logPath := logging.AnalysisLogPath(f)
+		report, ok := parallelLogs.content(logPath)
+		if !ok {
+			t.Fatalf("no analysis log at %q", logPath)
+		}
+		if !strings.Contains(report, "ANALYSIS: "+f) {
+			t.Fatalf("log %q missing report header for %q:\n%s", logPath, f, report)
+		}
 	}
 
 	// Both runs print the identical up-front banner.
 	banner := "Analysing 4 files…"
 	if !strings.Contains(parallel, banner) {
-		t.Fatalf("output missing banner %q:\n%s", banner, parallel)
+		t.Fatalf("stdout missing banner %q:\n%s", banner, parallel)
 	}
 }
 
@@ -416,6 +454,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYBannerThenOrderedReports(t *testing.T) {
 	analysisPoolAnalyze = analyze
 	t.Cleanup(func() { analysisPoolAnalyze = origAnalyze })
 
+	logs := newLogCapture()
 	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, len(files), analysisOnlyDeps{
 		stdout: &output,
 		hasTTY: func() bool {
@@ -436,6 +475,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYBannerThenOrderedReports(t *testing.T) {
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
 		},
+		createLog: logs.create,
 	})
 
 	got := output.String()
@@ -448,23 +488,40 @@ func TestRunAnalysisOnlyWithDeps_NonTTYBannerThenOrderedReports(t *testing.T) {
 		t.Fatalf("output does not start with banner %q:\n%s", banner, got)
 	}
 
-	// No per-file "Analysing: <file>" line from the old serial format.
+	// No per-file "Analysing: <file>" line from the old serial format, and no
+	// report body on stdout (the report now lives in the .log file).
 	if strings.Contains(got, "Analysing: ") {
 		t.Fatalf("output contains the removed per-file %q line:\n%s", "Analysing: ", got)
 	}
+	if strings.Contains(got, "ANALYSIS: ") {
+		t.Fatalf("report body leaked to stdout:\n%s", got)
+	}
 
-	// Reports appear in input order despite staggered completion.
+	// Confirmation lines appear in input order despite staggered completion.
+	plain := stripANSI(got)
 	lastPos := -1
 	for _, f := range files {
-		header := "ANALYSIS: " + f
-		pos := strings.Index(got, header)
+		line := "🗸 " + f + " → "
+		pos := strings.Index(plain, line)
 		if pos < 0 {
-			t.Fatalf("output missing report header %q:\n%s", header, got)
+			t.Fatalf("stdout missing confirmation %q:\n%s", line, plain)
 		}
 		if pos <= lastPos {
-			t.Fatalf("report for %s out of input order (pos %d <= prev %d):\n%s", f, pos, lastPos, got)
+			t.Fatalf("confirmation for %s out of input order (pos %d <= prev %d):\n%s", f, pos, lastPos, plain)
 		}
 		lastPos = pos
+	}
+
+	// Each file's full report lands in its own <name>-analysis.log.
+	for _, f := range files {
+		logPath := logging.AnalysisLogPath(f)
+		report, ok := logs.content(logPath)
+		if !ok {
+			t.Fatalf("no analysis log at %q", logPath)
+		}
+		if !strings.Contains(report, "ANALYSIS: "+f) {
+			t.Fatalf("log %q missing report header for %q:\n%s", logPath, f, report)
+		}
 	}
 }
 
@@ -508,6 +565,7 @@ func TestRunAnalysisOnlyWithDeps_FailureIsolation(t *testing.T) {
 	var printErrMu sync.Mutex
 	var printErrors []string
 
+	logs := newLogCapture()
 	runAnalysisOnlyWithDeps(files, baseConfig, func(string, ...any) {}, 4, analysisOnlyDeps{
 		stdout: &output,
 		hasTTY: func() bool {
@@ -530,6 +588,7 @@ func TestRunAnalysisOnlyWithDeps_FailureIsolation(t *testing.T) {
 			printErrors = append(printErrors, message)
 			printErrMu.Unlock()
 		},
+		createLog: logs.create,
 	})
 
 	// The failing file reports exactly one error naming the file and "boom".
@@ -540,24 +599,72 @@ func TestRunAnalysisOnlyWithDeps_FailureIsolation(t *testing.T) {
 		t.Fatalf("printError message = %q, want it to mention %q and %q", msg, files[failIndex], "boom")
 	}
 
-	got := output.String()
-
-	// The good siblings' reports print; the failing file has no normal report.
+	// The good siblings each get a log with their report; the failing file gets
+	// none (no log created, no confirmation).
 	for _, f := range []string{files[0], files[2]} {
-		if !strings.Contains(got, "ANALYSIS: "+f) {
-			t.Fatalf("output missing report header for sibling %q:\n%s", f, got)
+		report, ok := logs.content(logging.AnalysisLogPath(f))
+		if !ok {
+			t.Fatalf("missing analysis log for sibling %q", f)
+		}
+		if !strings.Contains(report, "ANALYSIS: "+f) {
+			t.Fatalf("log for sibling %q missing report header:\n%s", f, report)
 		}
 	}
-	if strings.Contains(got, "ANALYSIS: "+files[failIndex]) {
-		t.Fatalf("failing file %q must not produce a normal report:\n%s", files[failIndex], got)
+	if _, ok := logs.content(logging.AnalysisLogPath(files[failIndex])); ok {
+		t.Fatalf("failing file %q must not produce an analysis log", files[failIndex])
 	}
 
-	// The run completed (no early abort): all good siblings printed in order.
-	pos0 := strings.Index(got, "ANALYSIS: "+files[0])
-	pos2 := strings.Index(got, "ANALYSIS: "+files[2])
-	if pos0 < 0 || pos2 < 0 || pos2 <= pos0 {
-		t.Fatalf("sibling reports out of input order (pos0=%d, pos2=%d):\n%s", pos0, pos2, got)
+	plain := stripANSI(output.String())
+	if strings.Contains(plain, files[failIndex]+" → ") {
+		t.Fatalf("failing file %q must not print a confirmation:\n%s", files[failIndex], plain)
 	}
+
+	// The run completed (no early abort): both good siblings confirmed in order.
+	pos0 := strings.Index(plain, "🗸 "+files[0]+" → ")
+	pos2 := strings.Index(plain, "🗸 "+files[2]+" → ")
+	if pos0 < 0 || pos2 < 0 || pos2 <= pos0 {
+		t.Fatalf("sibling confirmations out of input order (pos0=%d, pos2=%d):\n%s", pos0, pos2, plain)
+	}
+}
+
+// ansiRE strips ANSI escape sequences so stdout assertions match plain text.
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string {
+	return ansiRE.ReplaceAllString(s, "")
+}
+
+// logCapture records analysis log writes keyed by the requested log path,
+// letting tests assert report content without touching the filesystem.
+type logCapture struct {
+	mu   sync.Mutex
+	logs map[string]*bytes.Buffer
+}
+
+func newLogCapture() *logCapture {
+	return &logCapture{logs: make(map[string]*bytes.Buffer)}
+}
+
+type bufferWriteCloser struct{ *bytes.Buffer }
+
+func (bufferWriteCloser) Close() error { return nil }
+
+func (c *logCapture) create(path string) (io.WriteCloser, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	buf := &bytes.Buffer{}
+	c.logs[path] = buf
+	return bufferWriteCloser{buf}, nil
+}
+
+func (c *logCapture) content(path string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	buf, ok := c.logs[path]
+	if !ok {
+		return "", false
+	}
+	return buf.String(), true
 }
 
 func parseCLIArgs(t *testing.T, args ...string) *CLI {

--- a/cmd/jivetalking/pool.go
+++ b/cmd/jivetalking/pool.go
@@ -105,13 +105,16 @@ func runWorkerPool(ctx context.Context, p *tea.Program, files []string, base *pr
 				reportWarnings <- fmt.Sprintf("Report was not written for %s: %v", inputPath, err)
 			}
 
+			finalNoiseFloor, _ := processor.FinalNoiseFloor(result)
+
 			wlog("[POOL] Sending FileCompleteMsg for file %d", i)
 			p.Send(ui.FileCompleteMsg{
-				FileIndex:  i,
-				InputLUFS:  result.InputLUFS,
-				OutputLUFS: result.OutputLUFS,
-				NoiseFloor: result.NoiseFloor,
-				OutputPath: result.OutputPath,
+				FileIndex:       i,
+				InputLUFS:       result.InputLUFS,
+				OutputLUFS:      result.OutputLUFS,
+				FinalNoiseFloor: finalNoiseFloor,
+				OutputPath:      result.OutputPath,
+				Quality:         processor.ComputeQualityScore(result),
 			})
 		}(i, inputPath)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,20 @@ module github.com/linuxmatters/jivetalking
 go 1.26.3
 
 require (
+	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.7
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/alecthomas/kong v1.15.0
+	github.com/charmbracelet/colorprofile v0.4.3
+	github.com/charmbracelet/harmonica v0.2.0
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/linuxmatters/ffmpeg-statigo v0.0.0-00010101000000-000000000000
 )
 
 replace github.com/linuxmatters/ffmpeg-statigo => ./third_party/ffmpeg-statigo
 
 require (
-	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
+charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
 charm.land/bubbletea/v2 v2.0.7 h1:7qw2tTAVar7m7klOPBYfTB0mniv/RuexsYwMRNxSeL0=
 charm.land/bubbletea/v2 v2.0.7/go.mod h1:DGW2q8gvzHnOpMpZTORs0aySVHCox5C+2Svk0fci1qs=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
@@ -12,6 +14,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 h1:FpSYhY28ucg9ZRr+2wj67FAQ0Ey5yiK0072PmRDJNek=
 github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654/go.mod h1:hFpumms29Smx3LStRfku8vcCTBe1Kq8aCXtHUJa3mjY=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -2,39 +2,41 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/alecthomas/kong"
+	"github.com/charmbracelet/colorprofile"
 )
 
 // Custom help styles
 var (
 	helpTitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#A40000")).
+			Foreground(ColorRed).
 			MarginBottom(1)
 
 	helpDescStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FFA500")).
+			Foreground(ColorOrange).
 			Italic(true).
 			MarginBottom(1)
 
 	helpSectionStyle = lipgloss.NewStyle().
 				Bold(true).
-				Foreground(lipgloss.Color("#FFA500")).
+				Foreground(ColorOrange).
 				MarginTop(1)
 
 	helpFlagStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00AA00")).
+			Foreground(ColorGreen).
 			Bold(true)
 
 	helpArgStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00AAAA")).
+			Foreground(ColorCyan).
 			Bold(true)
 
 	helpDefaultStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#888888")).
+				Foreground(ColorMuted).
 				Italic(true)
 )
 
@@ -94,7 +96,7 @@ func StyledHelpPrinter(options kong.HelpOptions) func(options kong.HelpOptions, 
 		}
 
 		sb.WriteString("\n")
-		fmt.Fprint(ctx.Stdout, sb.String())
+		fmt.Fprint(colorprofile.NewWriter(ctx.Stdout, os.Environ()), sb.String())
 		return nil
 	}
 }

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -36,6 +36,12 @@ var (
 	ColorCyan = compat.AdaptiveColor{Light: lipgloss.Color("#00AAAA"), Dark: lipgloss.Color("#00AAAA")}
 	// ColorFill is the empty/unfilled fill colour for meters and progress.
 	ColorFill = compat.AdaptiveColor{Light: lipgloss.Color("#CCCCCC"), Dark: lipgloss.Color("#444444")}
+	// ColorLightGrey is the subtle light-grey for panel borders.
+	ColorLightGrey = compat.AdaptiveColor{Light: lipgloss.Color("#666666"), Dark: lipgloss.Color("#CCCCCC")}
+	// ColorSkyBlue is the sky-blue used for panel borders.
+	ColorSkyBlue = compat.AdaptiveColor{Light: lipgloss.Color("#0284C7"), Dark: lipgloss.Color("#38BDF8")}
+	// ColorOrangeDim is the deep-orange trough of the peak-marker pulse.
+	ColorOrangeDim = compat.AdaptiveColor{Light: lipgloss.Color("#B35F00"), Dark: lipgloss.Color("#B35F00")}
 )
 
 // Color palette aliases retained for the cli styles below.

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -1,17 +1,41 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 
 	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/compat"
 )
 
-// Color palette
+// Palette is the single source of adaptive colours for both the cli and ui
+// packages. Each value is a compat.AdaptiveColor, which satisfies image/color's
+// Color interface and resolves Light/Dark variants at render time from the
+// terminal background detected globally by the compat package. Use these
+// instead of bespoke lipgloss.Color literals.
 var (
-	primaryColor = lipgloss.Color("#A40000") // Jivetalking red
-	mutedColor   = lipgloss.Color("#888888") // Gray
-	textColor    = lipgloss.Color("#FFFFFF") // White
+	// ColorRed is the Jivetalking brand red (errors, titles, peak zone).
+	ColorRed = compat.AdaptiveColor{Light: lipgloss.Color("#A40000"), Dark: lipgloss.Color("#A40000")}
+	// ColorRedDim is the dark end of the progress gradient.
+	ColorRedDim = compat.AdaptiveColor{Light: lipgloss.Color("#5A0000"), Dark: lipgloss.Color("#5A0000")}
+	// ColorMuted is the muted grey for labels and secondary borders.
+	ColorMuted = compat.AdaptiveColor{Light: lipgloss.Color("#888888"), Dark: lipgloss.Color("#888888")}
+	// ColorText is the primary value text colour.
+	ColorText = compat.AdaptiveColor{Light: lipgloss.Color("#1A1A1A"), Dark: lipgloss.Color("#FFFFFF")}
+	// ColorOrange is the warning / caution zone colour.
+	ColorOrange = compat.AdaptiveColor{Light: lipgloss.Color("#FFA500"), Dark: lipgloss.Color("#FFA500")}
+	// ColorGreen is the success / safe zone colour.
+	ColorGreen = compat.AdaptiveColor{Light: lipgloss.Color("#00AA00"), Dark: lipgloss.Color("#00AA00")}
+	// ColorCyan is the accent colour used in help output.
+	ColorCyan = compat.AdaptiveColor{Light: lipgloss.Color("#00AAAA"), Dark: lipgloss.Color("#00AAAA")}
+	// ColorFill is the empty/unfilled fill colour for meters and progress.
+	ColorFill = compat.AdaptiveColor{Light: lipgloss.Color("#CCCCCC"), Dark: lipgloss.Color("#444444")}
+)
+
+// Color palette aliases retained for the cli styles below.
+var (
+	primaryColor = ColorRed
+	mutedColor   = ColorMuted
+	textColor    = ColorText
 )
 
 // Styles
@@ -30,7 +54,7 @@ var (
 	// Warning message style
 	WarningStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#FFA500"))
+			Foreground(ColorOrange)
 
 	// Key-value pair styles
 	KeyStyle = lipgloss.NewStyle().
@@ -43,17 +67,17 @@ var (
 
 // PrintVersion prints version information
 func PrintVersion(version string) {
-	fmt.Println(TitleStyle.Render("Jivetalking 🕺"))
-	fmt.Printf("%s %s\n", KeyStyle.Render("Version:"), ValueStyle.Render(version))
-	fmt.Println()
+	lipgloss.Println(TitleStyle.Render("Jivetalking 🕺"))
+	lipgloss.Printf("%s %s\n", KeyStyle.Render("Version:"), ValueStyle.Render(version))
+	lipgloss.Println()
 }
 
 // PrintError prints an error message
 func PrintError(message string) {
-	fmt.Fprintf(os.Stderr, "%s %s\n", ErrorStyle.Render("Error:"), message)
+	lipgloss.Fprintf(os.Stderr, "%s %s\n", ErrorStyle.Render("Error:"), message)
 }
 
 // PrintWarning prints a warning message
 func PrintWarning(message string) {
-	fmt.Fprintf(os.Stderr, "%s %s\n", WarningStyle.Render("Warning:"), message)
+	lipgloss.Fprintf(os.Stderr, "%s %s\n", WarningStyle.Render("Warning:"), message)
 }

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -17,6 +17,11 @@ var (
 	ColorRed = compat.AdaptiveColor{Light: lipgloss.Color("#A40000"), Dark: lipgloss.Color("#A40000")}
 	// ColorRedDim is the dark end of the progress gradient.
 	ColorRedDim = compat.AdaptiveColor{Light: lipgloss.Color("#5A0000"), Dark: lipgloss.Color("#5A0000")}
+	// ColorAccentStart is the bright-cyan start of the progress bar gradient. Its
+	// CIELAB path to ColorAccentEnd stays vivid (no muddy midpoint).
+	ColorAccentStart = compat.AdaptiveColor{Light: lipgloss.Color("#00D4FF"), Dark: lipgloss.Color("#00D4FF")}
+	// ColorAccentEnd is the violet end of the progress bar gradient.
+	ColorAccentEnd = compat.AdaptiveColor{Light: lipgloss.Color("#9D4EDD"), Dark: lipgloss.Color("#9D4EDD")}
 	// ColorMuted is the muted grey for labels and secondary borders.
 	ColorMuted = compat.AdaptiveColor{Light: lipgloss.Color("#888888"), Dark: lipgloss.Color("#888888")}
 	// ColorText is the primary value text colour.

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -30,6 +30,8 @@ var (
 	ColorOrange = compat.AdaptiveColor{Light: lipgloss.Color("#FFA500"), Dark: lipgloss.Color("#FFA500")}
 	// ColorGreen is the success / safe zone colour.
 	ColorGreen = compat.AdaptiveColor{Light: lipgloss.Color("#00AA00"), Dark: lipgloss.Color("#00AA00")}
+	// ColorYellow is the mid-warm VU-meter stop between green and orange.
+	ColorYellow = compat.AdaptiveColor{Light: lipgloss.Color("#E6E600"), Dark: lipgloss.Color("#E6E600")}
 	// ColorCyan is the accent colour used in help output.
 	ColorCyan = compat.AdaptiveColor{Light: lipgloss.Color("#00AAAA"), Dark: lipgloss.Color("#00AAAA")}
 	// ColorFill is the empty/unfilled fill colour for meters and progress.

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/compat"
@@ -17,11 +18,9 @@ var (
 	ColorRed = compat.AdaptiveColor{Light: lipgloss.Color("#A40000"), Dark: lipgloss.Color("#A40000")}
 	// ColorRedDim is the dark end of the progress gradient.
 	ColorRedDim = compat.AdaptiveColor{Light: lipgloss.Color("#5A0000"), Dark: lipgloss.Color("#5A0000")}
-	// ColorAccentStart is the bright-cyan start of the progress bar gradient. Its
-	// CIELAB path to ColorAccentEnd stays vivid (no muddy midpoint).
-	ColorAccentStart = compat.AdaptiveColor{Light: lipgloss.Color("#00D4FF"), Dark: lipgloss.Color("#00D4FF")}
-	// ColorAccentEnd is the violet end of the progress bar gradient.
-	ColorAccentEnd = compat.AdaptiveColor{Light: lipgloss.Color("#9D4EDD"), Dark: lipgloss.Color("#9D4EDD")}
+	// ColorCyanBright is the bright cyan start of the header letter gradient. Its
+	// CIELAB path to ColorSkyBlue stays vivid (no muddy midpoint).
+	ColorCyanBright = compat.AdaptiveColor{Light: lipgloss.Color("#00D4FF"), Dark: lipgloss.Color("#00D4FF")}
 	// ColorMuted is the muted grey for labels and secondary borders.
 	ColorMuted = compat.AdaptiveColor{Light: lipgloss.Color("#888888"), Dark: lipgloss.Color("#888888")}
 	// ColorText is the primary value text colour.
@@ -40,6 +39,8 @@ var (
 	ColorLightGrey = compat.AdaptiveColor{Light: lipgloss.Color("#666666"), Dark: lipgloss.Color("#CCCCCC")}
 	// ColorSkyBlue is the sky-blue used for panel borders.
 	ColorSkyBlue = compat.AdaptiveColor{Light: lipgloss.Color("#0284C7"), Dark: lipgloss.Color("#38BDF8")}
+	// ColorIndigo is the indigo end of the progress bar gradient.
+	ColorIndigo = compat.AdaptiveColor{Light: lipgloss.Color("#6366F1"), Dark: lipgloss.Color("#6366F1")}
 	// ColorOrangeDim is the deep-orange trough of the peak-marker pulse.
 	ColorOrangeDim = compat.AdaptiveColor{Light: lipgloss.Color("#B35F00"), Dark: lipgloss.Color("#B35F00")}
 )
@@ -53,12 +54,6 @@ var (
 
 // Styles
 var (
-	// Title style - bold red with microphone emoji
-	TitleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(primaryColor).
-			MarginBottom(1)
-
 	// Error message style
 	ErrorStyle = lipgloss.NewStyle().
 			Bold(true).
@@ -78,9 +73,29 @@ var (
 			Foreground(textColor)
 )
 
+// RenderTitle returns the "Jivetalking 🕺" wordmark drawn as a per-letter
+// cyan→sky-blue Blend1D gradient (bold per letter), with the 🕺 emoji appended
+// outside the gradient so it keeps its own colours. Shared by the version banner
+// and the processing-TUI header so both render the wordmark identically.
+func RenderTitle() string {
+	letters := []rune("Jivetalking")
+	ramp := lipgloss.Blend1D(len(letters), ColorCyanBright, ColorSkyBlue)
+
+	var b strings.Builder
+	for i, r := range letters {
+		b.WriteString(lipgloss.NewStyle().
+			Bold(true).
+			Foreground(ramp[i]).
+			Render(string(r)))
+	}
+	b.WriteString(" 🕺")
+
+	return b.String()
+}
+
 // PrintVersion prints version information
 func PrintVersion(version string) {
-	lipgloss.Println(TitleStyle.Render("Jivetalking 🕺"))
+	lipgloss.Println(RenderTitle())
 	lipgloss.Printf("%s %s\n", KeyStyle.Render("Version:"), ValueStyle.Render(version))
 	lipgloss.Println()
 }

--- a/internal/cli/styles_test.go
+++ b/internal/cli/styles_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/colorprofile"
+)
+
+// renderThrough writes the styled string through a colorprofile.Writer pinned to
+// the given profile, mirroring the CLI output layer (help.go / styles.go), and
+// returns the downsampled bytes.
+func renderThrough(profile colorprofile.Profile, styled string) string {
+	var buf bytes.Buffer
+	w := &colorprofile.Writer{Forward: &buf, Profile: profile}
+	if _, err := w.Write([]byte(styled)); err != nil {
+		panic(err)
+	}
+	return buf.String()
+}
+
+func TestStyledOutputDownsamplesNoTruecolorLeak(t *testing.T) {
+	styled := helpTitleStyle.Render("Jivetalking") +
+		helpFlagStyle.Render("--jobs") +
+		ErrorStyle.Render("Error:")
+
+	if !strings.Contains(styled, "38;2;") {
+		t.Fatalf("precondition failed: styles did not emit truecolor; got %q", styled)
+	}
+
+	cases := []struct {
+		name    string
+		profile colorprofile.Profile
+	}{
+		{"NoTTY", colorprofile.NoTTY},
+		{"ASCII", colorprofile.ASCII},
+		{"ANSI", colorprofile.ANSI},
+		{"ANSI256", colorprofile.ANSI256},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := renderThrough(tc.profile, styled)
+			if strings.Contains(out, "38;2;") {
+				t.Errorf("%s profile leaked truecolor: %q", tc.name, out)
+			}
+		})
+	}
+}
+
+func TestStyledOutputStripsColorButKeepsTextWhenNoTTY(t *testing.T) {
+	styled := ErrorStyle.Render("Error:")
+	out := renderThrough(colorprofile.NoTTY, styled)
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("NoTTY profile left escape sequences: %q", out)
+	}
+	if !strings.Contains(out, "Error:") {
+		t.Errorf("NoTTY profile dropped text: %q", out)
+	}
+}
+
+func TestStyledOutputPreservesTruecolor(t *testing.T) {
+	styled := helpTitleStyle.Render("Jivetalking")
+	out := renderThrough(colorprofile.TrueColor, styled)
+	if !strings.Contains(out, "38;2;") {
+		t.Errorf("TrueColor profile dropped truecolor: %q", out)
+	}
+}

--- a/internal/cli/styles_test.go
+++ b/internal/cli/styles_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // renderThrough writes the styled string through a colorprofile.Writer pinned to
@@ -57,6 +60,73 @@ func TestStyledOutputStripsColorButKeepsTextWhenNoTTY(t *testing.T) {
 	}
 	if !strings.Contains(out, "Error:") {
 		t.Errorf("NoTTY profile dropped text: %q", out)
+	}
+}
+
+// titleColors extracts the distinct RGB foreground triples from a styled
+// string. Letters carry a bold prefix (1;38;2;r;g;b), so match the 38;2;r;g;b
+// foreground regardless of any leading SGR attributes.
+func titleColors(s string) [][3]int {
+	var out [][3]int
+	seen := map[[3]int]bool{}
+	for seg := range strings.SplitSeq(s, "\x1b[") {
+		_, after, found := strings.Cut(seg, "38;2;")
+		if !found {
+			continue
+		}
+		body, _, _ := strings.Cut(after, "m")
+		parts := strings.Split(body, ";")
+		if len(parts) < 3 {
+			continue
+		}
+		var c [3]int
+		ok := true
+		for i := range 3 {
+			n, err := strconv.Atoi(parts[i])
+			if err != nil {
+				ok = false
+				break
+			}
+			c[i] = n
+		}
+		if ok && !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestRenderTitleIsGradient confirms the shared wordmark is drawn as a
+// multi-colour per-letter gradient (more than one distinct foreground) and
+// never uses the brand red foreground.
+func TestRenderTitleIsGradient(t *testing.T) {
+	title := RenderTitle()
+
+	if !strings.Contains(ansi.Strip(title), "Jivetalking") {
+		t.Fatalf("title missing wordmark: %q", title)
+	}
+
+	colors := titleColors(title)
+	if len(colors) < 2 {
+		t.Errorf("expected a multi-colour title gradient, got %d colours: %v", len(colors), colors)
+	}
+	// Brand red (#A40000 -> 164,0,0) must not colour the title.
+	if slices.Contains(colors, [3]int{164, 0, 0}) {
+		t.Errorf("title contains brand red 164,0,0:\n%q", title)
+	}
+}
+
+// TestRenderTitleDownsamplesNoColor confirms the wordmark emits zero colour SGR
+// codes when written through a NoTTY (NO_COLOR-equivalent) profile, matching the
+// colorprofile-aware output path used by PrintVersion.
+func TestRenderTitleDownsamplesNoColor(t *testing.T) {
+	out := renderThrough(colorprofile.NoTTY, RenderTitle())
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("NoTTY profile left escape sequences: %q", out)
+	}
+	if !strings.Contains(out, "Jivetalking") {
+		t.Errorf("NoTTY profile dropped wordmark: %q", out)
 	}
 }
 

--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -16,14 +16,21 @@ import (
 )
 
 // AnalysisLogPath derives the analysis report log path for an input file:
-// <dir>/<base-without-ext>-analysis.log, in the same directory as the source
-// (matching the processed-audio output convention). Example:
-// /x/LMP-81-mark.flac → /x/LMP-81-mark-analysis.log.
+// <dir>/<stem>-<ext>-analysis.log, in the same directory as the source. The
+// extension is folded into the name so inputs that share a stem but differ by
+// extension (e.g. foo.flac and foo.wav in a mixed-format batch directory) get
+// distinct logs instead of silently clobbering one another. Examples:
+// /x/LMP-81-mark.flac → /x/LMP-81-mark-flac-analysis.log; /tmp/raw → /tmp/raw-analysis.log.
 func AnalysisLogPath(inputPath string) string {
 	dir := filepath.Dir(inputPath)
 	filename := filepath.Base(inputPath)
-	nameWithoutExt := strings.TrimSuffix(filename, filepath.Ext(filename))
-	return filepath.Join(dir, nameWithoutExt+"-analysis.log")
+	ext := filepath.Ext(filename)
+	nameWithoutExt := strings.TrimSuffix(filename, ext)
+	stem := nameWithoutExt
+	if ext != "" {
+		stem += "-" + strings.TrimPrefix(ext, ".")
+	}
+	return filepath.Join(dir, stem+"-analysis.log")
 }
 
 // AnalysisTimings contains reportable analysis-only stage durations.

--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -15,6 +15,17 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
+// AnalysisLogPath derives the analysis report log path for an input file:
+// <dir>/<base-without-ext>-analysis.log, in the same directory as the source
+// (matching the processed-audio output convention). Example:
+// /x/LMP-81-mark.flac → /x/LMP-81-mark-analysis.log.
+func AnalysisLogPath(inputPath string) string {
+	dir := filepath.Dir(inputPath)
+	filename := filepath.Base(inputPath)
+	nameWithoutExt := strings.TrimSuffix(filename, filepath.Ext(filename))
+	return filepath.Join(dir, nameWithoutExt+"-analysis.log")
+}
+
 // AnalysisTimings contains reportable analysis-only stage durations.
 type AnalysisTimings struct {
 	Analysis     time.Duration

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -11,6 +11,27 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
+func TestAnalysisLogPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"flac with dir", "/x/LMP-81-mark.flac", "/x/LMP-81-mark-analysis.log"},
+		{"wav swaps extension", "/a/b/voice.wav", "/a/b/voice-analysis.log"},
+		{"no extension", "/tmp/raw", "/tmp/raw-analysis.log"},
+		{"basename only", "sample.aiff", "sample-analysis.log"},
+		{"dotted name keeps stem", "/d/take.01.flac", "/d/take.01-analysis.log"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AnalysisLogPath(tc.in); got != tc.want {
+				t.Fatalf("AnalysisLogPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // makeMinimalMeasurements creates measurements with enough data to exercise DisplayAnalysisResults.
 func makeMinimalMeasurements() *processor.AudioMeasurements {
 	return &processor.AudioMeasurements{

--- a/internal/logging/analysis_display_test.go
+++ b/internal/logging/analysis_display_test.go
@@ -17,11 +17,11 @@ func TestAnalysisLogPath(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"flac with dir", "/x/LMP-81-mark.flac", "/x/LMP-81-mark-analysis.log"},
-		{"wav swaps extension", "/a/b/voice.wav", "/a/b/voice-analysis.log"},
+		{"flac with dir", "/x/LMP-81-mark.flac", "/x/LMP-81-mark-flac-analysis.log"},
+		{"wav folds extension", "/a/b/voice.wav", "/a/b/voice-wav-analysis.log"},
 		{"no extension", "/tmp/raw", "/tmp/raw-analysis.log"},
-		{"basename only", "sample.aiff", "sample-analysis.log"},
-		{"dotted name keeps stem", "/d/take.01.flac", "/d/take.01-analysis.log"},
+		{"basename only", "sample.aiff", "sample-aiff-analysis.log"},
+		{"dotted name keeps stem", "/d/take.01.flac", "/d/take.01-flac-analysis.log"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -29,6 +29,23 @@ func TestAnalysisLogPath(t *testing.T) {
 				t.Fatalf("AnalysisLogPath(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestAnalysisLogPath_CollidingStemsDistinct asserts inputs that share a stem
+// but differ by extension in the same directory map to distinct log paths, so a
+// mixed-format batch (foo.flac and foo.wav) never clobbers one log with another.
+func TestAnalysisLogPath_CollidingStemsDistinct(t *testing.T) {
+	flac := AnalysisLogPath("/batch/foo.flac")
+	wav := AnalysisLogPath("/batch/foo.wav")
+	if flac == wav {
+		t.Fatalf("colliding stems produced the same log path: %q", flac)
+	}
+	if flac != "/batch/foo-flac-analysis.log" {
+		t.Errorf("foo.flac log = %q, want /batch/foo-flac-analysis.log", flac)
+	}
+	if wav != "/batch/foo-wav-analysis.log" {
+		t.Errorf("foo.wav log = %q, want /batch/foo-wav-analysis.log", wav)
 	}
 }
 

--- a/internal/logging/table.go
+++ b/internal/logging/table.go
@@ -7,7 +7,9 @@ package logging
 import (
 	"fmt"
 	"math"
-	"strings"
+
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
 )
 
 // MetricRow represents a single row in a comparison table.
@@ -36,93 +38,82 @@ func (t *MetricTable) String() string {
 		return ""
 	}
 
-	// Determine if we need an interpretation column
+	// Determine whether optional unit/interpretation columns are needed.
+	hasUnit := false
 	hasInterpretation := false
 	for _, row := range t.Rows {
+		if row.Unit != "" {
+			hasUnit = true
+		}
 		if row.Interpretation != "" {
 			hasInterpretation = true
-			break
 		}
 	}
 
-	// Calculate column widths
-	// Column 0: Label
-	// Columns 1-N: Values (one per header)
-	// Column N+1: Unit (if any rows have units)
-	// Column N+2: Interpretation (if any rows have interpretations)
-
-	labelWidth := 0
-	for _, row := range t.Rows {
-		if len(row.Label) > labelWidth {
-			labelWidth = len(row.Label)
-		}
-	}
-
-	// Value column widths (one per header)
-	valueWidths := make([]int, len(t.Headers))
-	for i, header := range t.Headers {
-		valueWidths[i] = len(header) // Start with header width
-	}
-	for _, row := range t.Rows {
-		for i, val := range row.Values {
-			if i < len(valueWidths) && len(val) > valueWidths[i] {
-				valueWidths[i] = len(val)
-			}
-		}
-	}
-
-	// Unit width (find max unit length)
-	unitWidth := 0
-	for _, row := range t.Rows {
-		if len(row.Unit) > unitWidth {
-			unitWidth = len(row.Unit)
-		}
-	}
-
-	// Build output
-	var sb strings.Builder
-
-	// Header row
-	sb.WriteString(strings.Repeat(" ", labelWidth+2)) // Label column + gap
-	for i, header := range t.Headers {
-		fmt.Fprintf(&sb, "%*s  ", valueWidths[i], header)
-	}
-	if unitWidth > 0 {
-		sb.WriteString(strings.Repeat(" ", unitWidth+1)) // Unit column placeholder
+	// Column layout:
+	//   col 0          : Label (left-aligned)
+	//   col 1..N       : value columns, one per header (right-aligned)
+	//   col N+1        : Unit (left-aligned, present only if hasUnit)
+	//   col N+2        : Interpretation (left-aligned, present only if hasInterpretation)
+	valueCols := len(t.Headers)
+	unitCol := -1
+	interpCol := -1
+	nextCol := 1 + valueCols
+	if hasUnit {
+		unitCol = nextCol
+		nextCol++
 	}
 	if hasInterpretation {
-		sb.WriteString("Interpretation")
+		interpCol = nextCol
 	}
-	sb.WriteString("\n")
 
-	// Data rows
+	headers := make([]string, 0, nextCol)
+	headers = append(headers, "")
+	headers = append(headers, t.Headers...)
+	if hasUnit {
+		headers = append(headers, "")
+	}
+	if hasInterpretation {
+		headers = append(headers, "Interpretation")
+	}
+
+	tbl := table.New().
+		Border(lipgloss.HiddenBorder()).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderLeft(false).
+		BorderRight(false).
+		BorderColumn(false).
+		BorderRow(false).
+		Headers(headers...).
+		StyleFunc(func(_, col int) lipgloss.Style {
+			style := lipgloss.NewStyle().PaddingRight(2)
+			if col >= 1 && col <= valueCols {
+				return style.Align(lipgloss.Right)
+			}
+			return style.Align(lipgloss.Left)
+		})
+
 	for _, row := range t.Rows {
-		// Label (left-aligned)
-		fmt.Fprintf(&sb, "%-*s  ", labelWidth, row.Label)
-
-		// Values (right-aligned within their columns)
-		for i := 0; i < len(t.Headers); i++ {
-			val := "-" // Default for missing values
+		cells := make([]string, 0, nextCol)
+		cells = append(cells, row.Label)
+		for i := range valueCols {
+			val := MissingValue
 			if i < len(row.Values) && row.Values[i] != "" {
 				val = row.Values[i]
 			}
-			fmt.Fprintf(&sb, "%*s  ", valueWidths[i], val)
+			cells = append(cells, val)
 		}
-
-		// Unit (left-aligned, after values)
-		if unitWidth > 0 {
-			fmt.Fprintf(&sb, "%-*s ", unitWidth, row.Unit)
+		if unitCol >= 0 {
+			cells = append(cells, row.Unit)
 		}
-
-		// Interpretation (left-aligned, if present)
-		if hasInterpretation {
-			sb.WriteString(row.Interpretation)
+		if interpCol >= 0 {
+			cells = append(cells, row.Interpretation)
 		}
-
-		sb.WriteString("\n")
+		tbl.Row(cells...)
 	}
 
-	return sb.String()
+	return fmt.Sprintf("%s\n", tbl.Render())
 }
 
 // =============================================================================

--- a/internal/logging/table_test.go
+++ b/internal/logging/table_test.go
@@ -84,6 +84,52 @@ func TestFormatMetricWithUnit(t *testing.T) {
 	}
 }
 
+// tableLines splits rendered table output into trimmed-right lines, dropping the
+// trailing empty element from the final newline.
+//
+// lipgloss/table with a HiddenBorder renders as:
+//
+//	line 0  : header row
+//	line 1  : blank separator (the hidden border under the header)
+//	line 2+ : data rows
+func tableLines(output string) []string {
+	return strings.Split(strings.TrimRight(output, "\n"), "\n")
+}
+
+// headerLine returns the rendered header row (line 0).
+func headerLine(t *testing.T, output string) string {
+	t.Helper()
+	lines := tableLines(output)
+	if len(lines) < 1 {
+		t.Fatalf("expected at least a header line, got %q", output)
+	}
+	return lines[0]
+}
+
+// dataLines returns the rendered data rows (line 2 onward, after the blank
+// separator the hidden border emits under the header).
+func dataLines(t *testing.T, output string) []string {
+	t.Helper()
+	lines := tableLines(output)
+	if len(lines) < 3 {
+		t.Fatalf("expected header + blank separator + at least one data row, got %d lines: %q", len(lines), output)
+	}
+	return lines[2:]
+}
+
+// countMissingCells counts standalone MissingValue cells in a rendered row,
+// splitting on whitespace so a hyphen inside a negative value (e.g. "-10.0")
+// is not mistaken for a missing-value marker.
+func countMissingCells(row string) int {
+	n := 0
+	for field := range strings.FieldsSeq(row) {
+		if field == MissingValue {
+			n++
+		}
+	}
+	return n
+}
+
 func TestMetricTableString(t *testing.T) {
 	t.Run("basic_three_column", func(t *testing.T) {
 		table := NewMetricTable()
@@ -92,26 +138,35 @@ func TestMetricTableString(t *testing.T) {
 
 		output := table.String()
 
-		// Verify headers present
-		if !strings.Contains(output, "Input") {
-			t.Error("Output should contain 'Input' header")
+		// Header row carries the three value-column headers, in order, and no
+		// Interpretation column (no row has interpretation text).
+		header := headerLine(t, output)
+		for _, h := range []string{"Input", "Filtered", "Final"} {
+			if !strings.Contains(header, h) {
+				t.Errorf("header line %q should contain %q", header, h)
+			}
 		}
-		if !strings.Contains(output, "Filtered") {
-			t.Error("Output should contain 'Filtered' header")
+		if idxInput, idxFiltered, idxFinal := strings.Index(header, "Input"), strings.Index(header, "Filtered"), strings.Index(header, "Final"); idxInput >= idxFiltered || idxFiltered >= idxFinal {
+			t.Errorf("headers out of order in %q (Input=%d Filtered=%d Final=%d)", header, idxInput, idxFiltered, idxFinal)
 		}
-		if !strings.Contains(output, "Final") {
-			t.Error("Output should contain 'Final' header")
+		if strings.Contains(header, "Interpretation") {
+			t.Errorf("header should not contain Interpretation column when no row has one: %q", header)
 		}
 
-		// Verify data present
-		if !strings.Contains(output, "Integrated Loudness") {
-			t.Error("Output should contain row label")
+		// Data rows carry label, all values, and unit.
+		rows := dataLines(t, output)
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 data rows, got %d: %q", len(rows), rows)
 		}
-		if !strings.Contains(output, "-16.0") {
-			t.Error("Output should contain value")
+		for _, want := range []string{"Integrated Loudness", "-23.0", "-18.5", "-16.0", "LUFS"} {
+			if !strings.Contains(rows[0], want) {
+				t.Errorf("first data row %q should contain %q", rows[0], want)
+			}
 		}
-		if !strings.Contains(output, "LUFS") {
-			t.Error("Output should contain unit")
+		for _, want := range []string{"True Peak", "-3.5", "-1.2", "-1.5", "dBTP"} {
+			if !strings.Contains(rows[1], want) {
+				t.Errorf("second data row %q should contain %q", rows[1], want)
+			}
 		}
 	})
 
@@ -121,11 +176,15 @@ func TestMetricTableString(t *testing.T) {
 
 		output := table.String()
 
-		if !strings.Contains(output, "Interpretation") {
-			t.Error("Output should contain 'Interpretation' header when rows have interpretations")
+		// Interpretation column header appears when any row has interpretation text.
+		header := headerLine(t, output)
+		if !strings.Contains(header, "Interpretation") {
+			t.Errorf("header should contain Interpretation column: %q", header)
 		}
-		if !strings.Contains(output, "Good noise reduction") {
-			t.Error("Output should contain interpretation text")
+
+		rows := dataLines(t, output)
+		if !strings.Contains(rows[0], "Good noise reduction") {
+			t.Errorf("data row %q should contain interpretation text", rows[0])
 		}
 	})
 
@@ -135,9 +194,14 @@ func TestMetricTableString(t *testing.T) {
 
 		output := table.String()
 
-		// Missing values should show as "-"
-		if !strings.Contains(output, " -  ") {
-			t.Error("Missing values should display as dash")
+		// Two columns are missing values (empty string and absent third value);
+		// both render as MissingValue. The present value remains.
+		rows := dataLines(t, output)
+		if !strings.Contains(rows[0], "-10.0") {
+			t.Errorf("data row %q should contain the present value -10.0", rows[0])
+		}
+		if got := countMissingCells(rows[0]); got != 2 {
+			t.Errorf("expected 2 missing-value markers %q in %q, got %d", MissingValue, rows[0], got)
 		}
 	})
 
@@ -156,14 +220,11 @@ func TestMetricTableString(t *testing.T) {
 
 		output := table.String()
 
-		if !strings.Contains(output, "-23.5") {
-			t.Error("AddMetricRow should format input value")
-		}
-		if !strings.Contains(output, "-18.2") {
-			t.Error("AddMetricRow should format filtered value")
-		}
-		if !strings.Contains(output, "-16.0") {
-			t.Error("AddMetricRow should format final value")
+		rows := dataLines(t, output)
+		for _, want := range []string{"Test", "-23.5", "-18.2", "-16.0", "LUFS"} {
+			if !strings.Contains(rows[0], want) {
+				t.Errorf("AddMetricRow data row %q should contain %q", rows[0], want)
+			}
 		}
 	})
 
@@ -173,15 +234,15 @@ func TestMetricTableString(t *testing.T) {
 
 		output := table.String()
 
-		// NaN should display as "-"
-		lines := strings.Split(output, "\n")
-		if len(lines) < 2 {
-			t.Fatal("Expected at least 2 lines (header + data)")
+		// NaN filtered value renders as MissingValue; the two valid values remain.
+		rows := dataLines(t, output)
+		for _, want := range []string{"Test", "-23.5", "-16.0", "LUFS"} {
+			if !strings.Contains(rows[0], want) {
+				t.Errorf("data row %q should contain %q", rows[0], want)
+			}
 		}
-		dataLine := lines[1]
-		// Count dashes - should have one for NaN value
-		if !strings.Contains(dataLine, " -  ") && !strings.Contains(dataLine, " - ") {
-			t.Errorf("NaN value should display as dash in: %q", dataLine)
+		if got := countMissingCells(rows[0]); got != 1 {
+			t.Errorf("expected exactly 1 missing-value marker %q for the NaN value in %q, got %d", MissingValue, rows[0], got)
 		}
 	})
 }
@@ -192,19 +253,31 @@ func TestMetricTableAlignment(t *testing.T) {
 	table.AddRow("Much Longer Label", []string{"100", "200", "300"}, "", "")
 
 	output := table.String()
-	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 
-	if len(lines) < 3 {
-		t.Fatalf("Expected 3 lines (header + 2 data), got %d", len(lines))
+	rows := dataLines(t, output)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 data rows, got %d: %q", len(rows), rows)
 	}
 
-	// All data lines should have same position for first value column
-	// (values are right-aligned, so the rightmost digit should align)
-	// This is a basic check that formatting is consistent
-	for i := 1; i < len(lines); i++ {
-		if len(lines[i]) < 20 {
-			t.Errorf("Line %d seems too short: %q", i, lines[i])
-		}
+	// Value columns are right-aligned: the rightmost digit of each value column
+	// lines up across rows. Check the first value column ("1" vs "100") by
+	// confirming the trailing position of each shares a column boundary.
+	idxShort := strings.Index(rows[0], "1")
+	idxLong := strings.Index(rows[1], "100")
+	// "100" is wider; right alignment means "1" sits to the right of where "100"
+	// starts, and both end at the same column.
+	endShort := idxShort + len("1")
+	endLong := idxLong + len("100")
+	if endShort != endLong {
+		t.Errorf("first value column not right-aligned: %q ends at %d, %q ends at %d", rows[0], endShort, rows[1], endLong)
+	}
+
+	// Labels are left-aligned: both rows start with their label at column 0.
+	if !strings.HasPrefix(rows[0], "Short") {
+		t.Errorf("label should be left-aligned at column 0: %q", rows[0])
+	}
+	if !strings.HasPrefix(rows[1], "Much Longer Label") {
+		t.Errorf("label should be left-aligned at column 0: %q", rows[1])
 	}
 }
 

--- a/internal/processor/analyzer.go
+++ b/internal/processor/analyzer.go
@@ -183,6 +183,11 @@ type AudioMeasurements struct {
 	// Embed shared measurement fields
 	BaseMeasurements
 
+	// Duration is the total audio length in seconds, captured at file open. It is
+	// in-memory UI plumbing only and excluded from the report JSON contract (the
+	// custom MarshalJSON/UnmarshalJSON pair serialises named fields explicitly).
+	Duration float64 `json:"-"`
+
 	// Input-specific loudness measurements from ebur128
 	InputI           float64 `json:"input_i"`            // Integrated loudness (LUFS)
 	InputTP          float64 `json:"input_tp"`           // True peak (dBTP)
@@ -368,6 +373,7 @@ func buildInputMeasurements(filename string, collection *analysisFrameCollection
 	}
 
 	measurements := &AudioMeasurements{
+		Duration:            collection.totalDuration,
 		PreScanNoiseFloor:   noiseFloorEstimate,
 		RoomToneDetectLevel: silenceThreshold,
 		IntervalSamples:     collection.intervals,
@@ -480,6 +486,7 @@ type analysisFrameCollection struct {
 	intervals        []IntervalSample
 	silenceIntervals []IntervalSample
 	silenceMedians   silenceMedians
+	totalDuration    float64 // total audio length, seconds (from input metadata)
 }
 
 func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *BaseFilterConfig, context *ProcessingFilterContext, progressCallback ProgressCallback) (*analysisFrameCollection, error) {
@@ -561,6 +568,7 @@ func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *Base
 					PassName: "Analyzing",
 					Progress: progress,
 					Level:    currentLevel,
+					Duration: totalDuration,
 				})
 			}
 			frameCount++
@@ -598,6 +606,7 @@ func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *Base
 		intervals:        intervals,
 		silenceIntervals: silenceIntervals,
 		silenceMedians:   computeSilenceMedians(silenceIntervals),
+		totalDuration:    totalDuration,
 	}, nil
 }
 

--- a/internal/processor/encoder.go
+++ b/internal/processor/encoder.go
@@ -248,6 +248,11 @@ func (e *Encoder) Close() error {
 	return nil
 }
 
+// meterLevelFloorDB is the silence floor for the live audio level reported to the
+// VU meter. It matches the UI meter floor (ui.meterFloorDB = -70.0); the processor
+// package must not import internal/ui, so the value is mirrored here.
+const meterLevelFloorDB = -70.0
+
 // calculateFrameLevel calculates the RMS (Root Mean Square) level of an audio frame in dB
 // This provides accurate audio level measurement for VU meter display
 func calculateFrameLevel(frame *ffmpeg.AVFrame) float64 {
@@ -256,7 +261,7 @@ func calculateFrameLevel(frame *ffmpeg.AVFrame) float64 {
 		return -30.0 // Unsupported format
 	}
 	if sampleCount == 0 {
-		return -60.0 // Silence threshold
+		return meterLevelFloorDB // Silence threshold
 	}
 
 	// Calculate RMS (Root Mean Square)
@@ -265,14 +270,14 @@ func calculateFrameLevel(frame *ffmpeg.AVFrame) float64 {
 	// Convert to dB: 20 * log10(rms)
 	// Add small epsilon to avoid log(0)
 	if rms < 0.00001 { // Equivalent to -100 dB
-		return -60.0 // Floor at -60 dB for silence
+		return meterLevelFloorDB // Floor for silence
 	}
 
 	levelDB := 20.0 * math.Log10(rms)
 
-	// Clamp to reasonable range for display (-60 dB to 0 dB)
-	if levelDB < -60.0 {
-		levelDB = -60.0
+	// Clamp to reasonable range for display (meter floor to 0 dB)
+	if levelDB < meterLevelFloorDB {
+		levelDB = meterLevelFloorDB
 	} else if levelDB > 0.0 {
 		levelDB = 0.0
 	}

--- a/internal/processor/encoder_level_test.go
+++ b/internal/processor/encoder_level_test.go
@@ -1,0 +1,93 @@
+// Package processor handles audio analysis and processing
+package processor
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+
+	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
+)
+
+// newFloatTestFrame allocates a mono float (AVSampleFmtFlt) frame of nbSamples
+// with every sample set to amplitude. The caller must free the returned frame.
+func newFloatTestFrame(t *testing.T, nbSamples int, amplitude float32) *ffmpeg.AVFrame {
+	t.Helper()
+
+	frame := ffmpeg.AVFrameAlloc()
+	if frame == nil {
+		t.Fatal("AVFrameAlloc returned nil")
+	}
+	frame.SetNbSamples(nbSamples)
+	frame.SetFormat(int(ffmpeg.AVSampleFmtFlt))
+	ffmpeg.AVChannelLayoutDefault(frame.ChLayout(), 1)
+
+	if _, err := ffmpeg.AVFrameGetBuffer(frame, 0); err != nil {
+		ffmpeg.AVFrameFree(&frame)
+		t.Fatalf("AVFrameGetBuffer error = %v", err)
+	}
+
+	dataPtr := frame.Data().Get(0)
+	if dataPtr == nil {
+		ffmpeg.AVFrameFree(&frame)
+		t.Fatal("frame data plane 0 is nil")
+	}
+	samples := unsafe.Slice((*float32)(dataPtr), nbSamples)
+	for i := range samples {
+		samples[i] = amplitude
+	}
+	return frame
+}
+
+func TestCalculateFrameLevelFloorsAtMeterFloor(t *testing.T) {
+	if meterLevelFloorDB != -70.0 {
+		t.Fatalf("meterLevelFloorDB = %v, want -70.0 (must match ui.meterFloorDB)", meterLevelFloorDB)
+	}
+
+	tests := []struct {
+		name      string
+		amplitude float32 // constant sample value; RMS == amplitude for a DC frame
+		wantDB    float64
+	}{
+		// -65 dBFS (10^(-65/20)): previously floored to -60, now reads through.
+		{name: "quiet -65 dB reads below -60", amplitude: float32(math.Pow(10, -65.0/20.0)), wantDB: -65.0},
+		// -90 dBFS is below the meter floor and must clamp to -70, not -inf.
+		{name: "very quiet -90 dB clamps to -70 floor", amplitude: float32(math.Pow(10, -90.0/20.0)), wantDB: -70.0},
+		// Digital silence must not produce -inf garbage.
+		{name: "digital silence clamps to -70 floor", amplitude: 0.0, wantDB: -70.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := newFloatTestFrame(t, 1024, tt.amplitude)
+			defer ffmpeg.AVFrameFree(&frame)
+
+			got := calculateFrameLevel(frame)
+
+			if math.IsInf(got, 0) || math.IsNaN(got) {
+				t.Fatalf("calculateFrameLevel = %v, want finite value", got)
+			}
+			if got < meterLevelFloorDB {
+				t.Errorf("calculateFrameLevel = %.2f dB, below meter floor %.1f dB", got, meterLevelFloorDB)
+			}
+			if math.Abs(got-tt.wantDB) > 0.5 {
+				t.Errorf("calculateFrameLevel = %.2f dB, want ~%.1f dB", got, tt.wantDB)
+			}
+		})
+	}
+}
+
+// TestCalculateFrameLevelBelowOldMinus60Floor pins the regression: quiet audio
+// that the old -60 dB clamp would have floored must now report below -60 dB.
+func TestCalculateFrameLevelBelowOldMinus60Floor(t *testing.T) {
+	frame := newFloatTestFrame(t, 1024, float32(math.Pow(10, -68.0/20.0)))
+	defer ffmpeg.AVFrameFree(&frame)
+
+	got := calculateFrameLevel(frame)
+	if got >= -60.0 {
+		t.Errorf("calculateFrameLevel = %.2f dB, want < -60 dB (old floor removed)", got)
+	}
+	if got < meterLevelFloorDB {
+		t.Errorf("calculateFrameLevel = %.2f dB, below meter floor %.1f dB", got, meterLevelFloorDB)
+	}
+}

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -15,6 +15,16 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
 
+// normaliseDuration returns the total audio length in seconds from the Pass 1
+// measurements, or 0 when they are unavailable. Used to carry Duration through
+// the Pass 3/4 progress callbacks without re-opening the input.
+func normaliseDuration(m *AudioMeasurements) float64 {
+	if m == nil {
+		return 0
+	}
+	return m.Duration
+}
+
 // Limiter ceiling constants used by calculateLimiterCeiling and pre-gain deficit
 // calculation.
 const (
@@ -180,6 +190,7 @@ func measureWithLoudnorm(ctx context.Context, inputPath string, config *Effectiv
 					Pass:     PassMeasuring,
 					PassName: "Measuring",
 					Progress: progress,
+					Duration: metadata.Duration,
 				})
 			}
 		},
@@ -525,6 +536,7 @@ func ApplyNormalisation(
 		progressCallback(ProgressUpdate{
 			Pass:     PassMeasuring,
 			PassName: "Measuring",
+			Duration: normaliseDuration(inputMeasurements),
 		})
 	}
 
@@ -552,10 +564,12 @@ func ApplyNormalisation(
 			Pass:     PassMeasuring,
 			PassName: "Measuring",
 			Progress: 1.0,
+			Duration: normaliseDuration(inputMeasurements),
 		})
 		progressCallback(ProgressUpdate{
 			Pass:     PassNormalising,
 			PassName: "Normalising",
+			Duration: normaliseDuration(inputMeasurements),
 		})
 	}
 
@@ -596,6 +610,7 @@ func ApplyNormalisation(
 			Pass:     PassNormalising,
 			PassName: "Normalising",
 			Progress: 1.0,
+			Duration: normaliseDuration(inputMeasurements),
 		})
 	}
 
@@ -781,6 +796,7 @@ func executeAndPublishLoudnormApplication(
 					PassName: "Normalising",
 					Progress: progress,
 					Level:    result.acc.ebur128OutputI,
+					Duration: prep.metadata.Duration,
 				})
 			}
 		},

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -49,6 +49,7 @@ func AnalyzeOnlyDetailed(ctx context.Context, inputPath string, config *BaseFilt
 			Pass:         PassAnalysis,
 			PassName:     "Analyzing",
 			Progress:     1.0,
+			Duration:     measurements.Duration,
 			Measurements: measurements,
 		})
 	}
@@ -93,6 +94,7 @@ func ProcessAudio(ctx context.Context, inputPath string, config *BaseFilterConfi
 			Pass:         PassAnalysis,
 			PassName:     "Analyzing",
 			Progress:     1.0,
+			Duration:     measurements.Duration,
 			Measurements: measurements,
 		})
 	}
@@ -108,6 +110,7 @@ func ProcessAudio(ctx context.Context, inputPath string, config *BaseFilterConfi
 		progressCallback(ProgressUpdate{
 			Pass:         PassProcessing,
 			PassName:     "Processing",
+			Duration:     measurements.Duration,
 			Measurements: measurements,
 		})
 	}
@@ -144,6 +147,7 @@ func ProcessAudio(ctx context.Context, inputPath string, config *BaseFilterConfi
 			Pass:         PassProcessing,
 			PassName:     "Processing",
 			Progress:     1.0,
+			Duration:     measurements.Duration,
 			Measurements: measurements,
 		})
 	}
@@ -324,6 +328,7 @@ func processWithFilters(ctx context.Context, inputPath, outputPath string, confi
 					PassName:     "Processing",
 					Progress:     progress,
 					Level:        currentLevel,
+					Duration:     measurements.Duration,
 					Measurements: measurements,
 				})
 			}

--- a/internal/processor/progress.go
+++ b/internal/processor/progress.go
@@ -7,6 +7,7 @@ type ProgressUpdate struct {
 	PassName     string
 	Progress     float64
 	Level        float64
+	Duration     float64 // total audio length, seconds
 	Measurements *AudioMeasurements
 }
 

--- a/internal/processor/quality.go
+++ b/internal/processor/quality.go
@@ -1,0 +1,194 @@
+package processor
+
+import "math"
+
+// QualityScore is an objective 0-5 star rating of a processed file, derived
+// entirely from real Pass 4 output measurements. Stars and Label are the
+// display-ready form; Score is the underlying 0-100 composite so callers can
+// retune the star thresholds without recomputing the components.
+type QualityScore struct {
+	Score float64 // 0-100 composite
+	Stars int     // 0-5 filled stars (rounded from Score)
+	Label string  // Excellent / Great / Good / Fair / Poor
+}
+
+// Quality rubric weights. They sum to 1.0. Loudness accuracy dominates because
+// hitting the -16 LUFS target is the tool's primary contract; true-peak safety
+// guards against clipping; noise rewards a clean room-tone *result*, not how
+// much was removed, so an already-clean recording is not penalised for having
+// little to clean up.
+const (
+	qualityWeightLoudness = 0.50 // |OutputLUFS - target|
+	qualityWeightTruePeak = 0.30 // output true peak vs ceiling
+	qualityWeightNoise    = 0.20 // output room-tone noise floor cleanliness
+)
+
+// Loudness accuracy thresholds (LUFS deviation from target).
+// Within tightTol = full marks; degrades linearly to 0 at looseTol.
+const (
+	qualityLoudnessTightTol = 0.5 // within +-0.5 LUFS scores 1.0
+	qualityLoudnessLooseTol = 3.0 // at +-3.0 LUFS scores 0.0
+)
+
+// True-peak safety thresholds (dBTP). At or below safeTP = full marks; degrades
+// to 0 as the peak approaches/exceeds 0 dBTP (clipping).
+const (
+	qualityTPSafe = -1.0 // <= -1 dBTP scores 1.0
+	qualityTPHot  = 0.0  // >= 0 dBTP scores 0.0 (clipping)
+)
+
+// Noise cleanliness thresholds (output room-tone RMS floor in dBFS). The score
+// rewards a quiet *result*, not the amount removed: a recording that arrives
+// already clean scores full marks even though little was taken out. A lower
+// (more negative) final floor is cleaner. At or below qualityNoiseCleanFloor =
+// full marks; degrading linearly to 0 at qualityNoiseDirtyFloor.
+const (
+	qualityNoiseCleanFloor = -75.0 // <= -75 dBFS final floor scores 1.0
+	qualityNoiseDirtyFloor = -50.0 // >= -50 dBFS final floor scores 0.0
+)
+
+// Star label thresholds map the 0-100 composite to a 0-5 star count.
+// 5 -> Excellent, 4 -> Great, 3 -> Good, 2 -> Fair, <=1 -> Poor.
+var qualityStarBands = []struct {
+	min   float64
+	stars int
+	label string
+}{
+	{90, 5, "Excellent"},
+	{75, 4, "Great"},
+	{60, 3, "Good"},
+	{40, 2, "Fair"},
+	{0, 1, "Poor"},
+}
+
+// ComputeQualityScore derives an objective quality rating from a completed
+// ProcessingResult. It reads the real measured output loudness, output true
+// peak, and room-tone noise-floor reduction; it never returns a constant.
+func ComputeQualityScore(result *ProcessingResult) QualityScore {
+	if result == nil {
+		return QualityScore{Stars: 0, Label: "Poor"}
+	}
+
+	target := -16.0
+	if result.NormResult != nil && result.NormResult.RequestedTargetI != 0 {
+		target = result.NormResult.RequestedTargetI
+	}
+
+	loudness := scoreLoudness(result.OutputLUFS, target)
+	truePeak := scoreTruePeak(outputTruePeak(result))
+	noise := scoreNoiseCleanliness(result)
+
+	composite := 100 * (qualityWeightLoudness*loudness +
+		qualityWeightTruePeak*truePeak +
+		qualityWeightNoise*noise)
+
+	stars, label := starsForScore(composite)
+	return QualityScore{Score: composite, Stars: stars, Label: label}
+}
+
+// scoreLoudness returns 1.0 within the tight tolerance, falling linearly to 0.0
+// at the loose tolerance.
+func scoreLoudness(outputLUFS, target float64) float64 {
+	dev := math.Abs(outputLUFS - target)
+	if dev <= qualityLoudnessTightTol {
+		return 1.0
+	}
+	if dev >= qualityLoudnessLooseTol {
+		return 0.0
+	}
+	return 1.0 - (dev-qualityLoudnessTightTol)/(qualityLoudnessLooseTol-qualityLoudnessTightTol)
+}
+
+// scoreTruePeak returns 1.0 at or below the safe ceiling, falling linearly to
+// 0.0 as the peak reaches 0 dBTP (clipping).
+func scoreTruePeak(tp float64) float64 {
+	if tp <= qualityTPSafe {
+		return 1.0
+	}
+	if tp >= qualityTPHot {
+		return 0.0
+	}
+	return 1.0 - (tp-qualityTPSafe)/(qualityTPHot-qualityTPSafe)
+}
+
+// scoreNoiseCleanliness rates the cleanliness of the *output* room tone, not the
+// amount of noise removed. A lower (more negative) final floor scores higher, so
+// an already-clean recording is never scored below a noisier one with identical
+// loudness and true peak. When no final room-tone sample exists, fall back to the
+// input floor so the score stays honest rather than awarding free credit.
+func scoreNoiseCleanliness(result *ProcessingResult) float64 {
+	floor, ok := finalRoomToneRMS(result)
+	if !ok {
+		floor, ok = inputRoomToneRMS(result)
+		if !ok {
+			return 0.0
+		}
+	}
+	// Digital silence in the final room tone is maximally clean.
+	if math.IsInf(floor, -1) || floor <= qualityNoiseCleanFloor {
+		return 1.0
+	}
+	if floor >= qualityNoiseDirtyFloor {
+		return 0.0
+	}
+	return (qualityNoiseDirtyFloor - floor) / (qualityNoiseDirtyFloor - qualityNoiseCleanFloor)
+}
+
+// outputTruePeak resolves the real Pass 4 output true peak in dBTP. Prefers the
+// normalisation result; falls back to the final output measurements.
+func outputTruePeak(result *ProcessingResult) float64 {
+	if result.NormResult != nil && !result.NormResult.Skipped {
+		return result.NormResult.OutputTP
+	}
+	if result.NormResult != nil && result.NormResult.FinalMeasurements != nil {
+		return result.NormResult.FinalMeasurements.OutputTP
+	}
+	if result.FilteredMeasurements != nil {
+		return result.FilteredMeasurements.OutputTP
+	}
+	// No measurement available: assume worst case so the score is honest.
+	return qualityTPHot
+}
+
+// FinalNoiseFloor resolves the output room-tone RMS floor (dBFS) for display, the
+// same quantity the quality scorer rewards. Prefers the Pass 4 final room-tone
+// sample; falls back to the input floor when no final sample exists so the done
+// box always shows a real measured floor. The bool is false when neither is
+// available.
+func FinalNoiseFloor(result *ProcessingResult) (float64, bool) {
+	if floor, ok := finalRoomToneRMS(result); ok {
+		return floor, true
+	}
+	return inputRoomToneRMS(result)
+}
+
+// inputRoomToneRMS resolves the elected input room-tone RMS level (dBFS).
+func inputRoomToneRMS(result *ProcessingResult) (float64, bool) {
+	m := result.Measurements
+	if m == nil || m.NoiseProfile == nil {
+		return 0, false
+	}
+	return m.NoiseProfile.MeasuredNoiseFloor, true
+}
+
+// finalRoomToneRMS resolves the Pass 4 room-tone RMS level (dBFS).
+func finalRoomToneRMS(result *ProcessingResult) (float64, bool) {
+	if result.NormResult == nil || result.NormResult.FinalMeasurements == nil {
+		return 0, false
+	}
+	sample := result.NormResult.FinalMeasurements.RoomToneSample
+	if sample == nil {
+		return 0, false
+	}
+	return sample.RMSLevel, true
+}
+
+// starsForScore maps a 0-100 composite to a star count and word label.
+func starsForScore(score float64) (int, string) {
+	for _, band := range qualityStarBands {
+		if score >= band.min {
+			return band.stars, band.label
+		}
+	}
+	return 1, "Poor"
+}

--- a/internal/processor/quality_test.go
+++ b/internal/processor/quality_test.go
@@ -1,0 +1,116 @@
+package processor
+
+import "testing"
+
+// resultWith builds a minimal ProcessingResult exercising the quality scorer's
+// three inputs: output loudness, output true peak, and the output room-tone
+// floor. inputNoiseRMS is retained only for the legacy callers; the noise score
+// now depends on finalNoiseRMS (output cleanliness), not the reduction amount.
+func resultWith(outputLUFS, outputTP, inputNoiseRMS, finalNoiseRMS float64) *ProcessingResult {
+	return &ProcessingResult{
+		OutputLUFS: outputLUFS,
+		Measurements: &AudioMeasurements{
+			NoiseProfile: &NoiseProfile{MeasuredNoiseFloor: inputNoiseRMS},
+		},
+		NormResult: &NormalisationResult{
+			OutputTP:         outputTP,
+			RequestedTargetI: -16.0,
+			FinalMeasurements: &OutputMeasurements{
+				RoomToneSample: &RoomToneCandidateMetrics{RMSLevel: finalNoiseRMS},
+			},
+		},
+	}
+}
+
+func TestComputeQualityScoreExcellent(t *testing.T) {
+	// On target, safe true peak, strong noise reduction.
+	q := ComputeQualityScore(resultWith(-15.99, -2.18, -60.0, -82.0))
+	if q.Stars != 5 {
+		t.Errorf("on-target safe file: stars = %d, want 5 (score %.1f)", q.Stars, q.Score)
+	}
+	if q.Label != "Excellent" {
+		t.Errorf("label = %q, want Excellent", q.Label)
+	}
+}
+
+func TestComputeQualityScoreHotTruePeakPenalised(t *testing.T) {
+	// On target loudness and good noise reduction, but a clipping true peak
+	// (0 dBTP) zeroes the 0.30 true-peak weight, capping the composite at 0.70.
+	q := ComputeQualityScore(resultWith(-16.0, 0.0, -60.0, -82.0))
+	if q.Stars >= 5 {
+		t.Errorf("hot true peak should drop below 5 stars, got %d (score %.1f)", q.Stars, q.Score)
+	}
+	if q.Score >= 71 {
+		t.Errorf("hot true peak score = %.1f, want <= 70", q.Score)
+	}
+}
+
+func TestComputeQualityScoreOffTargetPenalised(t *testing.T) {
+	// Loudness 3 LUFS off target zeroes the 0.50 loudness weight.
+	onTarget := ComputeQualityScore(resultWith(-16.0, -2.0, -60.0, -82.0))
+	offTarget := ComputeQualityScore(resultWith(-19.0, -2.0, -60.0, -82.0))
+	if offTarget.Stars >= onTarget.Stars {
+		t.Errorf("off-target stars %d should be fewer than on-target %d", offTarget.Stars, onTarget.Stars)
+	}
+	if offTarget.Score >= onTarget.Score {
+		t.Errorf("off-target score %.1f should be lower than on-target %.1f", offTarget.Score, onTarget.Score)
+	}
+}
+
+func TestComputeQualityScoreCleanOutputScoresFullNoise(t *testing.T) {
+	// An output floor at or below qualityNoiseCleanFloor (-75 dBFS) earns the full
+	// 0.20 noise weight regardless of how clean the input was, so an already-clean
+	// recording (little to remove) still scores full noise marks.
+	q := ComputeQualityScore(resultWith(-16.0, -2.0, -78.0, -80.0))
+	if q.Stars != 5 || q.Label != "Excellent" {
+		t.Errorf("clean output: stars = %d label = %q, want 5 Excellent (score %.1f)", q.Stars, q.Label, q.Score)
+	}
+}
+
+func TestComputeQualityScoreNoisyOutputDropsNoise(t *testing.T) {
+	// An output floor at or above qualityNoiseDirtyFloor (-50 dBFS) zeroes the 0.20
+	// noise weight; with perfect loudness and true peak the composite is
+	// 0.50+0.30 = 0.80 -> 4 stars (Great).
+	q := ComputeQualityScore(resultWith(-16.0, -2.0, -52.0, -50.0))
+	if q.Stars != 4 {
+		t.Errorf("noisy output: stars = %d, want 4 (score %.1f)", q.Stars, q.Score)
+	}
+	if q.Label != "Great" {
+		t.Errorf("label = %q, want Great", q.Label)
+	}
+}
+
+// TestComputeQualityScoreCleanInputNotPenalised locks the exact bug fixed here: a
+// clean-input file (already low noise floor, little to remove) must score at least
+// as high as a noisier-input file with identical loudness and true peak. The old
+// scorer rewarded the *reduction amount*, so the clean file scored lower; the new
+// scorer rewards output cleanliness, so the clean output wins or ties.
+func TestComputeQualityScoreCleanInputNotPenalised(t *testing.T) {
+	// Clean recording: -80 dBFS input, stays clean at -80 dBFS output (mark/popey).
+	clean := ComputeQualityScore(resultWith(-16.0, -2.0, -80.0, -80.0))
+	// Noisier recording: -67 dBFS input, processed to -67 dBFS output (martin).
+	noisy := ComputeQualityScore(resultWith(-16.0, -2.0, -67.0, -67.0))
+
+	if clean.Score < noisy.Score {
+		t.Errorf("clean output score %.1f must be >= noisy output score %.1f", clean.Score, noisy.Score)
+	}
+	if clean.Stars < noisy.Stars {
+		t.Errorf("clean output stars %d must be >= noisy output stars %d", clean.Stars, noisy.Stars)
+	}
+}
+
+func TestComputeQualityScoreNeverConstant(t *testing.T) {
+	// Distinct inputs must yield distinct scores: the scorer is not a constant.
+	a := ComputeQualityScore(resultWith(-15.99, -2.18, -55.0, -82.0))
+	b := ComputeQualityScore(resultWith(-19.0, -0.2, -60.0, -61.0))
+	if a.Score == b.Score {
+		t.Errorf("distinct inputs gave identical score %.2f", a.Score)
+	}
+}
+
+func TestComputeQualityScoreNilSafe(t *testing.T) {
+	q := ComputeQualityScore(nil)
+	if q.Stars != 0 {
+		t.Errorf("nil result: stars = %d, want 0", q.Stars)
+	}
+}

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -6,13 +6,19 @@ import (
 	"strings"
 	"time"
 
+	"charm.land/bubbles/v2/progress"
+	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/linuxmatters/jivetalking/internal/cli"
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
-// Spinner frames for indeterminate progress
-var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+import (
+	// Temporary anchor import (Task 1.1): keep harmonica a direct require until
+	// Phase 4 consumes it. Remove this block when Phase 4 wires harmonica.
+	_ "github.com/charmbracelet/harmonica"
+)
 
 // analysisFileState tracks analysis progress and results for a single file
 type analysisFileState struct {
@@ -37,7 +43,10 @@ type AnalysisModel struct {
 	Done      bool
 
 	// Spinner state
-	spinnerIndex int
+	spinner spinner.Model
+
+	// Progress bar (owned by Update; rendered via ViewAs)
+	progress progress.Model
 
 	// Terminal dimensions
 	Width  int
@@ -67,9 +76,6 @@ type AnalysisCompleteMsg struct {
 	Error        error
 }
 
-// tickMsg is sent for spinner/timer animation
-type tickMsg time.Time
-
 // NewAnalysisModel creates a new analysis UI model with the given input files
 func NewAnalysisModel(files []string) AnalysisModel {
 	states := make([]analysisFileState, len(files))
@@ -83,19 +89,14 @@ func NewAnalysisModel(files []string) AnalysisModel {
 		Files:      states,
 		TotalFiles: len(files),
 		StartTime:  time.Now(),
+		spinner:    spinner.New(),
+		progress:   newProgressModel(),
 	}
 }
 
 // Init initializes the model
 func (m AnalysisModel) Init() tea.Cmd {
-	return tickCmd()
-}
-
-// tickCmd returns a command that sends a tick message every 100ms
-func tickCmd() tea.Cmd {
-	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
-		return tickMsg(t)
-	})
+	return m.spinner.Tick
 }
 
 // Update handles messages and updates the model
@@ -110,14 +111,14 @@ func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
 		m.Height = msg.Height
-
-	case tickMsg:
-		if !m.Done {
-			// Advance spinner
-			m.spinnerIndex = (m.spinnerIndex + 1) % len(spinnerFrames)
-			return m, tickCmd()
+		if msg.Width > 0 {
+			m.progress.SetWidth(progressWidthFor(msg.Width, analysisBarOverhead))
 		}
-		return m, nil
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
 
 	case AnalysisStartMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
@@ -165,11 +166,11 @@ func (m AnalysisModel) View() tea.View {
 	// Header
 	title := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#A40000")).
+		Foreground(cli.ColorRed).
 		Render("Jivetalking")
 
 	subtitle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#888888")).
+		Foreground(cli.ColorMuted).
 		Italic(true).
 		Render("Analysis Mode")
 
@@ -182,12 +183,12 @@ func (m AnalysisModel) View() tea.View {
 	}
 
 	fileStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#FFFFFF")).
+		Foreground(cli.ColorText).
 		Bold(true)
-	spinnerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#A40000"))
-	doneStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00AA00"))
-	errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#A40000"))
-	spinner := spinnerStyle.Render(spinnerFrames[m.spinnerIndex])
+	spinnerStyle := lipgloss.NewStyle().Foreground(cli.ColorRed)
+	doneStyle := lipgloss.NewStyle().Foreground(cli.ColorGreen)
+	errorStyle := lipgloss.NewStyle().Foreground(cli.ColorRed)
+	spinnerView := spinnerStyle.Render(m.spinner.View())
 	elapsed := time.Since(m.StartTime)
 
 	for i := range m.Files {
@@ -201,8 +202,8 @@ func (m AnalysisModel) View() tea.View {
 			icon := doneStyle.Render("🗸")
 			fmt.Fprintf(&b, " %s %s\n   Analysed\n", icon, fileStyle.Render(f.FileName))
 		default:
-			fmt.Fprintf(&b, " %s %s\n", spinner, fileStyle.Render(f.FileName))
-			fmt.Fprintf(&b, "   %s\n", renderAnalysisProgressBar(f.Progress, 40, elapsed))
+			fmt.Fprintf(&b, " %s %s\n", spinnerView, fileStyle.Render(f.FileName))
+			fmt.Fprintf(&b, "   %s [%s]\n", m.progress.ViewAs(f.Progress), formatElapsed(elapsed))
 			if f.Level != 0 {
 				fmt.Fprintf(&b, "   Level: %.1f dB\n", f.Level)
 			}
@@ -213,30 +214,13 @@ func (m AnalysisModel) View() tea.View {
 
 	footer := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#888888")).
+		BorderForeground(cli.ColorMuted).
 		Padding(0, 1).
 		Render(fmt.Sprintf("Analysing %d files, %d complete, %d failed",
 			m.TotalFiles, m.CompletedFiles, m.FailedFiles))
 	b.WriteString(footer)
 
 	return tea.NewView(b.String())
-}
-
-// renderAnalysisProgressBar renders a progress bar with percentage and elapsed time
-func renderAnalysisProgressBar(progress float64, width int, elapsed time.Duration) string {
-	filled := int(progress * float64(width))
-	empty := width - filled
-
-	// Use Unicode box drawing characters for a cleaner look
-	filledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#A40000"))
-	emptyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#444444"))
-
-	bar := filledStyle.Render(strings.Repeat("━", filled)) +
-		emptyStyle.Render(strings.Repeat("━", empty))
-
-	percentage := int(progress * 100)
-
-	return fmt.Sprintf("%s %3d%% [%s]", bar, percentage, formatElapsed(elapsed))
 }
 
 // formatElapsed formats elapsed time as MM:SS or HH:MM:SS

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/linuxmatters/jivetalking/internal/cli"
+	"github.com/linuxmatters/jivetalking/internal/logging"
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
@@ -182,7 +183,8 @@ func (m AnalysisModel) View() tea.View {
 			fmt.Fprintf(&b, " %s %s\n   Error: %v\n", icon, fileStyle.Render(f.FileName), f.Err)
 		case f.Done:
 			icon := doneStyle.Render("🗸")
-			fmt.Fprintf(&b, " %s %s\n   Analysed\n", icon, fileStyle.Render(f.FileName))
+			logName := filepath.Base(logging.AnalysisLogPath(f.FileName))
+			fmt.Fprintf(&b, " %s %s → %s\n", icon, fileStyle.Render(f.FileName), logName)
 		default:
 			fmt.Fprintf(&b, " %s %s\n", activeIcon, fileStyle.Render(f.FileName))
 			fmt.Fprintf(&b, "   %s [%s]\n", m.progress.ViewAs(f.Progress), formatElapsed(elapsed))

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/progress"
-	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/linuxmatters/jivetalking/internal/cli"
@@ -35,9 +34,6 @@ type AnalysisModel struct {
 	// Global state
 	StartTime time.Time
 	Done      bool
-
-	// Spinner state
-	spinner spinner.Model
 
 	// Progress bar (owned by Update; rendered via ViewAs)
 	progress progress.Model
@@ -83,14 +79,13 @@ func NewAnalysisModel(files []string) AnalysisModel {
 		Files:      states,
 		TotalFiles: len(files),
 		StartTime:  time.Now(),
-		spinner:    spinner.New(),
 		progress:   newProgressModel(),
 	}
 }
 
 // Init initializes the model
 func (m AnalysisModel) Init() tea.Cmd {
-	return m.spinner.Tick
+	return nil
 }
 
 // Update handles messages and updates the model
@@ -108,11 +103,6 @@ func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Width > 0 {
 			m.progress.SetWidth(progressWidthFor(msg.Width, analysisBarOverhead))
 		}
-
-	case spinner.TickMsg:
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(msg)
-		return m, cmd
 
 	case AnalysisStartMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
@@ -157,18 +147,17 @@ func (m AnalysisModel) View() tea.View {
 
 	var b strings.Builder
 
-	// Header
-	title := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(cli.ColorRed).
-		Render("Jivetalking")
+	// Header (title only), then the status box directly beneath it.
+	b.WriteString(cli.RenderTitle())
+	b.WriteString("\n\n")
 
-	subtitle := lipgloss.NewStyle().
-		Foreground(cli.ColorMuted).
-		Italic(true).
-		Render("Analysis Mode")
-
-	b.WriteString(title + " " + subtitle)
+	statusBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(cli.ColorMuted).
+		Padding(0, 1).
+		Render(fmt.Sprintf("Analysing %d files, %d complete, %d failed",
+			m.TotalFiles, m.CompletedFiles, m.FailedFiles))
+	b.WriteString(statusBox)
 	b.WriteString("\n\n")
 
 	if len(m.Files) == 0 {
@@ -179,10 +168,9 @@ func (m AnalysisModel) View() tea.View {
 	fileStyle := lipgloss.NewStyle().
 		Foreground(cli.ColorText).
 		Bold(true)
-	spinnerStyle := lipgloss.NewStyle().Foreground(cli.ColorRed)
+	activeIcon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("∿")
 	doneStyle := lipgloss.NewStyle().Foreground(cli.ColorGreen)
 	errorStyle := lipgloss.NewStyle().Foreground(cli.ColorRed)
-	spinnerView := spinnerStyle.Render(m.spinner.View())
 	elapsed := time.Since(m.StartTime)
 
 	for i := range m.Files {
@@ -196,23 +184,15 @@ func (m AnalysisModel) View() tea.View {
 			icon := doneStyle.Render("🗸")
 			fmt.Fprintf(&b, " %s %s\n   Analysed\n", icon, fileStyle.Render(f.FileName))
 		default:
-			fmt.Fprintf(&b, " %s %s\n", spinnerView, fileStyle.Render(f.FileName))
+			fmt.Fprintf(&b, " %s %s\n", activeIcon, fileStyle.Render(f.FileName))
 			fmt.Fprintf(&b, "   %s [%s]\n", m.progress.ViewAs(f.Progress), formatElapsed(elapsed))
 			if f.Level != 0 {
-				fmt.Fprintf(&b, "   Level: %.1f dB\n", f.Level)
+				fmt.Fprintf(&b, "   Level: %.1f ㏈\n", f.Level)
 			}
 		}
 
 		b.WriteString("\n")
 	}
-
-	footer := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(cli.ColorMuted).
-		Padding(0, 1).
-		Render(fmt.Sprintf("Analysing %d files, %d complete, %d failed",
-			m.TotalFiles, m.CompletedFiles, m.FailedFiles))
-	b.WriteString(footer)
 
 	return tea.NewView(b.String())
 }

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -14,12 +14,6 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
-import (
-	// Temporary anchor import (Task 1.1): keep harmonica a direct require until
-	// Phase 4 consumes it. Remove this block when Phase 4 wires harmonica.
-	_ "github.com/charmbracelet/harmonica"
-)
-
 // analysisFileState tracks analysis progress and results for a single file
 type analysisFileState struct {
 	FileName string

--- a/internal/ui/analysis_model_test.go
+++ b/internal/ui/analysis_model_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 )
 
@@ -23,6 +24,26 @@ func TestAnalysisProgressMsgIndexRouting(t *testing.T) {
 	if m.Files[0] != before {
 		t.Errorf("Files[0] changed: got %+v, want %+v", m.Files[0], before)
 	}
+}
+
+func TestAnalysisWindowSizeMsgPreservesRoutedFiles(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav", "b.wav"})
+
+	// Route progress before any resize: the seeded default width makes ViewAs safe.
+	updated, _ := m.Update(AnalysisProgressMsg{FileIndex: 1, Progress: 0.75, Level: -12.5})
+	m = updated.(AnalysisModel)
+	want := append([]analysisFileState(nil), m.Files...)
+	_ = m.progress.ViewAs(m.Files[1].Progress)
+
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(AnalysisModel)
+
+	for i := range want {
+		if m.Files[i] != want[i] {
+			t.Errorf("Files[%d] changed after WindowSizeMsg: got %+v, want %+v", i, m.Files[i], want[i])
+		}
+	}
+	_ = m.progress.ViewAs(m.Files[1].Progress)
 }
 
 func TestAnalysisCompleteMsgCounts(t *testing.T) {
@@ -80,6 +101,50 @@ func TestAnalysisQuitOnlyOnAllComplete(t *testing.T) {
 	}
 	if !m.Done {
 		t.Error("Done = false after AllCompleteMsg, want true")
+	}
+}
+
+func TestAnalysisInitStartsSpinner(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav"})
+
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init returned nil cmd, want spinner tick cmd")
+	}
+	if isQuitCmd(cmd) {
+		t.Error("Init returned a quit cmd, want non-quit spinner tick")
+	}
+	if _, ok := cmd().(spinner.TickMsg); !ok {
+		t.Errorf("Init cmd yielded %T, want spinner.TickMsg", cmd())
+	}
+}
+
+func TestAnalysisSpinnerTickAdvancesWithoutQuitting(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav"})
+	before := m.spinner.View()
+	files := append([]analysisFileState(nil), m.Files...)
+
+	// A zero-value TickMsg (ID 0, tag 0) is accepted by the spinner and
+	// advances one frame, returning a follow-up tick cmd.
+	updated, cmd := m.Update(spinner.TickMsg{})
+	m = updated.(AnalysisModel)
+
+	if isQuitCmd(cmd) {
+		t.Error("spinner.TickMsg returned a quit cmd, want non-quit follow-up tick")
+	}
+	if cmd == nil {
+		t.Error("spinner.TickMsg returned nil cmd, want follow-up tick")
+	}
+	if m.spinner.View() == before {
+		t.Errorf("spinner view unchanged after tick: %q", before)
+	}
+	for i := range files {
+		if m.Files[i] != files[i] {
+			t.Errorf("Files[%d] changed on spinner tick: got %+v, want %+v", i, m.Files[i], files[i])
+		}
+	}
+	if m.Done {
+		t.Error("Done = true after spinner tick, want false")
 	}
 }
 

--- a/internal/ui/analysis_model_test.go
+++ b/internal/ui/analysis_model_test.go
@@ -147,8 +147,8 @@ func TestAnalysisMessagesDriveViewWithoutSpinner(t *testing.T) {
 		t.Error("complete msg did not mark file done")
 	}
 	view = stripANSI(m.View().Content)
-	if !strings.Contains(view, "🗸 a.wav → a-analysis.log") {
-		t.Errorf("completed row missing '🗸 a.wav → a-analysis.log':\n%s", view)
+	if !strings.Contains(view, "🗸 a.wav → a-wav-analysis.log") {
+		t.Errorf("completed row missing '🗸 a.wav → a-wav-analysis.log':\n%s", view)
 	}
 	if strings.Contains(view, "Analysed") {
 		t.Errorf("completed row still shows removed 'Analysed' sub-line:\n%s", view)

--- a/internal/ui/analysis_model_test.go
+++ b/internal/ui/analysis_model_test.go
@@ -147,8 +147,11 @@ func TestAnalysisMessagesDriveViewWithoutSpinner(t *testing.T) {
 		t.Error("complete msg did not mark file done")
 	}
 	view = stripANSI(m.View().Content)
-	if !strings.Contains(view, "Analysed") {
-		t.Errorf("completed row missing 'Analysed':\n%s", view)
+	if !strings.Contains(view, "🗸 a.wav → a-analysis.log") {
+		t.Errorf("completed row missing '🗸 a.wav → a-analysis.log':\n%s", view)
+	}
+	if strings.Contains(view, "Analysed") {
+		t.Errorf("completed row still shows removed 'Analysed' sub-line:\n%s", view)
 	}
 }
 

--- a/internal/ui/analysis_model_test.go
+++ b/internal/ui/analysis_model_test.go
@@ -2,11 +2,19 @@ package ui
 
 import (
 	"errors"
+	"regexp"
+	"strings"
 	"testing"
 
-	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 )
+
+// ansiRE strips ANSI escape sequences so view assertions match on plain text.
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string {
+	return ansiRE.ReplaceAllString(s, "")
+}
 
 func TestAnalysisProgressMsgIndexRouting(t *testing.T) {
 	m := NewAnalysisModel([]string{"a.wav", "b.wav"})
@@ -104,47 +112,89 @@ func TestAnalysisQuitOnlyOnAllComplete(t *testing.T) {
 	}
 }
 
-func TestAnalysisInitStartsSpinner(t *testing.T) {
+func TestAnalysisInitReturnsNil(t *testing.T) {
 	m := NewAnalysisModel([]string{"a.wav"})
 
-	cmd := m.Init()
-	if cmd == nil {
-		t.Fatal("Init returned nil cmd, want spinner tick cmd")
-	}
-	if isQuitCmd(cmd) {
-		t.Error("Init returned a quit cmd, want non-quit spinner tick")
-	}
-	if _, ok := cmd().(spinner.TickMsg); !ok {
-		t.Errorf("Init cmd yielded %T, want spinner.TickMsg", cmd())
+	if cmd := m.Init(); cmd != nil {
+		t.Errorf("Init returned non-nil cmd %T, want nil (spinner removed)", cmd())
 	}
 }
 
-func TestAnalysisSpinnerTickAdvancesWithoutQuitting(t *testing.T) {
+// Without a spinner tick loop, re-renders are driven by progress/complete
+// messages. Confirm those still update state and the rendered view.
+func TestAnalysisMessagesDriveViewWithoutSpinner(t *testing.T) {
 	m := NewAnalysisModel([]string{"a.wav"})
-	before := m.spinner.View()
-	files := append([]analysisFileState(nil), m.Files...)
-
-	// A zero-value TickMsg (ID 0, tag 0) is accepted by the spinner and
-	// advances one frame, returning a follow-up tick cmd.
-	updated, cmd := m.Update(spinner.TickMsg{})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m = updated.(AnalysisModel)
 
-	if isQuitCmd(cmd) {
-		t.Error("spinner.TickMsg returned a quit cmd, want non-quit follow-up tick")
+	updated, _ = m.Update(AnalysisProgressMsg{FileIndex: 0, Progress: 0.5, Level: -12.5})
+	m = updated.(AnalysisModel)
+	if m.Files[0].Progress != 0.5 || m.Files[0].Level != -12.5 {
+		t.Errorf("progress msg did not update state: %+v", m.Files[0])
 	}
-	if cmd == nil {
-		t.Error("spinner.TickMsg returned nil cmd, want follow-up tick")
+
+	view := stripANSI(m.View().Content)
+	if !strings.Contains(view, "∿") {
+		t.Errorf("active row missing orange wave glyph ∿:\n%s", view)
 	}
-	if m.spinner.View() == before {
-		t.Errorf("spinner view unchanged after tick: %q", before)
+	if !strings.Contains(view, "Level: -12.5 ㏈") {
+		t.Errorf("level line missing ㏈ unit:\n%s", view)
 	}
-	for i := range files {
-		if m.Files[i] != files[i] {
-			t.Errorf("Files[%d] changed on spinner tick: got %+v, want %+v", i, m.Files[i], files[i])
-		}
+
+	updated, _ = m.Update(AnalysisCompleteMsg{FileIndex: 0})
+	m = updated.(AnalysisModel)
+	if !m.Files[0].Done {
+		t.Error("complete msg did not mark file done")
 	}
-	if m.Done {
-		t.Error("Done = true after spinner tick, want false")
+	view = stripANSI(m.View().Content)
+	if !strings.Contains(view, "Analysed") {
+		t.Errorf("completed row missing 'Analysed':\n%s", view)
+	}
+}
+
+// TestAnalysisViewLayout checks the header gradient title, absent subtitle, and
+// status box ordering above the file list.
+func TestAnalysisViewLayout(t *testing.T) {
+	m := NewAnalysisModel([]string{"a.wav", "b.wav", "c.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(AnalysisModel)
+
+	// a.wav active with a level; b.wav done; c.wav errored.
+	updated, _ = m.Update(AnalysisProgressMsg{FileIndex: 0, Progress: 0.4, Level: -9.0})
+	m = updated.(AnalysisModel)
+	updated, _ = m.Update(AnalysisCompleteMsg{FileIndex: 1})
+	m = updated.(AnalysisModel)
+	updated, _ = m.Update(AnalysisCompleteMsg{FileIndex: 2, Error: errors.New("boom")})
+	m = updated.(AnalysisModel)
+
+	view := stripANSI(m.View().Content)
+
+	if !strings.Contains(view, "Jivetalking") {
+		t.Errorf("view missing gradient title 'Jivetalking':\n%s", view)
+	}
+	if strings.Contains(view, "Analysis Mode") {
+		t.Errorf("view still contains dropped subtitle 'Analysis Mode':\n%s", view)
+	}
+
+	boxIdx := strings.Index(view, "Analysing")
+	listIdx := strings.Index(view, "a.wav")
+	if boxIdx < 0 {
+		t.Fatalf("status box text not found:\n%s", view)
+	}
+	if listIdx < 0 {
+		t.Fatalf("file list not found:\n%s", view)
+	}
+	if boxIdx > listIdx {
+		t.Errorf("status box (%d) renders after file list (%d), want before:\n%s", boxIdx, listIdx, view)
+	}
+	if !strings.Contains(view, "∿") {
+		t.Errorf("active row missing ∿ glyph:\n%s", view)
+	}
+	if !strings.Contains(view, "🗸") {
+		t.Errorf("done row missing 🗸 icon:\n%s", view)
+	}
+	if !strings.Contains(view, "✗") {
+		t.Errorf("error row missing ✗ icon:\n%s", view)
 	}
 }
 

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -11,6 +11,7 @@ type ProgressMsg struct {
 	PassName     string
 	Progress     float64
 	Level        float64
+	Duration     float64 // total audio length, seconds
 	Measurements *processor.AudioMeasurements
 }
 

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -26,9 +26,13 @@ type FileCompleteMsg struct {
 	FileIndex  int
 	InputLUFS  float64
 	OutputLUFS float64
-	NoiseFloor float64
-	OutputPath string
-	Error      error
+	// FinalNoiseFloor is the output room-tone noise floor in dBFS (lower = cleaner),
+	// the same quantity the quality score rewards, so the done box's Noise row and
+	// the star count move together.
+	FinalNoiseFloor float64
+	OutputPath      string
+	Quality         processor.QualityScore
+	Error           error
 }
 
 // AllCompleteMsg indicates all files have been processed

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -134,7 +134,10 @@ type FileProgress struct {
 	// Completion results
 	InputLUFS  float64
 	OutputLUFS float64
-	NoiseFloor float64
+	// FinalNoiseFloor is the output room-tone noise floor in dBFS (lower = cleaner),
+	// shown in the done box and aligned with the quality score's noise component.
+	FinalNoiseFloor float64
+	Quality         processor.QualityScore
 
 	// Error tracking
 	Error error
@@ -270,8 +273,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Files[msg.FileIndex].Status = StatusComplete
 			m.Files[msg.FileIndex].InputLUFS = msg.InputLUFS
 			m.Files[msg.FileIndex].OutputLUFS = msg.OutputLUFS
-			m.Files[msg.FileIndex].NoiseFloor = msg.NoiseFloor
+			m.Files[msg.FileIndex].FinalNoiseFloor = msg.FinalNoiseFloor
 			m.Files[msg.FileIndex].OutputPath = msg.OutputPath
+			m.Files[msg.FileIndex].Quality = msg.Quality
 			m.Files[msg.FileIndex].Error = msg.Error
 
 			if msg.Error != nil {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -118,6 +118,10 @@ type FileProgress struct {
 	StartTime   time.Time
 	ElapsedTime time.Duration
 
+	// Duration is the total audio length in seconds (constant per file; the
+	// first non-zero value is kept). Drives the realtime-speed badge.
+	Duration float64
+
 	// Analysis results (from Pass 1)
 	Measurements *processor.AudioMeasurements
 
@@ -337,6 +341,11 @@ func updateFileProgress(fp FileProgress, msg ProgressMsg) FileProgress {
 	fp.CurrentPass = msg.Pass
 	fp.PassName = msg.PassName
 	fp.ElapsedTime = time.Since(fp.StartTime)
+
+	// Duration is constant per file; keep the first non-zero value seen.
+	if msg.Duration > 0 && fp.Duration == 0 {
+		fp.Duration = msg.Duration
+	}
 
 	if msg.Measurements != nil {
 		fp.Measurements = msg.Measurements

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -52,9 +52,14 @@ func progressWidthFor(termWidth, overhead int) int {
 // meterFPS is the spring step rate for the eased audio level meter (~60fps).
 const meterFPS = 60
 
+// meterFloorDB is the audio level meter's silence floor in dB: the bottom of the
+// rendered dB range, the meter spring start position, and the initial PeakLevel.
+// Shared so the meter display (views.go) and these start values never drift apart.
+const meterFloorDB = -70.0
+
 // meterStartDB is the initial eased position for a file's meter, matching the
 // PeakLevel silence floor so the meter eases up from silence on first sample.
-const meterStartDB = -60.0
+const meterStartDB = meterFloorDB
 
 // meterTickMsg drives the spring step for the eased audio level meter. The loop
 // is self-scheduling while any file is active and stops once m.Done is set.
@@ -164,7 +169,7 @@ func NewModel(inputFiles []string) Model {
 		files[i] = FileProgress{
 			InputPath: path,
 			Status:    StatusQueued,
-			PeakLevel: -60.0, // Initialize to silence threshold
+			PeakLevel: meterFloorDB, // Initialize to silence threshold
 		}
 		meters[i] = meterState{pos: meterStartDB}
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -5,9 +5,76 @@ import (
 	"fmt"
 	"time"
 
+	"charm.land/bubbles/v2/progress"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/harmonica"
+	"github.com/linuxmatters/jivetalking/internal/cli"
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
+
+// defaultProgressWidth is the fallback bar width before a WindowSizeMsg arrives.
+const defaultProgressWidth = 40
+
+// minProgressWidth floors the bar so it stays usable on narrow terminals.
+const minProgressWidth = 10
+
+// maxProgressWidth caps the bar so it does not sprawl on wide terminals.
+const maxProgressWidth = 80
+
+// processingBarOverhead is the horizontal chrome around the processing-view
+// progress bar: RoundedBorder (2 cols) + Padding(0,1) (2 cols) plus a 2-col
+// safety margin so the box and its percentage label never reach the edge.
+const processingBarOverhead = 6
+
+// analysisBarOverhead is the horizontal chrome around the analysis-view progress
+// bar: a 3-col leading indent, the " [MM:SS]" elapsed suffix (~8 cols), plus a
+// 2-col safety margin.
+const analysisBarOverhead = 13
+
+// progressWidthFor clamps the bar width derived from a terminal width and its
+// surrounding chrome into the supported range.
+func progressWidthFor(termWidth, overhead int) int {
+	w := termWidth - overhead
+	if w < minProgressWidth {
+		return minProgressWidth
+	}
+	if w > maxProgressWidth {
+		return maxProgressWidth
+	}
+	return w
+}
+
+// meterFPS is the spring step rate for the eased audio level meter (~60fps).
+const meterFPS = 60
+
+// meterStartDB is the initial eased position for a file's meter, matching the
+// PeakLevel silence floor so the meter eases up from silence on first sample.
+const meterStartDB = -60.0
+
+// meterTickMsg drives the spring step for the eased audio level meter. The loop
+// is self-scheduling while any file is active and stops once m.Done is set.
+type meterTickMsg struct{}
+
+// meterState holds the harmonica spring smoothing state for a single file's
+// audio level meter. It is parallel to Model.Files (keyed by file index) so the
+// routed FileProgress data contract stays free of presentation-only state.
+type meterState struct {
+	pos float64 // eased display position in dB
+	vel float64 // spring velocity
+}
+
+// newProgressModel builds the shared gradient progress bar used by both the
+// processing and analysis models.
+func newProgressModel() progress.Model {
+	// Solid brand-red fill. A 2-stop dark-red gradient blends through blue in
+	// CIELAB space (lipgloss.Blend1D), so a single colour keeps the fill clean.
+	p := progress.New(
+		progress.WithColors(cli.ColorRed),
+	)
+	p.EmptyColor = cli.ColorFill
+	p.SetWidth(defaultProgressWidth)
+	return p
+}
 
 // FileStatus represents the processing state of a single file
 type FileStatus int
@@ -64,6 +131,14 @@ type Model struct {
 	StartTime time.Time
 	Done      bool
 
+	// Progress bar (owned by Update; rendered via ViewAs)
+	progress progress.Model
+
+	// Eased audio level meter state, parallel to Files (keyed by file index).
+	// Owned and mutated only in Update; never touched by pool workers.
+	meters []meterState
+	spring harmonica.Spring
+
 	// Terminal dimensions
 	Width  int
 	Height int
@@ -72,24 +147,59 @@ type Model struct {
 // NewModel creates a new UI model with the given input files
 func NewModel(inputFiles []string) Model {
 	files := make([]FileProgress, len(inputFiles))
+	meters := make([]meterState, len(inputFiles))
 	for i, path := range inputFiles {
 		files[i] = FileProgress{
 			InputPath: path,
 			Status:    StatusQueued,
 			PeakLevel: -60.0, // Initialize to silence threshold
 		}
+		meters[i] = meterState{pos: meterStartDB}
 	}
 
 	return Model{
 		Files:      files,
 		TotalFiles: len(inputFiles),
 		StartTime:  time.Now(),
+		progress:   newProgressModel(),
+		meters:     meters,
+		// Gentle under-damped spring: eases toward target without hard snapping.
+		spring: harmonica.NewSpring(harmonica.FPS(meterFPS), 6.0, 0.7),
 	}
 }
 
-// Init initializes the model
+// meterTick schedules the next spring step for the eased audio level meter.
+func meterTick() tea.Cmd {
+	return tea.Tick(time.Second/meterFPS, func(time.Time) tea.Msg {
+		return meterTickMsg{}
+	})
+}
+
+// fileActive reports whether a file is still being worked on and therefore its
+// meter should keep easing.
+func fileActive(s FileStatus) bool {
+	switch s {
+	case StatusAnalyzing, StatusProcessing, StatusNormalising:
+		return true
+	default:
+		return false
+	}
+}
+
+// anyActive reports whether at least one file is still active, gating the tick
+// loop so it terminates once processing finishes.
+func (m Model) anyActive() bool {
+	for i := range m.Files {
+		if fileActive(m.Files[i].Status) {
+			return true
+		}
+	}
+	return false
+}
+
+// Init initializes the model and starts the meter tick loop.
 func (m Model) Init() tea.Cmd {
-	return nil
+	return meterTick()
 }
 
 // Update handles messages and updates the model
@@ -104,6 +214,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
 		m.Height = msg.Height
+		if msg.Width > 0 {
+			m.progress.SetWidth(progressWidthFor(msg.Width, processingBarOverhead))
+		}
 
 	case ProgressMsg:
 		// Update the current file's progress
@@ -138,6 +251,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+
+	case meterTickMsg:
+		// Step each active file's meter spring toward its target level, then
+		// re-schedule only while work remains. Stop once m.Done is set or no
+		// file is active, guaranteeing the loop terminates on AllCompleteMsg.
+		if m.Done {
+			return m, nil
+		}
+		for i := range m.Files {
+			if !fileActive(m.Files[i].Status) {
+				continue
+			}
+			if i >= len(m.meters) {
+				continue
+			}
+			target := m.Files[i].CurrentLevel
+			m.meters[i].pos, m.meters[i].vel = m.spring.Update(
+				m.meters[i].pos, m.meters[i].vel, target)
+		}
+		if !m.anyActive() {
+			return m, nil
+		}
+		return m, meterTick()
 
 	case AllCompleteMsg:
 		// All files processed

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -12,14 +12,19 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
+// meterWidth is the cell width of the audio level meter. The progress bar caps
+// its rendered total at this width so its right edge aligns with the meter.
+const meterWidth = 40
+
 // defaultProgressWidth is the fallback bar width before a WindowSizeMsg arrives.
-const defaultProgressWidth = 40
+const defaultProgressWidth = meterWidth
 
 // minProgressWidth floors the bar so it stays usable on narrow terminals.
 const minProgressWidth = 10
 
-// maxProgressWidth caps the bar so it does not sprawl on wide terminals.
-const maxProgressWidth = 80
+// maxProgressWidth caps the bar's rendered total (fill + percentage label) so it
+// aligns with the meterWidth-cell audio level meter rather than sprawling.
+const maxProgressWidth = meterWidth
 
 // processingBarOverhead is the horizontal chrome around the processing-view
 // progress bar: RoundedBorder (2 cols) + Padding(0,1) (2 cols) plus a 2-col
@@ -56,20 +61,25 @@ const meterStartDB = -60.0
 type meterTickMsg struct{}
 
 // meterState holds the harmonica spring smoothing state for a single file's
-// audio level meter. It is parallel to Model.Files (keyed by file index) so the
-// routed FileProgress data contract stays free of presentation-only state.
+// audio level meter and its progress bar. It is parallel to Model.Files (keyed
+// by file index) so the routed FileProgress data contract stays free of
+// presentation-only state.
 type meterState struct {
-	pos float64 // eased display position in dB
-	vel float64 // spring velocity
+	pos     float64 // eased meter display position in dB
+	vel     float64 // meter spring velocity
+	progPos float64 // eased progress display position (0.0-1.0)
+	progVel float64 // progress spring velocity
 }
 
 // newProgressModel builds the shared gradient progress bar used by both the
 // processing and analysis models.
 func newProgressModel() progress.Model {
-	// Solid brand-red fill. A 2-stop dark-red gradient blends through blue in
-	// CIELAB space (lipgloss.Blend1D), so a single colour keeps the fill clean.
+	// Bright-cyan to violet gradient. WithScaled blends the two stops across the
+	// filled portion only, so the gradient is always visible regardless of fill.
+	// The CIELAB path between these endpoints stays vivid (no muddy midpoint).
 	p := progress.New(
-		progress.WithColors(cli.ColorRed),
+		progress.WithColors(cli.ColorAccentStart, cli.ColorAccentEnd),
+		progress.WithScaled(true),
 	)
 	p.EmptyColor = cli.ColorFill
 	p.SetWidth(defaultProgressWidth)
@@ -134,10 +144,12 @@ type Model struct {
 	// Progress bar (owned by Update; rendered via ViewAs)
 	progress progress.Model
 
-	// Eased audio level meter state, parallel to Files (keyed by file index).
-	// Owned and mutated only in Update; never touched by pool workers.
-	meters []meterState
-	spring harmonica.Spring
+	// Eased audio level meter and progress bar state, parallel to Files (keyed
+	// by file index). Owned and mutated only in Update; never touched by pool
+	// workers.
+	meters         []meterState
+	spring         harmonica.Spring // eases the audio level meter
+	progressSpring harmonica.Spring // eases the progress bar fill
 
 	// Terminal dimensions
 	Width  int
@@ -165,6 +177,9 @@ func NewModel(inputFiles []string) Model {
 		meters:     meters,
 		// Gentle under-damped spring: eases toward target without hard snapping.
 		spring: harmonica.NewSpring(harmonica.FPS(meterFPS), 6.0, 0.7),
+		// Snappier critically-damped spring for the bar fill: smooth motion that
+		// tracks progress promptly without overshoot.
+		progressSpring: harmonica.NewSpring(harmonica.FPS(meterFPS), 10.0, 1.0),
 	}
 }
 
@@ -269,6 +284,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			target := m.Files[i].CurrentLevel
 			m.meters[i].pos, m.meters[i].vel = m.spring.Update(
 				m.meters[i].pos, m.meters[i].vel, target)
+			m.meters[i].progPos, m.meters[i].progVel = m.progressSpring.Update(
+				m.meters[i].progPos, m.meters[i].progVel, m.Files[i].Progress)
 		}
 		if !m.anyActive() {
 			return m, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -79,11 +79,11 @@ type meterState struct {
 // newProgressModel builds the shared gradient progress bar used by both the
 // processing and analysis models.
 func newProgressModel() progress.Model {
-	// Bright-cyan to violet gradient. WithScaled blends the two stops across the
+	// Sky-blue to indigo gradient. WithScaled blends the two stops across the
 	// filled portion only, so the gradient is always visible regardless of fill.
 	// The CIELAB path between these endpoints stays vivid (no muddy midpoint).
 	p := progress.New(
-		progress.WithColors(cli.ColorAccentStart, cli.ColorAccentEnd),
+		progress.WithColors(cli.ColorSkyBlue, cli.ColorIndigo),
 		progress.WithScaled(true),
 	)
 	p.EmptyColor = cli.ColorFill

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -74,6 +74,8 @@ type meterState struct {
 	vel     float64 // meter spring velocity
 	progPos float64 // eased progress display position (0.0-1.0)
 	progVel float64 // progress spring velocity
+	peakPos float64 // eased peak-hold marker position in dB
+	peakVel float64 // peak spring velocity
 }
 
 // newProgressModel builds the shared gradient progress bar used by both the
@@ -159,6 +161,7 @@ type Model struct {
 	meters         []meterState
 	spring         harmonica.Spring // eases the audio level meter
 	progressSpring harmonica.Spring // eases the progress bar fill
+	peakSpring     harmonica.Spring // eases the peak-hold marker
 
 	// Terminal dimensions
 	Width  int
@@ -175,7 +178,7 @@ func NewModel(inputFiles []string) Model {
 			Status:    StatusQueued,
 			PeakLevel: meterFloorDB, // Initialize to silence threshold
 		}
-		meters[i] = meterState{pos: meterStartDB}
+		meters[i] = meterState{pos: meterStartDB, peakPos: meterFloorDB}
 	}
 
 	return Model{
@@ -189,6 +192,10 @@ func NewModel(inputFiles []string) Model {
 		// Snappier critically-damped spring for the bar fill: smooth motion that
 		// tracks progress promptly without overshoot.
 		progressSpring: harmonica.NewSpring(harmonica.FPS(meterFPS), 10.0, 1.0),
+		// Critically-damped spring for the peak marker: damping ratio 1.0 guarantees
+		// a monotonic, no-overshoot approach so the eased marker/label never report a
+		// value louder than the measured peak-hold.
+		peakSpring: harmonica.NewSpring(harmonica.FPS(meterFPS), 8.0, 1.0),
 	}
 }
 
@@ -295,6 +302,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.meters[i].pos, m.meters[i].vel, target)
 			m.meters[i].progPos, m.meters[i].progVel = m.progressSpring.Update(
 				m.meters[i].progPos, m.meters[i].progVel, m.Files[i].Progress)
+			m.meters[i].peakPos, m.meters[i].peakVel = m.peakSpring.Update(
+				m.meters[i].peakPos, m.meters[i].peakVel, m.Files[i].PeakLevel)
 		}
 		if !m.anyActive() {
 			return m, nil

--- a/internal/ui/model_routing_test.go
+++ b/internal/ui/model_routing_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
@@ -62,6 +64,7 @@ func TestFileCompleteMsgIndexRouting(t *testing.T) {
 func TestUpdateOutOfRangeSafety(t *testing.T) {
 	m := NewModel([]string{"a.wav", "b.wav"})
 	want := append([]FileProgress(nil), m.Files...)
+	wantMeters := append([]meterState(nil), m.meters...)
 
 	indices := []int{-1, len(m.Files)}
 	for _, idx := range indices {
@@ -76,9 +79,37 @@ func TestUpdateOutOfRangeSafety(t *testing.T) {
 			t.Errorf("Files[%d] changed after out-of-range messages: got %+v, want %+v", i, m.Files[i], want[i])
 		}
 	}
+	for i := range wantMeters {
+		if m.meters[i] != wantMeters[i] {
+			t.Errorf("meters[%d] changed after out-of-range messages: got %+v, want %+v", i, m.meters[i], wantMeters[i])
+		}
+	}
 	if m.CompletedFiles != 0 || m.FailedFiles != 0 {
 		t.Errorf("counts changed: completed=%d failed=%d, want 0/0", m.CompletedFiles, m.FailedFiles)
 	}
+}
+
+func TestWindowSizeMsgPreservesRoutedFiles(t *testing.T) {
+	m := NewModel([]string{"a.wav", "b.wav"})
+
+	// Route progress before any resize: the seeded default width makes ViewAs safe.
+	updated, _ := m.Update(ProgressMsg{FileIndex: 0, Pass: processor.PassProcessing, Progress: 0.5})
+	m = updated.(Model)
+	want := append([]FileProgress(nil), m.Files...)
+	_ = m.progress.ViewAs(m.Files[0].Progress)
+
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+
+	if m.Width != 120 || m.Height != 40 {
+		t.Errorf("dimensions not stored: Width=%d Height=%d, want 120/40", m.Width, m.Height)
+	}
+	for i := range want {
+		if m.Files[i] != want[i] {
+			t.Errorf("Files[%d] changed after WindowSizeMsg: got %+v, want %+v", i, m.Files[i], want[i])
+		}
+	}
+	_ = m.progress.ViewAs(m.Files[0].Progress)
 }
 
 func TestRenderOverallProgressFooter(t *testing.T) {
@@ -105,5 +136,76 @@ func TestRenderOverallProgressFooter(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(footer), "file 3 of") || strings.Contains(strings.ToLower(footer), "of 3") {
 		t.Errorf("footer must not contain a 'file N of M' cursor: %q", footer)
+	}
+}
+
+func TestInitStartsMeterTick(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init() returned nil cmd, want a meter tick cmd")
+	}
+	if _, ok := cmd().(meterTickMsg); !ok {
+		t.Errorf("Init() cmd yielded %T, want meterTickMsg", cmd())
+	}
+}
+
+func TestMeterTickStepsSpringWithoutMutatingRoutedFields(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+
+	// Make the file active and give the meter a target above its start floor.
+	updated, _ := m.Update(ProgressMsg{FileIndex: 0, Pass: processor.PassProcessing, Progress: 0.5, Level: -12})
+	m = updated.(Model)
+
+	wantProgress := m.Files[0].Progress
+	wantStatus := m.Files[0].Status
+	startPos := m.meters[0].pos
+	target := m.Files[0].CurrentLevel
+
+	updated, cmd := m.Update(meterTickMsg{})
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Error("meterTickMsg returned nil cmd while a file is active, want re-scheduled tick")
+	}
+	// Eased: the meter moves toward the target but must not snap to it.
+	if m.meters[0].pos <= startPos {
+		t.Errorf("meters[0].pos = %v, want > start %v (should ease toward target)", m.meters[0].pos, startPos)
+	}
+	if m.meters[0].pos >= target {
+		t.Errorf("meters[0].pos = %v, want < target %v (must be eased, not instantaneous)", m.meters[0].pos, target)
+	}
+	// Routed data contract must stay untouched by presentation-only stepping.
+	if m.Files[0].Progress != wantProgress {
+		t.Errorf("Files[0].Progress = %v, want unchanged %v", m.Files[0].Progress, wantProgress)
+	}
+	if m.Files[0].Status != wantStatus {
+		t.Errorf("Files[0].Status = %v, want unchanged %v", m.Files[0].Status, wantStatus)
+	}
+}
+
+func TestMeterTickStopsAfterAllComplete(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+
+	// Activate the file so a tick would normally re-schedule.
+	updated, _ := m.Update(ProgressMsg{FileIndex: 0, Pass: processor.PassProcessing, Progress: 0.5, Level: -12})
+	m = updated.(Model)
+
+	updated, _ = m.Update(AllCompleteMsg{})
+	m = updated.(Model)
+	if !m.Done {
+		t.Fatal("AllCompleteMsg did not set m.Done")
+	}
+	posBefore := m.meters[0].pos
+
+	updated, cmd := m.Update(meterTickMsg{})
+	m = updated.(Model)
+
+	if cmd != nil {
+		t.Error("meterTickMsg returned non-nil cmd after m.Done, want loop termination")
+	}
+	if m.meters[0].pos != posBefore {
+		t.Errorf("meters[0].pos = %v, want unchanged %v after Done", m.meters[0].pos, posBefore)
 	}
 }

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -183,11 +183,16 @@ func TestMeterHasNoInBarPeakGlyph(t *testing.T) {
 	bar := ansi.Strip(out)
 	// Take the bar line: the line that contains the gradient cells.
 	var barLine string
+	found := false
 	for line := range strings.SplitSeq(bar, "\n") {
 		if strings.ContainsRune(line, '▓') || strings.ContainsRune(line, '░') {
 			barLine = line
+			found = true
 			break
 		}
+	}
+	if !found {
+		t.Fatalf("no meter bar line (▓/░) rendered; cannot assert peak glyph absence:\n%q", bar)
 	}
 	if strings.ContainsRune(barLine, '|') {
 		t.Errorf("bar line still contains in-bar peak glyph '|':\n%q", barLine)
@@ -319,6 +324,40 @@ func TestMeterPeakElbowTethersValue(t *testing.T) {
 		}
 		if w := ansi.StringWidth(elbowLine); w > meterWidth {
 			t.Errorf("peak=%g: elbow line width %d > meterWidth %d", tc.peak, w, meterWidth)
+		}
+	}
+}
+
+// TestMeterPeakAtCeilingStaysInBounds asserts a peak at (and near) the 0 dB
+// ceiling places the marker at the last in-bounds column (width-1), not one cell
+// beyond the bar, and that no rendered line exceeds the meter width.
+func TestMeterPeakAtCeilingStaysInBounds(t *testing.T) {
+	marker := []rune(peakMarkerGlyph)[0]
+	for _, peak := range []float64{0.0, -0.5, -1.0} {
+		out := renderAudioLevelMeter(-40.0, peak, 0)
+		plain := ansi.Strip(out)
+
+		var markerLine string
+		for line := range strings.SplitSeq(plain, "\n") {
+			if strings.ContainsRune(line, marker) {
+				markerLine = line
+				break
+			}
+		}
+		if markerLine == "" {
+			t.Fatalf("peak=%g: no marker line found in:\n%q", peak, plain)
+		}
+		lead := len(markerLine) - len(strings.TrimLeft(markerLine, " "))
+		if lead != meterWidth-1 {
+			t.Errorf("peak=%g: marker at column %d, want last in-bounds column %d",
+				peak, lead, meterWidth-1)
+		}
+
+		// No rendered line may spill past the meter width.
+		for line := range strings.SplitSeq(plain, "\n") {
+			if w := ansi.StringWidth(line); w > meterWidth {
+				t.Errorf("peak=%g: line width %d > meterWidth %d:\n%q", peak, w, meterWidth, line)
+			}
 		}
 	}
 }

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// hasBlueFill reports whether any truecolor SGR sequence in the rendered bar
+// carries a blue component above the red and green components, which would
+// betray the bubbles default purple/blue gradient leaking into the fill.
+func hasBlueFill(s string) bool {
+	for seg := range strings.SplitSeq(s, "\x1b[") {
+		if !strings.HasPrefix(seg, "38;2;") {
+			continue
+		}
+		body, _, _ := strings.Cut(seg, "m")
+		parts := strings.Split(body, ";")
+		if len(parts) < 5 {
+			continue
+		}
+		r, err1 := strconv.Atoi(parts[2])
+		g, err2 := strconv.Atoi(parts[3])
+		b, err3 := strconv.Atoi(parts[4])
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		if b > r && b > g && b > 40 {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProgressFillIsBrandRed(t *testing.T) {
+	p := newProgressModel()
+	p.SetWidth(40)
+	out := p.ViewAs(0.5)
+	if hasBlueFill(out) {
+		t.Errorf("progress fill contains blue bytes (default gradient leaked):\n%q", out)
+	}
+}
+
+func TestProcessingProgressWidthFitsTerminal(t *testing.T) {
+	for _, term := range []int{20, 40, 80, 120, 200} {
+		m := NewModel([]string{"a.wav"})
+		updated, _ := m.Update(tea.WindowSizeMsg{Width: term, Height: 24})
+		m = updated.(Model)
+
+		w := m.progress.Width()
+		if w < minProgressWidth || w > maxProgressWidth {
+			t.Errorf("term=%d progress width %d out of [%d,%d]", term, w, minProgressWidth, maxProgressWidth)
+		}
+
+		// Box outer width = bar width + border(2) + padding(2). It must not
+		// exceed the terminal unless the bar hit its minimum floor on a narrow
+		// terminal.
+		box := w + 4
+		if box > term && w > minProgressWidth {
+			t.Errorf("term=%d box width %d overflows terminal", term, box)
+		}
+	}
+}
+
+func TestAnalysisProgressWidthFitsTerminal(t *testing.T) {
+	for _, term := range []int{20, 40, 80, 120, 200} {
+		m := NewAnalysisModel([]string{"a.wav"})
+		updated, _ := m.Update(tea.WindowSizeMsg{Width: term, Height: 24})
+		m = updated.(AnalysisModel)
+
+		w := m.progress.Width()
+		if w < minProgressWidth || w > maxProgressWidth {
+			t.Errorf("term=%d analysis progress width %d out of [%d,%d]", term, w, minProgressWidth, maxProgressWidth)
+		}
+	}
+}
+
+// TestProcessingRowFitsTerminal renders the full active file detail box and
+// asserts no line exceeds the terminal width.
+func TestProcessingRowFitsTerminal(t *testing.T) {
+	for _, term := range []int{40, 80, 120} {
+		m := NewModel([]string{"recording.wav"})
+		updated, _ := m.Update(tea.WindowSizeMsg{Width: term, Height: 24})
+		m = updated.(Model)
+		updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5})
+		m = updated.(Model)
+
+		row := renderFileDetails(m.Files[0], m.progress, -20.0)
+		for line := range strings.SplitSeq(row, "\n") {
+			if w := ansi.StringWidth(line); w > term {
+				t.Errorf("term=%d line width %d overflows:\n%q", term, w, line)
+			}
+		}
+	}
+}

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -57,15 +57,16 @@ func durSec(s float64) time.Duration {
 	return time.Duration(s * float64(time.Second))
 }
 
-// triangleColor extracts the RGB foreground applied to the '▲' peak marker, or
-// nil if no triangle is present.
+// triangleColor extracts the RGB foreground applied to the '🭯' peak marker, or
+// nil if no marker is present.
 func triangleColor(s string) *[3]int {
+	marker := []rune(peakMarkerGlyph)[0]
 	for seg := range strings.SplitSeq(s, "\x1b[") {
 		if !strings.HasPrefix(seg, "38;2;") {
 			continue
 		}
 		head, rest, _ := strings.Cut(seg, "m")
-		if !strings.ContainsRune(rest, '▲') {
+		if !strings.ContainsRune(rest, marker) {
 			continue
 		}
 		parts := strings.Split(head, ";")
@@ -192,9 +193,10 @@ func TestMeterHasNoInBarPeakGlyph(t *testing.T) {
 	}
 }
 
-// TestMeterPeakTriangleAlignsBeneathBar asserts a '▲' marker appears on its own
+// TestMeterPeakTriangleAlignsBeneathBar asserts a '🭯' marker appears on its own
 // line beneath the bar with exactly peakPos leading spaces, for two peak levels.
 func TestMeterPeakTriangleAlignsBeneathBar(t *testing.T) {
+	marker := []rune(peakMarkerGlyph)[0]
 	cases := []struct {
 		peak    float64
 		peakPos int
@@ -207,21 +209,21 @@ func TestMeterPeakTriangleAlignsBeneathBar(t *testing.T) {
 		plain := ansi.Strip(out)
 		var markerLine string
 		for line := range strings.SplitSeq(plain, "\n") {
-			if strings.ContainsRune(line, '▲') {
+			if strings.ContainsRune(line, marker) {
 				markerLine = line
 				break
 			}
 		}
 		if markerLine == "" {
-			t.Fatalf("peak=%g: no '▲' marker line found in:\n%q", tc.peak, plain)
+			t.Fatalf("peak=%g: no '%c' marker line found in:\n%q", tc.peak, marker, plain)
 		}
 		lead := len(markerLine) - len(strings.TrimLeft(markerLine, " "))
 		if lead != tc.peakPos {
 			t.Errorf("peak=%g: marker leading spaces %d, want peakPos %d\n%q",
 				tc.peak, lead, tc.peakPos, markerLine)
 		}
-		if strings.TrimLeft(markerLine, " ") != "▲" {
-			t.Errorf("peak=%g: marker line is not a lone triangle: %q", tc.peak, markerLine)
+		if strings.TrimLeft(markerLine, " ") != peakMarkerGlyph {
+			t.Errorf("peak=%g: marker line is not a lone marker: %q", tc.peak, markerLine)
 		}
 	}
 }
@@ -239,18 +241,30 @@ func TestMeterHeaderShowsLevelNotPeak(t *testing.T) {
 	}
 }
 
+// displayCol returns the display column (cell offset) of the first occurrence of
+// r in s, measuring the prefix with ansi.StringWidth so wide glyphs like ㏈ count
+// as two columns. It returns -1 when r is absent.
+func displayCol(s string, r rune) int {
+	idx := strings.IndexRune(s, r)
+	if idx < 0 {
+		return -1
+	}
+	return ansi.StringWidth(s[:idx])
+}
+
 // TestMeterPeakElbowTethersValue asserts an elbow connector line beneath the
-// triangle carries the peak dB value, the elbow glyph aligns at the peak column
-// (└ to the right under ▲, or ┘ flipped left at the column), and the line stays
-// within the bar width in both orientations.
+// marker carries the peak ㏈ value, the elbow glyph aligns at the peak display
+// column (└ to the right under 🭯, or ┘ flipped left at the column), and the line
+// stays within the bar width in both orientations.
 func TestMeterPeakElbowTethersValue(t *testing.T) {
+	marker := []rune(peakMarkerGlyph)[0]
 	cases := []struct {
 		peak     float64
 		peakPos  int
 		wantLeft bool // true => left-flip form "value ┘", false => "└ value"
 	}{
-		{-30.0, 22, false}, // room to the right: └ -30.0 dB
-		{-10.0, 34, true},  // near right edge: flips to -10.0 dB ┘
+		{-30.0, 22, false}, // room to the right: └ -30.0 ㏈
+		{-10.0, 34, true},  // near right edge: flips to -10.0 ㏈ ┘
 	}
 	for _, tc := range cases {
 		out := renderAudioLevelMeter(-40.0, tc.peak, 0)
@@ -259,7 +273,7 @@ func TestMeterPeakElbowTethersValue(t *testing.T) {
 
 		var triLine, elbowLine string
 		for i, line := range lines {
-			if strings.TrimSpace(line) == "▲" {
+			if strings.TrimSpace(line) == peakMarkerGlyph {
 				triLine = line
 				if i+1 < len(lines) {
 					elbowLine = lines[i+1]
@@ -268,7 +282,7 @@ func TestMeterPeakElbowTethersValue(t *testing.T) {
 			}
 		}
 		if triLine == "" || elbowLine == "" {
-			t.Fatalf("peak=%g: missing triangle/elbow lines in:\n%q", tc.peak, plain)
+			t.Fatalf("peak=%g: missing marker/elbow lines in:\n%q", tc.peak, plain)
 		}
 
 		wantValue := strconv.FormatFloat(tc.peak, 'f', 1, 64) + " ㏈"
@@ -276,20 +290,26 @@ func TestMeterPeakElbowTethersValue(t *testing.T) {
 			t.Errorf("peak=%g: elbow line missing value %q: %q", tc.peak, wantValue, elbowLine)
 		}
 
-		// Elbow glyph aligns at the peak column (same as the triangle).
-		triCol := strings.IndexRune(triLine, '▲')
+		// Elbow glyph aligns at the peak display column (same as the marker). The
+		// flipped line carries the wide ㏈ before ┘, so measure columns by display
+		// width, not byte index.
+		triCol := displayCol(triLine, marker)
 		var elbowCol int
 		if tc.wantLeft {
-			elbowCol = strings.IndexRune(elbowLine, '┘')
+			elbowCol = displayCol(elbowLine, '┘')
 			if !strings.HasSuffix(strings.TrimRight(elbowLine, " "), "┘") {
 				t.Errorf("peak=%g: left-flip elbow not ending in '┘': %q", tc.peak, elbowLine)
 			}
 		} else {
-			elbowCol = strings.IndexRune(elbowLine, '└')
+			elbowCol = displayCol(elbowLine, '└')
 		}
-		if elbowCol != triCol {
-			t.Errorf("peak=%g: elbow column %d != triangle column %d\n%q\n%q",
-				tc.peak, elbowCol, triCol, triLine, elbowLine)
+		if elbowCol != tc.peakPos {
+			t.Errorf("peak=%g: elbow display column %d != peakPos %d\n%q\n%q",
+				tc.peak, elbowCol, tc.peakPos, triLine, elbowLine)
+		}
+		if triCol != tc.peakPos {
+			t.Errorf("peak=%g: marker display column %d != peakPos %d\n%q",
+				tc.peak, triCol, tc.peakPos, triLine)
 		}
 
 		// Both lines must stay within the bar width.
@@ -302,12 +322,12 @@ func TestMeterPeakElbowTethersValue(t *testing.T) {
 	}
 }
 
-// TestMeterNoPeakElbowAtFloor asserts neither the triangle nor the elbow line
+// TestMeterNoPeakElbowAtFloor asserts neither the marker nor the elbow line
 // renders when the peak is still at the silence floor.
 func TestMeterNoPeakElbowAtFloor(t *testing.T) {
 	out := ansi.Strip(renderAudioLevelMeter(-40.0, meterFloorDB, 0))
-	if strings.ContainsRune(out, '▲') {
-		t.Errorf("triangle rendered at silence floor:\n%q", out)
+	if strings.ContainsRune(out, []rune(peakMarkerGlyph)[0]) {
+		t.Errorf("marker rendered at silence floor:\n%q", out)
 	}
 	if strings.ContainsRune(out, '└') || strings.ContainsRune(out, '┘') {
 		t.Errorf("elbow rendered at silence floor:\n%q", out)

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -9,10 +10,11 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// hasBlueFill reports whether any truecolor SGR sequence in the rendered bar
-// carries a blue component above the red and green components, which would
-// betray the bubbles default purple/blue gradient leaking into the fill.
-func hasBlueFill(s string) bool {
+// fillColors extracts the distinct RGB foreground triples (38;2;r;g;b) from a
+// rendered bar, in order of first appearance, ignoring the empty-track colour.
+func fillColors(s string) [][3]int {
+	var out [][3]int
+	seen := map[[3]int]bool{}
 	for seg := range strings.SplitSeq(s, "\x1b[") {
 		if !strings.HasPrefix(seg, "38;2;") {
 			continue
@@ -28,19 +30,74 @@ func hasBlueFill(s string) bool {
 		if err1 != nil || err2 != nil || err3 != nil {
 			continue
 		}
-		if b > r && b > g && b > 40 {
-			return true
+		c := [3]int{r, g, b}
+		if !seen[c] {
+			seen[c] = true
+			out = append(out, c)
 		}
 	}
-	return false
+	return out
 }
 
-func TestProgressFillIsBrandRed(t *testing.T) {
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// hasColor reports whether the rendered bar contains a given RGB foreground.
+func hasColor(s string, r, g, b int) bool {
+	return slices.Contains(fillColors(s), [3]int{r, g, b})
+}
+
+// TestProgressFillIsGradient asserts the fill is a multi-colour gradient that
+// starts at the cyan accent, ends at the violet accent, never uses the red brand
+// colour, and has no muddy/grey midpoint.
+func TestProgressFillIsGradient(t *testing.T) {
 	p := newProgressModel()
-	p.SetWidth(40)
+	p.SetWidth(meterWidth)
 	out := p.ViewAs(0.5)
-	if hasBlueFill(out) {
-		t.Errorf("progress fill contains blue bytes (default gradient leaked):\n%q", out)
+
+	colors := fillColors(out)
+	// Drop the trailing empty-track colour: it is the dark fill (#444444 dark /
+	// #CCCCCC light). The gradient fill must still carry multiple stops.
+	if len(colors) < 3 {
+		t.Fatalf("expected a multi-colour gradient fill, got %d colours: %v", len(colors), colors)
+	}
+
+	// Brand red (#A40000) must not appear anywhere in the fill.
+	if hasColor(out, 164, 0, 0) {
+		t.Errorf("progress fill contains brand red 38;2;164;0;0:\n%q", out)
+	}
+
+	// Start endpoint: bright cyan #00D4FF must appear exactly.
+	if !hasColor(out, 0, 212, 255) {
+		t.Errorf("progress fill missing cyan start #00D4FF (0,212,255):\n%v", colors)
+	}
+	// End endpoint: at a partial fill the last cell approaches but need not equal
+	// the violet stop #9D4EDD (157,78,221). Assert the final fill colour is close
+	// (each channel within 12) and clearly violet (blue dominant, low green).
+	fill := colors[:len(colors)-1] // drop trailing empty-track colour
+	last := fill[len(fill)-1]
+	near := abs(last[0]-157) <= 12 && abs(last[1]-78) <= 12 && abs(last[2]-221) <= 12
+	if !near {
+		t.Errorf("final fill colour %v not near violet end (157,78,221)", last)
+	}
+
+	// Midpoint sanity: at least one mid-gradient colour must stay vivid (channel
+	// spread > 40) rather than collapsing to a muddy near-grey.
+	vivid := false
+	for _, c := range colors {
+		lo := min(c[0], min(c[1], c[2]))
+		hi := max(c[0], max(c[1], c[2]))
+		if hi-lo > 40 {
+			vivid = true
+			break
+		}
+	}
+	if !vivid {
+		t.Errorf("gradient looks muddy (no vivid colour found): %v", colors)
 	}
 }
 
@@ -62,6 +119,46 @@ func TestProcessingProgressWidthFitsTerminal(t *testing.T) {
 		if box > term && w > minProgressWidth {
 			t.Errorf("term=%d box width %d overflows terminal", term, box)
 		}
+	}
+}
+
+// TestProgressWidthCapsAtMeterWidth locks the bar to the meter width on wide
+// terminals so its right edge aligns with the audio level meter.
+func TestProgressWidthCapsAtMeterWidth(t *testing.T) {
+	for _, term := range []int{80, 120, 200} {
+		m := NewModel([]string{"a.wav"})
+		updated, _ := m.Update(tea.WindowSizeMsg{Width: term, Height: 24})
+		m = updated.(Model)
+
+		if w := m.progress.Width(); w != meterWidth {
+			t.Errorf("term=%d progress width %d, want %d (meterWidth)", term, w, meterWidth)
+		}
+	}
+}
+
+// TestProgressBarAlignsWithMeter renders both the eased bar line and the meter
+// line at a normal width and asserts their rendered cell widths match.
+func TestProgressBarAlignsWithMeter(t *testing.T) {
+	m := NewModel([]string{"recording.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = updated.(Model)
+
+	barLine := m.progress.ViewAs(0.5)
+	barW := ansi.StringWidth(barLine)
+	if barW != meterWidth {
+		t.Errorf("bar rendered width %d, want %d", barW, meterWidth)
+	}
+
+	meter := renderAudioLevelMeter(-20.0, -10.0)
+	// The meter's second line is the bar cells; take the widest non-label line.
+	var meterW int
+	for line := range strings.SplitSeq(meter, "\n") {
+		if w := ansi.StringWidth(line); w > meterW {
+			meterW = w
+		}
+	}
+	if meterW != meterWidth {
+		t.Errorf("meter bar width %d, want %d", meterW, meterWidth)
 	}
 }
 
@@ -88,11 +185,67 @@ func TestProcessingRowFitsTerminal(t *testing.T) {
 		updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5})
 		m = updated.(Model)
 
-		row := renderFileDetails(m.Files[0], m.progress, -20.0)
+		row := renderFileDetails(m.Files[0], m.progress, -20.0, 0.5)
 		for line := range strings.SplitSeq(row, "\n") {
 			if w := ansi.StringWidth(line); w > term {
 				t.Errorf("term=%d line width %d overflows:\n%q", term, w, line)
 			}
 		}
+	}
+}
+
+// TestProgressSpringEases asserts the bar fill eases toward a higher target
+// after one tick (moves, but does not snap), and that ticking stops once all
+// files complete.
+func TestProgressSpringEases(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Activate the file and set a target progress well ahead of the eased pos.
+	updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.8})
+	m = updated.(Model)
+
+	const start = 0.0
+	const target = 0.8
+	if got := m.meters[0].progPos; got != start {
+		t.Fatalf("initial progPos = %v, want %v", got, start)
+	}
+
+	updated, cmd := m.Update(meterTickMsg{})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Error("tick returned nil cmd while a file is active; loop must continue")
+	}
+
+	eased := m.meters[0].progPos
+	if !(start < eased && eased < target) {
+		t.Errorf("eased progPos %v not strictly between start %v and target %v", eased, start, target)
+	}
+
+	// After AllCompleteMsg the model is Done and the tick must not reschedule.
+	updated, _ = m.Update(AllCompleteMsg{})
+	m = updated.(Model)
+	_, cmd = m.Update(meterTickMsg{})
+	if cmd != nil {
+		t.Error("tick rescheduled after AllCompleteMsg; loop must terminate")
+	}
+}
+
+// TestProgressSpringIgnoresOutOfRange asserts out-of-range progress messages do
+// not panic or disturb spring state.
+func TestProgressSpringIgnoresOutOfRange(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	before := m.meters[0].progPos
+	updated, _ = m.Update(ProgressMsg{FileIndex: 5, Pass: 2, Progress: 0.9})
+	m = updated.(Model)
+	updated, _ = m.Update(ProgressMsg{FileIndex: -1, Pass: 2, Progress: 0.9})
+	m = updated.(Model)
+
+	if got := m.meters[0].progPos; got != before {
+		t.Errorf("out-of-range message disturbed spring state: %v != %v", got, before)
 	}
 }

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -49,6 +50,37 @@ func abs(n int) int {
 // hasColor reports whether the rendered bar contains a given RGB foreground.
 func hasColor(s string, r, g, b int) bool {
 	return slices.Contains(fillColors(s), [3]int{r, g, b})
+}
+
+// durSec returns a time.Duration for a fractional second count.
+func durSec(s float64) time.Duration {
+	return time.Duration(s * float64(time.Second))
+}
+
+// triangleColor extracts the RGB foreground applied to the '▲' peak marker, or
+// nil if no triangle is present.
+func triangleColor(s string) *[3]int {
+	for seg := range strings.SplitSeq(s, "\x1b[") {
+		if !strings.HasPrefix(seg, "38;2;") {
+			continue
+		}
+		head, rest, _ := strings.Cut(seg, "m")
+		if !strings.ContainsRune(rest, '▲') {
+			continue
+		}
+		parts := strings.Split(head, ";")
+		if len(parts) < 5 {
+			continue
+		}
+		r, err1 := strconv.Atoi(parts[2])
+		g, err2 := strconv.Atoi(parts[3])
+		b, err3 := strconv.Atoi(parts[4])
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		return &[3]int{r, g, b}
+	}
+	return nil
 }
 
 // TestProgressFillIsGradient asserts the fill is a multi-colour gradient that
@@ -106,7 +138,7 @@ func TestProgressFillIsGradient(t *testing.T) {
 // at the first cell, red-ish at the last, and more than 3 distinct fill colours.
 func TestMeterIsGradient(t *testing.T) {
 	// Drive the level to the hot end so every cell is filled and coloured.
-	out := renderAudioLevelMeter(-1.0, 0.0)
+	out := renderAudioLevelMeter(-1.0, 0.0, 0)
 
 	colors := fillColors(out)
 	if len(colors) <= 3 {
@@ -139,6 +171,94 @@ func TestMeterIsGradient(t *testing.T) {
 	}
 	if !vivid {
 		t.Errorf("meter gradient looks muddy (no vivid colour): %v", colors)
+	}
+}
+
+// TestMeterHasNoInBarPeakGlyph asserts the peak marker is no longer overlaid
+// inside the bar: the bar cells are pure filled/empty gradient with no '|'.
+func TestMeterHasNoInBarPeakGlyph(t *testing.T) {
+	out := renderAudioLevelMeter(-20.0, -10.0, 0)
+	bar := ansi.Strip(out)
+	// Take the bar line: the line that contains the gradient cells.
+	var barLine string
+	for line := range strings.SplitSeq(bar, "\n") {
+		if strings.ContainsRune(line, '▓') || strings.ContainsRune(line, '░') {
+			barLine = line
+			break
+		}
+	}
+	if strings.ContainsRune(barLine, '|') {
+		t.Errorf("bar line still contains in-bar peak glyph '|':\n%q", barLine)
+	}
+}
+
+// TestMeterPeakTriangleAlignsBeneathBar asserts a '▲' marker appears on its own
+// line beneath the bar with exactly peakPos leading spaces, for two peak levels.
+func TestMeterPeakTriangleAlignsBeneathBar(t *testing.T) {
+	cases := []struct {
+		peak    float64
+		peakPos int
+	}{
+		{-10.0, 34}, // ((-10+70)/70)*40 = 34.3 -> 34
+		{-30.0, 22}, // ((-30+70)/70)*40 = 22.9 -> 22
+	}
+	for _, tc := range cases {
+		out := renderAudioLevelMeter(-40.0, tc.peak, 0)
+		plain := ansi.Strip(out)
+		var markerLine string
+		for line := range strings.SplitSeq(plain, "\n") {
+			if strings.ContainsRune(line, '▲') {
+				markerLine = line
+				break
+			}
+		}
+		if markerLine == "" {
+			t.Fatalf("peak=%g: no '▲' marker line found in:\n%q", tc.peak, plain)
+		}
+		lead := len(markerLine) - len(strings.TrimLeft(markerLine, " "))
+		if lead != tc.peakPos {
+			t.Errorf("peak=%g: marker leading spaces %d, want peakPos %d\n%q",
+				tc.peak, lead, tc.peakPos, markerLine)
+		}
+		if strings.TrimLeft(markerLine, " ") != "▲" {
+			t.Errorf("peak=%g: marker line is not a lone triangle: %q", tc.peak, markerLine)
+		}
+	}
+}
+
+// TestMeterPeakTriangleIsOrange asserts the marker triangle is styled in an
+// orange shade (red > green > blue, with a substantial green component so it
+// reads as orange rather than pure red).
+func TestMeterPeakTriangleIsOrange(t *testing.T) {
+	out := renderAudioLevelMeter(-40.0, -10.0, 0)
+	c := triangleColor(out)
+	if c == nil {
+		t.Fatalf("no triangle colour found in:\n%q", out)
+	}
+	if c[0] <= c[1] || c[1] <= c[2] {
+		t.Errorf("triangle colour %v is not an orange shade (want r>g>b)", c)
+	}
+}
+
+// TestMeterPeakTrianglePulses asserts the marker oscillates between two distinct
+// orange shades across pulse phases.
+func TestMeterPeakTrianglePulses(t *testing.T) {
+	// Trough and crest of the 1.2 Hz sine: t=0 sits mid-rise; pick phases that
+	// land near the dim trough and the bright peak.
+	// durSec(0.625): sin = -1 -> dim trough. durSec(0.208): sin ≈ +1 -> bright crest.
+	dim := triangleColor(renderAudioLevelMeter(-40.0, -10.0, durSec(0.625)))
+	bright := triangleColor(renderAudioLevelMeter(-40.0, -10.0, durSec(0.208)))
+	if dim == nil || bright == nil {
+		t.Fatalf("missing triangle colour: dim=%v bright=%v", dim, bright)
+	}
+	if *dim == *bright {
+		t.Errorf("triangle colour did not change across pulse phases: %v", *dim)
+	}
+	// Both endpoints must stay clearly orange so the marker never vanishes.
+	for _, c := range []*[3]int{dim, bright} {
+		if c[0] <= c[1] || c[1] <= c[2] {
+			t.Errorf("pulse shade %v is not an orange shade (want r>g>b)", *c)
+		}
 	}
 }
 
@@ -190,7 +310,7 @@ func TestProgressBarAlignsWithMeter(t *testing.T) {
 		t.Errorf("bar rendered width %d, want %d", barW, meterWidth)
 	}
 
-	meter := renderAudioLevelMeter(-20.0, -10.0)
+	meter := renderAudioLevelMeter(-20.0, -10.0, 0)
 	// The meter's second line is the bar cells; take the widest non-label line.
 	var meterW int
 	for line := range strings.SplitSeq(meter, "\n") {

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -226,6 +226,94 @@ func TestMeterPeakTriangleAlignsBeneathBar(t *testing.T) {
 	}
 }
 
+// TestMeterHeaderShowsLevelNotPeak asserts the meter header line carries the
+// current level only; the peak value moved down to the elbow connector line.
+func TestMeterHeaderShowsLevelNotPeak(t *testing.T) {
+	out := ansi.Strip(renderAudioLevelMeter(-20.0, -10.0, 0))
+	header := strings.SplitN(out, "\n", 2)[0]
+	if !strings.Contains(header, "Level:") {
+		t.Errorf("header missing 'Level:': %q", header)
+	}
+	if strings.Contains(header, "Peak:") {
+		t.Errorf("header still contains 'Peak:': %q", header)
+	}
+}
+
+// TestMeterPeakElbowTethersValue asserts an elbow connector line beneath the
+// triangle carries the peak dB value, the elbow glyph aligns at the peak column
+// (└ to the right under ▲, or ┘ flipped left at the column), and the line stays
+// within the bar width in both orientations.
+func TestMeterPeakElbowTethersValue(t *testing.T) {
+	cases := []struct {
+		peak     float64
+		peakPos  int
+		wantLeft bool // true => left-flip form "value ┘", false => "└ value"
+	}{
+		{-30.0, 22, false}, // room to the right: └ -30.0 dB
+		{-10.0, 34, true},  // near right edge: flips to -10.0 dB ┘
+	}
+	for _, tc := range cases {
+		out := renderAudioLevelMeter(-40.0, tc.peak, 0)
+		plain := ansi.Strip(out)
+		lines := strings.Split(plain, "\n")
+
+		var triLine, elbowLine string
+		for i, line := range lines {
+			if strings.TrimSpace(line) == "▲" {
+				triLine = line
+				if i+1 < len(lines) {
+					elbowLine = lines[i+1]
+				}
+				break
+			}
+		}
+		if triLine == "" || elbowLine == "" {
+			t.Fatalf("peak=%g: missing triangle/elbow lines in:\n%q", tc.peak, plain)
+		}
+
+		wantValue := strconv.FormatFloat(tc.peak, 'f', 1, 64) + " ㏈"
+		if !strings.Contains(elbowLine, wantValue) {
+			t.Errorf("peak=%g: elbow line missing value %q: %q", tc.peak, wantValue, elbowLine)
+		}
+
+		// Elbow glyph aligns at the peak column (same as the triangle).
+		triCol := strings.IndexRune(triLine, '▲')
+		var elbowCol int
+		if tc.wantLeft {
+			elbowCol = strings.IndexRune(elbowLine, '┘')
+			if !strings.HasSuffix(strings.TrimRight(elbowLine, " "), "┘") {
+				t.Errorf("peak=%g: left-flip elbow not ending in '┘': %q", tc.peak, elbowLine)
+			}
+		} else {
+			elbowCol = strings.IndexRune(elbowLine, '└')
+		}
+		if elbowCol != triCol {
+			t.Errorf("peak=%g: elbow column %d != triangle column %d\n%q\n%q",
+				tc.peak, elbowCol, triCol, triLine, elbowLine)
+		}
+
+		// Both lines must stay within the bar width.
+		if w := ansi.StringWidth(triLine); w > meterWidth {
+			t.Errorf("peak=%g: triangle line width %d > meterWidth %d", tc.peak, w, meterWidth)
+		}
+		if w := ansi.StringWidth(elbowLine); w > meterWidth {
+			t.Errorf("peak=%g: elbow line width %d > meterWidth %d", tc.peak, w, meterWidth)
+		}
+	}
+}
+
+// TestMeterNoPeakElbowAtFloor asserts neither the triangle nor the elbow line
+// renders when the peak is still at the silence floor.
+func TestMeterNoPeakElbowAtFloor(t *testing.T) {
+	out := ansi.Strip(renderAudioLevelMeter(-40.0, meterFloorDB, 0))
+	if strings.ContainsRune(out, '▲') {
+		t.Errorf("triangle rendered at silence floor:\n%q", out)
+	}
+	if strings.ContainsRune(out, '└') || strings.ContainsRune(out, '┘') {
+		t.Errorf("elbow rendered at silence floor:\n%q", out)
+	}
+}
+
 // TestMeterPeakTriangleIsOrange asserts the marker triangle is styled in an
 // orange shade (red > green > blue, with a substantial green component so it
 // reads as orange rather than pure red).
@@ -259,6 +347,94 @@ func TestMeterPeakTrianglePulses(t *testing.T) {
 		if c[0] <= c[1] || c[1] <= c[2] {
 			t.Errorf("pulse shade %v is not an orange shade (want r>g>b)", *c)
 		}
+	}
+}
+
+// TestTimelineClocksAndBadge asserts the Time block renders the elapsed clock,
+// projected total clock, a dot timeline filled to progress, and the realtime
+// speed badge with the expected value for a known input.
+func TestTimelineClocksAndBadge(t *testing.T) {
+	fp := FileProgress{
+		Status:      StatusProcessing,
+		CurrentPass: 2,
+		Progress:    0.5,
+		Duration:    60.0,
+		ElapsedTime: 10 * time.Second,
+	}
+	line := ansi.Strip(renderTimeline(fp))
+
+	// Elapsed clock 00:10, projected total = 10/0.5 = 20s -> 00:20.
+	if !strings.Contains(line, "00:10") {
+		t.Errorf("missing elapsed clock 00:10: %q", line)
+	}
+	if !strings.Contains(line, "00:20") {
+		t.Errorf("missing projected clock 00:20: %q", line)
+	}
+
+	// realtime × = (0.5 × 60) / 10 = 3.0×.
+	if !strings.Contains(line, "⚡ 3.0×") {
+		t.Errorf("missing realtime badge '⚡ 3.0×': %q", line)
+	}
+
+	// Dot timeline filled to progress: 0.5 of 8 cells = 4 filled, 4 empty.
+	filled := strings.Count(line, "▰")
+	empty := strings.Count(line, "▱")
+	if filled != 4 || empty != 4 {
+		t.Errorf("timeline fill %d/%d, want 4/4 for progress 0.5: %q", filled, empty, line)
+	}
+}
+
+// TestTimelineBadgeGuards asserts the realtime badge shows the placeholder when
+// duration, progress, or elapsed are below the display thresholds, and a number
+// once all three clear them.
+func TestTimelineBadgeGuards(t *testing.T) {
+	cases := []struct {
+		name    string
+		fp      FileProgress
+		wantNum bool
+	}{
+		{"no duration", FileProgress{Progress: 0.5, Duration: 0, ElapsedTime: 10 * time.Second}, false},
+		{"progress too low", FileProgress{Progress: 0.01, Duration: 60, ElapsedTime: 10 * time.Second}, false},
+		{"elapsed too short", FileProgress{Progress: 0.5, Duration: 60, ElapsedTime: 200 * time.Millisecond}, false},
+		{"all clear", FileProgress{Progress: 0.5, Duration: 60, ElapsedTime: 10 * time.Second}, true},
+	}
+	for _, tc := range cases {
+		line := ansi.Strip(renderTimeline(tc.fp))
+		hasPlaceholder := strings.Contains(line, "⚡ —×")
+		hasNumber := strings.Contains(line, "×") && !hasPlaceholder
+		if tc.wantNum && !hasNumber {
+			t.Errorf("%s: expected a numeric badge, got: %q", tc.name, line)
+		}
+		if !tc.wantNum && !hasPlaceholder {
+			t.Errorf("%s: expected placeholder '⚡ —×', got: %q", tc.name, line)
+		}
+	}
+}
+
+// TestTimelineFillTracksProgress asserts the dot timeline fill count tracks the
+// pass progress across the full range and never overflows the timeline width.
+func TestTimelineFillTracksProgress(t *testing.T) {
+	for _, p := range []float64{0.0, 0.25, 0.5, 0.99, 1.0} {
+		fp := FileProgress{Progress: p, Duration: 60, ElapsedTime: 5 * time.Second}
+		line := ansi.Strip(renderTimeline(fp))
+		filled := strings.Count(line, "▰")
+		want := min(int(p*float64(timelineWidth)+0.5), timelineWidth)
+		if filled != want {
+			t.Errorf("progress %g: filled %d, want %d: %q", p, filled, want, line)
+		}
+		if filled+strings.Count(line, "▱") != timelineWidth {
+			t.Errorf("progress %g: total dots != %d: %q", p, timelineWidth, line)
+		}
+	}
+}
+
+// TestTimelineProjectedClockPlaceholder asserts the projected total clock shows
+// the --:-- placeholder until progress is meaningful.
+func TestTimelineProjectedClockPlaceholder(t *testing.T) {
+	fp := FileProgress{Progress: 0, Duration: 60, ElapsedTime: 2 * time.Second}
+	line := ansi.Strip(renderTimeline(fp))
+	if !strings.Contains(line, "--:--") {
+		t.Errorf("expected projected clock placeholder '--:--': %q", line)
 	}
 }
 

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -101,6 +101,47 @@ func TestProgressFillIsGradient(t *testing.T) {
 	}
 }
 
+// TestMeterIsGradient asserts the audio level meter colours its filled cells as
+// a smooth green→yellow→orange→red ramp rather than three flat zones: green-ish
+// at the first cell, red-ish at the last, and more than 3 distinct fill colours.
+func TestMeterIsGradient(t *testing.T) {
+	// Drive the level to the hot end so every cell is filled and coloured.
+	out := renderAudioLevelMeter(-1.0, 0.0)
+
+	colors := fillColors(out)
+	if len(colors) <= 3 {
+		t.Fatalf("expected a gradient (>3 distinct fill colours), got %d: %v", len(colors), colors)
+	}
+
+	first := colors[0]
+	last := colors[len(colors)-1]
+
+	// First cell green-ish: green channel dominant over red and blue.
+	greenDominant := first[1] > first[0] && first[1] > first[2]
+	if !greenDominant {
+		t.Errorf("first cell %v is not green-dominant", first)
+	}
+	// Last cell red-ish: red channel dominant over green and blue.
+	redDominant := last[0] > last[1] && last[0] > last[2]
+	if !redDominant {
+		t.Errorf("last cell %v is not red-dominant", last)
+	}
+
+	// No muddy/grey midpoint: at least one mid colour stays vivid.
+	vivid := false
+	for _, c := range colors {
+		lo := min(c[0], min(c[1], c[2]))
+		hi := max(c[0], max(c[1], c[2]))
+		if hi-lo > 40 {
+			vivid = true
+			break
+		}
+	}
+	if !vivid {
+		t.Errorf("meter gradient looks muddy (no vivid colour): %v", colors)
+	}
+}
+
 func TestProcessingProgressWidthFitsTerminal(t *testing.T) {
 	for _, term := range []int{20, 40, 80, 120, 200} {
 		m := NewModel([]string{"a.wav"})

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -542,7 +543,7 @@ func TestProcessingRowFitsTerminal(t *testing.T) {
 		updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5})
 		m = updated.(Model)
 
-		row := renderFileDetails(m.Files[0], m.progress, -20.0, 0.5)
+		row := renderFileDetails(m.Files[0], m.progress, -20.0, 0.5, -12.0)
 		for line := range strings.SplitSeq(row, "\n") {
 			if w := ansi.StringWidth(line); w > term {
 				t.Errorf("term=%d line width %d overflows:\n%q", term, w, line)
@@ -604,5 +605,133 @@ func TestProgressSpringIgnoresOutOfRange(t *testing.T) {
 
 	if got := m.meters[0].progPos; got != before {
 		t.Errorf("out-of-range message disturbed spring state: %v != %v", got, before)
+	}
+}
+
+// TestPeakSpringInitialisesAtFloor asserts each file's eased peak starts at the
+// silence floor so the marker eases up from silence rather than from zero.
+func TestPeakSpringInitialisesAtFloor(t *testing.T) {
+	m := NewModel([]string{"a.wav", "b.wav"})
+	for i := range m.meters {
+		if got := m.meters[i].peakPos; got != meterFloorDB {
+			t.Errorf("meters[%d].peakPos = %v, want floor %v", i, got, meterFloorDB)
+		}
+	}
+}
+
+// TestPeakSpringEases asserts the peak marker eases toward a higher target after
+// one tick (moves, but does not snap), and that ticking stops once all files
+// complete.
+func TestPeakSpringEases(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Activate the file and raise the peak-hold well above the silence floor.
+	updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5, Level: -12})
+	m = updated.(Model)
+
+	start := meterFloorDB
+	target := m.Files[0].PeakLevel
+	if got := m.meters[0].peakPos; got != start {
+		t.Fatalf("initial peakPos = %v, want %v", got, start)
+	}
+
+	updated, cmd := m.Update(meterTickMsg{})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Error("tick returned nil cmd while a file is active; loop must continue")
+	}
+
+	eased := m.meters[0].peakPos
+	if !(start < eased && eased < target) {
+		t.Errorf("eased peakPos %v not strictly between start %v and target %v", eased, start, target)
+	}
+
+	updated, _ = m.Update(AllCompleteMsg{})
+	m = updated.(Model)
+	_, cmd = m.Update(meterTickMsg{})
+	if cmd != nil {
+		t.Error("tick rescheduled after AllCompleteMsg; loop must terminate")
+	}
+}
+
+// TestPeakSpringNoOvershoot asserts the critically-damped peak spring converges
+// to a stepped target without ever exceeding it. Peak-hold is monotonic, so any
+// overshoot would momentarily render a value louder than the measured peak.
+func TestPeakSpringNoOvershoot(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5, Level: -10})
+	m = updated.(Model)
+
+	target := m.Files[0].PeakLevel
+	prev := m.meters[0].peakPos
+	for tick := range 600 {
+		updated, _ = m.Update(meterTickMsg{})
+		m = updated.(Model)
+		cur := m.meters[0].peakPos
+		if cur > target {
+			t.Fatalf("tick %d: peakPos %v overshot target %v", tick, cur, target)
+		}
+		if cur < prev-1e-9 {
+			t.Fatalf("tick %d: peakPos %v moved backward from %v (non-monotonic)", tick, cur, prev)
+		}
+		prev = cur
+	}
+	if math.Abs(m.meters[0].peakPos-target) > 0.01 {
+		t.Errorf("peakPos %v did not converge to target %v", m.meters[0].peakPos, target)
+	}
+}
+
+// TestPeakSpringRisingTargets feeds a rising series of peak-hold targets and
+// confirms the eased peak glides monotonically to each without overshoot.
+func TestPeakSpringRisingTargets(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+	updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5, Level: -40})
+	m = updated.(Model)
+
+	prev := m.meters[0].peakPos
+	for _, level := range []float64{-30, -20, -12, -6} {
+		updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5, Level: level})
+		m = updated.(Model)
+		target := m.Files[0].PeakLevel
+		for tick := range 600 {
+			updated, _ = m.Update(meterTickMsg{})
+			m = updated.(Model)
+			cur := m.meters[0].peakPos
+			if cur > target+1e-9 {
+				t.Fatalf("level %v tick %d: peakPos %v exceeded target %v", level, tick, cur, target)
+			}
+			if cur < prev-1e-9 {
+				t.Fatalf("level %v tick %d: peakPos %v moved backward from %v", level, tick, cur, prev)
+			}
+			prev = cur
+		}
+		if math.Abs(prev-target) > 0.01 {
+			t.Errorf("level %v: peakPos %v did not converge to target %v", level, prev, target)
+		}
+	}
+}
+
+// TestPeakSpringIgnoresOutOfRange asserts out-of-range messages do not disturb
+// peak spring state.
+func TestPeakSpringIgnoresOutOfRange(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	before := m.meters[0].peakPos
+	updated, _ = m.Update(ProgressMsg{FileIndex: 5, Pass: 2, Progress: 0.9, Level: -6})
+	m = updated.(Model)
+	updated, _ = m.Update(ProgressMsg{FileIndex: -1, Pass: 2, Progress: 0.9, Level: -6})
+	m = updated.(Model)
+
+	if got := m.meters[0].peakPos; got != before {
+		t.Errorf("out-of-range message disturbed peak spring state: %v != %v", got, before)
 	}
 }

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -85,8 +85,8 @@ func triangleColor(s string) *[3]int {
 }
 
 // TestProgressFillIsGradient asserts the fill is a multi-colour gradient that
-// starts at the cyan accent, ends at the violet accent, never uses the red brand
-// colour, and has no muddy/grey midpoint.
+// starts at the sky-blue accent, ends at the indigo accent, never uses the red
+// brand colour, and has no muddy/grey midpoint.
 func TestProgressFillIsGradient(t *testing.T) {
 	p := newProgressModel()
 	p.SetWidth(meterWidth)
@@ -104,18 +104,18 @@ func TestProgressFillIsGradient(t *testing.T) {
 		t.Errorf("progress fill contains brand red 38;2;164;0;0:\n%q", out)
 	}
 
-	// Start endpoint: bright cyan #00D4FF must appear exactly.
-	if !hasColor(out, 0, 212, 255) {
-		t.Errorf("progress fill missing cyan start #00D4FF (0,212,255):\n%v", colors)
+	// Start endpoint: sky-blue #38BDF8 must appear exactly.
+	if !hasColor(out, 56, 189, 248) {
+		t.Errorf("progress fill missing sky-blue start #38BDF8 (56,189,248):\n%v", colors)
 	}
 	// End endpoint: at a partial fill the last cell approaches but need not equal
-	// the violet stop #9D4EDD (157,78,221). Assert the final fill colour is close
-	// (each channel within 12) and clearly violet (blue dominant, low green).
+	// the indigo stop #6366F1 (99,102,241). Assert the final fill colour is close
+	// (each channel within 12) and clearly indigo (blue dominant).
 	fill := colors[:len(colors)-1] // drop trailing empty-track colour
 	last := fill[len(fill)-1]
-	near := abs(last[0]-157) <= 12 && abs(last[1]-78) <= 12 && abs(last[2]-221) <= 12
+	near := abs(last[0]-99) <= 12 && abs(last[1]-102) <= 12 && abs(last[2]-241) <= 12
 	if !near {
-		t.Errorf("final fill colour %v not near violet end (157,78,221)", last)
+		t.Errorf("final fill colour %v not near indigo end (99,102,241)", last)
 	}
 
 	// Midpoint sanity: at least one mid-gradient colour must stay vivid (channel

--- a/internal/ui/view_layout_test.go
+++ b/internal/ui/view_layout_test.go
@@ -1,0 +1,94 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+// TestHeaderHasNoSubtitle confirms the redundant "Processing N file(s)"
+// subtitle was removed from the header while the title stays.
+func TestHeaderHasNoSubtitle(t *testing.T) {
+	header := renderHeader()
+
+	if !strings.Contains(header, "Jivetalking") {
+		t.Errorf("header missing title: %q", header)
+	}
+	if strings.Contains(header, "file(s)") {
+		t.Errorf("header still contains subtitle: %q", header)
+	}
+}
+
+// TestProcessingViewSectionOrder confirms the overall-progress box sits directly
+// under the title and above the file queue, with no subtitle.
+func TestProcessingViewSectionOrder(t *testing.T) {
+	m := NewModel([]string{"a.wav", "b.wav"})
+	m.Width = 120
+	m.Height = 40
+
+	view := renderProcessingView(m)
+
+	if strings.Contains(view, "file(s)") {
+		t.Errorf("processing view still contains subtitle: %q", view)
+	}
+
+	titleIdx := strings.Index(view, "Jivetalking")
+	boxIdx := strings.Index(view, "complete")
+	queueIdx := strings.Index(view, "a.wav")
+
+	if titleIdx < 0 || boxIdx < 0 || queueIdx < 0 {
+		t.Fatalf("expected title, overall-progress box, and file queue in view:\n%s", view)
+	}
+	if titleIdx >= boxIdx || boxIdx >= queueIdx {
+		t.Errorf("section order wrong: title=%d box=%d queue=%d\n%s", titleIdx, boxIdx, queueIdx, view)
+	}
+}
+
+// TestProcessingViewOverallProgressContent confirms the overall-progress box
+// content appears near the top of the processing view.
+func TestProcessingViewOverallProgressContent(t *testing.T) {
+	m := NewModel([]string{"a.wav", "b.wav", "c.wav"})
+	m.Width = 120
+
+	updated, _ := m.Update(FileCompleteMsg{FileIndex: 0, OutputPath: "a-out.wav"})
+	m = updated.(Model)
+
+	view := renderProcessingView(m)
+
+	if !strings.Contains(view, "3 files") {
+		t.Errorf("view missing total count: %q", view)
+	}
+	if !strings.Contains(view, "1 complete") {
+		t.Errorf("view missing complete count: %q", view)
+	}
+}
+
+// TestFinalSummaryReturnsCompletionContent confirms FinalSummary returns the
+// per-file results and overall summary for a completed model.
+func TestFinalSummaryReturnsCompletionContent(t *testing.T) {
+	m := NewModel([]string{"a.wav", "b.wav"})
+
+	updated, _ := m.Update(ProgressMsg{FileIndex: 0, Pass: processor.PassProcessing, Progress: 0.5, Level: -12})
+	m = updated.(Model)
+	updated, _ = m.Update(FileCompleteMsg{FileIndex: 0, OutputPath: "a-out.wav", InputLUFS: -23.0, OutputLUFS: -16.0, NoiseFloor: 12.0})
+	m = updated.(Model)
+	updated, _ = m.Update(FileCompleteMsg{FileIndex: 1, OutputPath: "b-out.wav", InputLUFS: -20.0, OutputLUFS: -16.0, NoiseFloor: 8.0})
+	m = updated.(Model)
+	m.Done = true
+
+	summary := FinalSummary(m)
+
+	if !strings.Contains(summary, "Processing Complete") {
+		t.Errorf("summary missing completion header: %q", summary)
+	}
+	if !strings.Contains(summary, "a-out.wav") || !strings.Contains(summary, "b-out.wav") {
+		t.Errorf("summary missing per-file results: %q", summary)
+	}
+	if !strings.Contains(summary, "-16.0 LUFS") {
+		t.Errorf("summary missing output LUFS: %q", summary)
+	}
+	if !strings.Contains(summary, "-16 LUFS and level-matched") {
+		t.Errorf("summary missing overall footer: %q", summary)
+	}
+}

--- a/internal/ui/view_layout_test.go
+++ b/internal/ui/view_layout_test.go
@@ -120,31 +120,147 @@ func TestProcessingViewOverallProgressContent(t *testing.T) {
 	}
 }
 
-// TestFinalSummaryReturnsCompletionContent confirms FinalSummary returns the
-// per-file results and overall summary for a completed model.
+// TestFinalSummaryReturnsCompletionContent confirms FinalSummary renders the
+// title, the overall-progress status box, and a done box per completed file,
+// with the old green banner and Audacity lines removed.
 func TestFinalSummaryReturnsCompletionContent(t *testing.T) {
 	m := NewModel([]string{"a.wav", "b.wav"})
 
 	updated, _ := m.Update(ProgressMsg{FileIndex: 0, Pass: processor.PassProcessing, Progress: 0.5, Level: -12})
 	m = updated.(Model)
-	updated, _ = m.Update(FileCompleteMsg{FileIndex: 0, OutputPath: "a-out.wav", InputLUFS: -23.0, OutputLUFS: -16.0, NoiseFloor: 12.0})
+	updated, _ = m.Update(FileCompleteMsg{
+		FileIndex: 0, OutputPath: "a-out.wav", InputLUFS: -30.9, OutputLUFS: -15.9, FinalNoiseFloor: -80.0,
+		Quality: processor.QualityScore{Stars: 4, Label: "Great"},
+	})
 	m = updated.(Model)
-	updated, _ = m.Update(FileCompleteMsg{FileIndex: 1, OutputPath: "b-out.wav", InputLUFS: -20.0, OutputLUFS: -16.0, NoiseFloor: 8.0})
+	updated, _ = m.Update(FileCompleteMsg{
+		FileIndex: 1, OutputPath: "b-out.wav", InputLUFS: -20.0, OutputLUFS: -16.0, FinalNoiseFloor: -65.0,
+		Quality: processor.QualityScore{Stars: 5, Label: "Excellent"},
+	})
 	m = updated.(Model)
 	m.Done = true
 
-	summary := FinalSummary(m)
+	summary := ansi.Strip(FinalSummary(m))
 
-	if !strings.Contains(summary, "Processing Complete") {
-		t.Errorf("summary missing completion header: %q", summary)
+	// Title and overall-progress status box appear, matching the live view.
+	if !strings.Contains(summary, "Jivetalking") {
+		t.Errorf("summary missing title: %q", summary)
 	}
+	if !strings.Contains(summary, "2 files") || !strings.Contains(summary, "complete") {
+		t.Errorf("summary missing overall-progress status box: %q", summary)
+	}
+
+	// Per-file done boxes.
 	if !strings.Contains(summary, "a-out.wav") || !strings.Contains(summary, "b-out.wav") {
 		t.Errorf("summary missing per-file results: %q", summary)
 	}
-	if !strings.Contains(summary, "-16.0 LUFS") {
-		t.Errorf("summary missing output LUFS: %q", summary)
+
+	// Removed strings must be gone.
+	for _, gone := range []string{"Processing Complete", "Audacity", "normalized to -16", "level-matched"} {
+		if strings.Contains(summary, gone) {
+			t.Errorf("summary still contains removed string %q: %q", gone, summary)
+		}
 	}
-	if !strings.Contains(summary, "-16 LUFS and level-matched") {
-		t.Errorf("summary missing overall footer: %q", summary)
+}
+
+// TestDoneBoxRendersIndigoLabelledRows confirms a completed file renders as an
+// indigo-bordered box with the three labelled rows (Loudness/Noise/Quality), the
+// ㏈ glyph, the signed Δ, and the stars + word label.
+func TestDoneBoxRendersIndigoLabelledRows(t *testing.T) {
+	file := FileProgress{
+		InputPath:       "LMP-81-mark.flac",
+		OutputPath:      "LMP-81-mark-LUFS-16-processed.flac",
+		Status:          StatusComplete,
+		InputLUFS:       -30.9,
+		OutputLUFS:      -15.9,
+		FinalNoiseFloor: -80.0,
+		Quality:         processor.QualityScore{Stars: 4, Label: "Excellent"},
+	}
+
+	raw := renderDoneBox(file)
+	plain := ansi.Strip(raw)
+
+	// Indigo border (#6366F1 -> 99,102,241) must colour the box.
+	if !slices.Contains(headerColors(raw), [3]int{99, 102, 241}) {
+		t.Errorf("done box border is not indigo (99,102,241):\n%q", raw)
+	}
+
+	// Labelled rows.
+	for _, label := range []string{"Loudness", "Noise floor", "Quality"} {
+		if !strings.Contains(plain, label) {
+			t.Errorf("done box missing %q row:\n%s", label, plain)
+		}
+	}
+
+	// Loudness row: Input → Output with ㏈ glyph and signed Δ.
+	if !strings.Contains(plain, "-30.9 → -15.9 ㏈") {
+		t.Errorf("done box missing loudness values:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Δ +15.0") {
+		t.Errorf("done box missing signed Δ:\n%s", plain)
+	}
+
+	// Noise row shows the output noise floor in dBFS, not an amount "reduced".
+	if !strings.Contains(plain, "-80 ㏈") {
+		t.Errorf("done box missing noise floor value:\n%s", plain)
+	}
+	if strings.Contains(plain, "reduced") {
+		t.Errorf("done box still labels the noise floor as 'reduced':\n%s", plain)
+	}
+
+	// Quality row: filled + empty stars and the word label.
+	if !strings.Contains(plain, "★★★★☆") {
+		t.Errorf("done box missing 4-of-5 star bar:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Excellent") {
+		t.Errorf("done box missing quality label:\n%s", plain)
+	}
+
+	// No leftover hardcoded full-star bar.
+	if strings.Contains(plain, "★★★★★") {
+		t.Errorf("done box renders hardcoded 5 stars for a 4-star file:\n%s", plain)
+	}
+}
+
+// TestDoneBoxNoiseAndStarsMoveTogether confirms the rendered Noise floor metric
+// and the star count point the same direction: a cleaner file (lower dBFS floor)
+// must show both a more-negative floor and at least as many stars as a noisier
+// file. This locks the display against the prior contradiction where the better
+// number sat next to fewer stars.
+func TestDoneBoxNoiseAndStarsMoveTogether(t *testing.T) {
+	clean := FileProgress{
+		InputPath:       "clean.flac",
+		OutputPath:      "clean-out.flac",
+		Status:          StatusComplete,
+		OutputLUFS:      -16.0,
+		FinalNoiseFloor: -80.0,
+		Quality:         processor.QualityScore{Stars: 5, Label: "Excellent"},
+	}
+	noisy := FileProgress{
+		InputPath:       "noisy.flac",
+		OutputPath:      "noisy-out.flac",
+		Status:          StatusComplete,
+		OutputLUFS:      -16.0,
+		FinalNoiseFloor: -55.0,
+		Quality:         processor.QualityScore{Stars: 4, Label: "Great"},
+	}
+
+	cleanPlain := ansi.Strip(renderDoneBox(clean))
+	noisyPlain := ansi.Strip(renderDoneBox(noisy))
+
+	if !strings.Contains(cleanPlain, "-80 ㏈") {
+		t.Errorf("clean done box missing -80 floor:\n%s", cleanPlain)
+	}
+	if !strings.Contains(noisyPlain, "-55 ㏈") {
+		t.Errorf("noisy done box missing -55 floor:\n%s", noisyPlain)
+	}
+
+	// Cleaner file: more-negative floor AND more stars. The number and the stars
+	// move together, so the display can never contradict the score.
+	if !strings.Contains(cleanPlain, "★★★★★") {
+		t.Errorf("clean (cleaner floor) should show 5 stars:\n%s", cleanPlain)
+	}
+	if !strings.Contains(noisyPlain, "★★★★☆") {
+		t.Errorf("noisy (higher floor) should show 4 stars:\n%s", noisyPlain)
 	}
 }

--- a/internal/ui/view_layout_test.go
+++ b/internal/ui/view_layout_test.go
@@ -1,22 +1,78 @@
 package ui
 
 import (
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
 // TestHeaderHasNoSubtitle confirms the redundant "Processing N file(s)"
-// subtitle was removed from the header while the title stays.
+// subtitle was removed from the header while the title stays. The per-letter
+// gradient inserts ANSI escapes between letters, so strip them before matching
+// the contiguous title word.
 func TestHeaderHasNoSubtitle(t *testing.T) {
 	header := renderHeader()
+	plain := ansi.Strip(header)
 
-	if !strings.Contains(header, "Jivetalking") {
+	if !strings.Contains(plain, "Jivetalking") {
 		t.Errorf("header missing title: %q", header)
 	}
-	if strings.Contains(header, "file(s)") {
+	if strings.Contains(plain, "file(s)") {
 		t.Errorf("header still contains subtitle: %q", header)
+	}
+}
+
+// headerColors extracts the distinct RGB foreground triples from the styled
+// header. Title letters carry a bold prefix (1;38;2;r;g;b), so match the
+// 38;2;r;g;b foreground regardless of any leading SGR attributes.
+func headerColors(s string) [][3]int {
+	var out [][3]int
+	seen := map[[3]int]bool{}
+	for seg := range strings.SplitSeq(s, "\x1b[") {
+		_, after, found := strings.Cut(seg, "38;2;")
+		if !found {
+			continue
+		}
+		body, _, _ := strings.Cut(after, "m")
+		parts := strings.Split(body, ";")
+		if len(parts) < 3 {
+			continue
+		}
+		var c [3]int
+		ok := true
+		for i := range 3 {
+			n, err := strconv.Atoi(parts[i])
+			if err != nil {
+				ok = false
+				break
+			}
+			c[i] = n
+		}
+		if ok && !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestHeaderIsGradient confirms the title word is drawn as a multi-colour
+// per-letter gradient (more than one distinct foreground across the letters)
+// and never uses the brand red foreground.
+func TestHeaderIsGradient(t *testing.T) {
+	header := renderHeader()
+
+	colors := headerColors(header)
+	if len(colors) < 2 {
+		t.Errorf("expected a multi-colour header gradient, got %d colours: %v", len(colors), colors)
+	}
+	// Brand red (#A40000 -> 164,0,0) must not colour the title.
+	if slices.Contains(colors, [3]int{164, 0, 0}) {
+		t.Errorf("header contains brand red 164,0,0:\n%q", header)
 	}
 }
 
@@ -27,7 +83,7 @@ func TestProcessingViewSectionOrder(t *testing.T) {
 	m.Width = 120
 	m.Height = 40
 
-	view := renderProcessingView(m)
+	view := ansi.Strip(renderProcessingView(m))
 
 	if strings.Contains(view, "file(s)") {
 		t.Errorf("processing view still contains subtitle: %q", view)

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -67,12 +67,7 @@ func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedPr
 
 	switch file.Status {
 	case StatusComplete:
-		// 🗸 completed file with summary
-		icon := lipgloss.NewStyle().Foreground(cli.ColorGreen).Render("🗸")
-		delta := file.OutputLUFS - file.InputLUFS
-		summary := fmt.Sprintf("Input: %.1f LUFS | Output: %.1f LUFS | Δ %+.1f dB",
-			file.InputLUFS, file.OutputLUFS, delta)
-		return fmt.Sprintf(" %s %s → %s\n   %s", icon, fileName, filepath.Base(file.OutputPath), summary)
+		return renderDoneBox(file)
 
 	case StatusAnalyzing, StatusProcessing, StatusNormalising:
 		// active file with detailed progress
@@ -344,49 +339,96 @@ func FinalSummary(m Model) string {
 	return renderCompletionSummary(m)
 }
 
-// renderCompletionSummary renders the final completion summary
+// renderCompletionSummary renders the persisted completion view: the same title
+// and overall-progress status box as the live view, followed by the stack of
+// indigo done boxes. Completed files render through renderDoneBox so they look
+// identical to the live processing view at completion.
 func renderCompletionSummary(m Model) string {
 	var b strings.Builder
 
-	// Completion header
-	header := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(cli.ColorGreen).
-		Render("✨ Processing Complete!")
-	b.WriteString(header)
+	b.WriteString(renderHeader())
 	b.WriteString("\n\n")
 
-	// Summary for each file
-	for _, file := range m.Files {
-		if file.Status == StatusComplete {
-			b.WriteString(renderCompletedFile(file))
+	b.WriteString(renderOverallProgress(m))
+	b.WriteString("\n\n")
+
+	for i := range m.Files {
+		if m.Files[i].Status == StatusError {
+			b.WriteString(renderFileEntry(m.Files[i], m.progress, 0, 0, 0))
+			b.WriteString("\n")
+			continue
+		}
+		if m.Files[i].Status == StatusComplete {
+			b.WriteString(renderDoneBox(m.Files[i]))
 			b.WriteString("\n")
 		}
 	}
 
-	// Overall summary
-	b.WriteString("\n")
-	b.WriteString(strings.Repeat("─", 60))
-	b.WriteString("\n")
-	b.WriteString("All files normalized to -16 LUFS and level-matched ✓\n")
-	b.WriteString("Ready for import into Audacity - no additional processing needed!\n")
-
 	return b.String()
 }
 
-// renderCompletedFile renders a summary for a completed file
-func renderCompletedFile(file FileProgress) string {
+// doneBoxLabelWidth is the column width reserved for the leading label in each
+// done-box row so the values align in a column. Wide enough for the longest
+// label ("Noise floor" = 11 cols) plus a trailing space.
+const doneBoxLabelWidth = 12
+
+// renderDoneBox renders a completed file as a filename line above an
+// indigo-bordered box with three labelled rows: Loudness, Noise, and Quality.
+// Shared by the live processing view (StatusComplete) and the persisted final
+// summary so completed files look identical in both. The box matches the active
+// processing box (RoundedBorder, Padding(0,1), meterWidth inner width) but uses
+// an indigo border to mark "done" against the active sky-blue.
+func renderDoneBox(file FileProgress) string {
 	fileName := filepath.Base(file.InputPath)
 	outputName := filepath.Base(file.OutputPath)
 
-	icon := lipgloss.NewStyle().Foreground(cli.ColorGreen).Render("✓")
+	icon := lipgloss.NewStyle().Foreground(cli.ColorGreen).Render("🗸")
+	heading := fmt.Sprintf(" %s %s → %s", icon, fileName, outputName)
 
-	quality := "★★★★★" // Always 5 stars
+	labelStyle := lipgloss.NewStyle().Foreground(cli.ColorMuted).Width(doneBoxLabelWidth)
+	valueStyle := lipgloss.NewStyle().Foreground(cli.ColorText)
+	starStyle := lipgloss.NewStyle().Foreground(cli.ColorOrange)
 
-	return fmt.Sprintf(" %s %s → %s\n"+
-		"   Before: %.1f LUFS | After: %.1f LUFS | Quality: %s\n"+
-		"   Noise Reduced: %.0f dB",
-		icon, fileName, outputName,
-		file.InputLUFS, file.OutputLUFS, quality,
-		file.NoiseFloor)
+	// Match the active processing box frame width: meterWidth content + Padding(0,1)
+	// (2 cols) + RoundedBorder (2 cols) = meterWidth + 4 total columns.
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(cli.ColorIndigo).
+		Padding(0, 1).
+		Width(meterWidth + 4)
+
+	var content strings.Builder
+
+	// Loudness row: Input → Output ㏈ with signed Δ.
+	delta := file.OutputLUFS - file.InputLUFS
+	loudnessValue := fmt.Sprintf("%.1f → %.1f ㏈  Δ %+.1f",
+		file.InputLUFS, file.OutputLUFS, delta)
+	fmt.Fprintf(&content, "%s%s\n",
+		labelStyle.Render("Loudness"), valueStyle.Render(loudnessValue))
+
+	// Noise row: the output room-tone noise floor in dBFS. A lower (more negative)
+	// floor is cleaner, the same direction the quality stars move, so the number and
+	// the stars stay consistent. This is a floor, not an amount removed, so it is
+	// labelled "Noise floor", never "reduced".
+	noiseValue := fmt.Sprintf("%.0f ㏈", file.FinalNoiseFloor)
+	fmt.Fprintf(&content, "%s%s\n",
+		labelStyle.Render("Noise floor"), valueStyle.Render(noiseValue))
+
+	// Quality row: objective stars + word label.
+	stars := starStyle.Render(qualityStars(file.Quality.Stars))
+	fmt.Fprintf(&content, "%s%s  %s",
+		labelStyle.Render("Quality"), stars, valueStyle.Render(file.Quality.Label))
+
+	return heading + "\n" + box.Render(content.String())
+}
+
+// qualityStars renders an n-of-5 star bar as filled ★ followed by empty ☆.
+func qualityStars(n int) string {
+	if n < 0 {
+		n = 0
+	}
+	if n > 5 {
+		n = 5
+	}
+	return strings.Repeat("★", n) + strings.Repeat("☆", 5-n)
 }

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -50,13 +50,15 @@ func renderFileQueue(m Model, prog progress.Model) string {
 	var b strings.Builder
 
 	for i := range m.Files {
-		// Use the eased meter position for the active level display; fall back
-		// to the raw level when no meter slot exists.
+		// Use the eased meter and progress positions for the active display;
+		// fall back to the raw values when no spring slot exists.
 		easedLevel := m.Files[i].CurrentLevel
+		easedProgress := m.Files[i].Progress
 		if i < len(m.meters) {
 			easedLevel = m.meters[i].pos
+			easedProgress = m.meters[i].progPos
 		}
-		b.WriteString(renderFileEntry(m.Files[i], prog, easedLevel))
+		b.WriteString(renderFileEntry(m.Files[i], prog, easedLevel, easedProgress))
 		b.WriteString("\n")
 	}
 
@@ -64,7 +66,7 @@ func renderFileQueue(m Model, prog progress.Model) string {
 }
 
 // renderFileEntry renders a single file entry in the queue
-func renderFileEntry(file FileProgress, prog progress.Model, easedLevel float64) string {
+func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedProgress float64) string {
 	fileName := filepath.Base(file.InputPath)
 
 	switch file.Status {
@@ -81,7 +83,7 @@ func renderFileEntry(file FileProgress, prog progress.Model, easedLevel float64)
 		icon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("🞽")
 		return fmt.Sprintf(" %s %s\n%s",
 			icon, fileName,
-			renderFileDetails(file, prog, easedLevel))
+			renderFileDetails(file, prog, easedLevel, easedProgress))
 
 	case StatusError:
 		// ✗ failed file
@@ -97,7 +99,7 @@ func renderFileEntry(file FileProgress, prog progress.Model, easedLevel float64)
 
 // renderFileDetails renders detailed progress for the active file. easedLevel is
 // the spring-smoothed audio level used for the meter display.
-func renderFileDetails(file FileProgress, prog progress.Model, easedLevel float64) string {
+func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, easedProgress float64) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cli.ColorRed).
@@ -121,8 +123,8 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel float6
 	}
 	fmt.Fprintf(&content, "Pass %d/4: %s\n", file.CurrentPass, passName)
 
-	// Progress bar
-	content.WriteString(prog.ViewAs(file.Progress))
+	// Progress bar (spring-eased fill for smooth motion)
+	content.WriteString(prog.ViewAs(easedProgress))
 	content.WriteString("\n\n")
 
 	// Time estimates
@@ -152,8 +154,8 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
 
 	// Create visual meter
 	// dB range: -60 dB (silence) to 0 dB (maximum)
-	// Map to 40-character width meter
-	width := 40
+	// Map to meterWidth-character width meter
+	width := meterWidth
 	minDB := -60.0
 	maxDB := 0.0
 

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -204,8 +204,11 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	// Calculate fill position for current level
 	currentPos := max(0, min(int(((currentLevel-minDB)/(maxDB-minDB))*float64(width)), width))
 
-	// Calculate position for peak marker
-	peakPos := max(0, min(int(((peakLevel-minDB)/(maxDB-minDB))*float64(width)), width))
+	// Calculate column for peak marker. Unlike currentPos (an exclusive fill
+	// count, so 0..width), this is a 0-based column index, so it must clamp to
+	// width-1: at peakLevel == maxDB the raw ratio is 1.0 and would otherwise
+	// place the marker and elbow one cell beyond the bar.
+	peakPos := max(0, min(int(((peakLevel-minDB)/(maxDB-minDB))*float64(width)), width-1))
 
 	// Build a continuous green→yellow→orange→red colour ramp once per render.
 	// Real VU meters keep green dominant across the low range and compress the

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -2,10 +2,13 @@ package ui
 
 import (
 	"fmt"
+	"image/color"
 	"path/filepath"
 	"strings"
 
+	"charm.land/bubbles/v2/progress"
 	"charm.land/lipgloss/v2"
+	"github.com/linuxmatters/jivetalking/internal/cli"
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
@@ -18,7 +21,7 @@ func renderProcessingView(m Model) string {
 	b.WriteString("\n\n")
 
 	// File queue
-	b.WriteString(renderFileQueue(m))
+	b.WriteString(renderFileQueue(m, m.progress))
 	b.WriteString("\n\n")
 
 	// Overall progress
@@ -31,11 +34,11 @@ func renderProcessingView(m Model) string {
 func renderHeader(m Model) string {
 	title := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#A40000")).
+		Foreground(cli.ColorRed).
 		Render("Jivetalking 🕺")
 
 	subtitle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#888888")).
+		Foreground(cli.ColorMuted).
 		Italic(true).
 		Render(fmt.Sprintf("Processing %d file(s)", m.TotalFiles))
 
@@ -43,11 +46,17 @@ func renderHeader(m Model) string {
 }
 
 // renderFileQueue renders the list of files with their status
-func renderFileQueue(m Model) string {
+func renderFileQueue(m Model, prog progress.Model) string {
 	var b strings.Builder
 
-	for _, file := range m.Files {
-		b.WriteString(renderFileEntry(file))
+	for i := range m.Files {
+		// Use the eased meter position for the active level display; fall back
+		// to the raw level when no meter slot exists.
+		easedLevel := m.Files[i].CurrentLevel
+		if i < len(m.meters) {
+			easedLevel = m.meters[i].pos
+		}
+		b.WriteString(renderFileEntry(m.Files[i], prog, easedLevel))
 		b.WriteString("\n")
 	}
 
@@ -55,13 +64,13 @@ func renderFileQueue(m Model) string {
 }
 
 // renderFileEntry renders a single file entry in the queue
-func renderFileEntry(file FileProgress) string {
+func renderFileEntry(file FileProgress, prog progress.Model, easedLevel float64) string {
 	fileName := filepath.Base(file.InputPath)
 
 	switch file.Status {
 	case StatusComplete:
 		// 🗸 completed file with summary
-		icon := lipgloss.NewStyle().Foreground(lipgloss.Color("#00AA00")).Render("🗸")
+		icon := lipgloss.NewStyle().Foreground(cli.ColorGreen).Render("🗸")
 		delta := file.OutputLUFS - file.InputLUFS
 		summary := fmt.Sprintf("Input: %.1f LUFS | Output: %.1f LUFS | Δ %+.1f dB",
 			file.InputLUFS, file.OutputLUFS, delta)
@@ -69,28 +78,29 @@ func renderFileEntry(file FileProgress) string {
 
 	case StatusAnalyzing, StatusProcessing, StatusNormalising:
 		// 🞽 active file with detailed progress
-		icon := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500")).Render("🞽")
+		icon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("🞽")
 		return fmt.Sprintf(" %s %s\n%s",
 			icon, fileName,
-			renderFileDetails(file))
+			renderFileDetails(file, prog, easedLevel))
 
 	case StatusError:
 		// ✗ failed file
-		icon := lipgloss.NewStyle().Foreground(lipgloss.Color("#A40000")).Render("✗")
+		icon := lipgloss.NewStyle().Foreground(cli.ColorRed).Render("✗")
 		return fmt.Sprintf(" %s %s\n   Error: %v", icon, fileName, file.Error)
 
 	default:
 		// ⧗ queued file
-		icon := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888")).Render("⧗")
+		icon := lipgloss.NewStyle().Foreground(cli.ColorMuted).Render("⧗")
 		return fmt.Sprintf(" %s %s\n   Queued...", icon, fileName)
 	}
 }
 
-// renderFileDetails renders detailed progress for the active file
-func renderFileDetails(file FileProgress) string {
+// renderFileDetails renders detailed progress for the active file. easedLevel is
+// the spring-smoothed audio level used for the meter display.
+func renderFileDetails(file FileProgress, prog progress.Model, easedLevel float64) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#A40000")).
+		BorderForeground(cli.ColorRed).
 		Padding(0, 1)
 
 	var content strings.Builder
@@ -112,7 +122,7 @@ func renderFileDetails(file FileProgress) string {
 	fmt.Fprintf(&content, "Pass %d/4: %s\n", file.CurrentPass, passName)
 
 	// Progress bar
-	content.WriteString(renderProgressBar(file.Progress, 40))
+	content.WriteString(prog.ViewAs(file.Progress))
 	content.WriteString("\n\n")
 
 	// Time estimates
@@ -123,24 +133,14 @@ func renderFileDetails(file FileProgress) string {
 	}
 	fmt.Fprintf(&content, "✇ Elapsed: %.1fs | Remaining: ~%.1fs\n", elapsed, remaining)
 
-	// Audio level visualization
+	// Audio level visualization. The displayed level eases toward the target
+	// via the spring; the peak marker stays driven by the measured peak.
 	if file.CurrentLevel != 0 {
 		content.WriteString("\n")
-		content.WriteString(renderAudioLevelMeter(file.CurrentLevel, file.PeakLevel))
+		content.WriteString(renderAudioLevelMeter(easedLevel, file.PeakLevel))
 	}
 
 	return box.Render(content.String())
-}
-
-// renderProgressBar renders a progress bar
-func renderProgressBar(progress float64, width int) string {
-	filled := int(progress * float64(width))
-	empty := width - filled
-
-	bar := strings.Repeat("█", filled) + strings.Repeat("░", empty)
-	percentage := int(progress * 100)
-
-	return fmt.Sprintf("%s %d%%", bar, percentage)
 }
 
 // renderAudioLevelMeter renders a live audio level meter with dB visualization
@@ -170,44 +170,58 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
 	greenZone := int((((-16.0) - minDB) / (maxDB - minDB)) * float64(width))
 	orangeZone := int((((-6.0) - minDB) / (maxDB - minDB)) * float64(width))
 
-	// Build meter character by character with appropriate colors
-	// Using ANSI color codes directly to avoid lipgloss width calculation issues
-	greenColor := "\033[38;2;0;170;0m"    // #00AA00
-	orangeColor := "\033[38;2;255;165;0m" // #FFA500
-	redColor := "\033[38;2;164;0;0m"      // #A40000
-	resetColor := "\033[0m"
+	// Zone colours sourced from the centralised palette.
+	greenColor := cli.ColorGreen
+	orangeColor := cli.ColorOrange
+	redColor := cli.ColorRed
 
-	for i := range width {
-		// Determine color zone
-		var color string
+	zoneColor := func(i int) color.Color {
 		switch {
 		case i < greenZone:
-			color = greenColor
+			return greenColor
 		case i < orangeZone:
-			color = orangeColor
+			return orangeColor
 		default:
-			color = redColor
+			return redColor
 		}
+	}
 
-		// Determine character
-		var char rune
+	meterChar := func(i int) rune {
 		switch {
 		case i == peakPos && i > currentPos:
 			// Show peak marker only if it's ahead of current position
-			char = '|'
+			return '|'
 		case i < currentPos:
-			char = '▓' // Filled
+			return '▓' // Filled
 		case i == currentPos && currentPos == peakPos:
 			// When current level is at peak, show filled bar
-			char = '▓'
+			return '▓'
 		default:
-			char = '░' // Empty
+			return '░' // Empty
 		}
-
-		b.WriteString(color)
-		b.WriteRune(char)
 	}
-	b.WriteString(resetColor)
+
+	// Build contiguous same-colour runs and style each as one segment so
+	// lipgloss emits a single colour sequence per run rather than per rune.
+	var run strings.Builder
+	var runColor color.Color
+	flush := func() {
+		if run.Len() == 0 {
+			return
+		}
+		b.WriteString(lipgloss.NewStyle().Foreground(runColor).Render(run.String()))
+		run.Reset()
+	}
+
+	for i := range width {
+		color := zoneColor(i)
+		if run.Len() > 0 && color != runColor {
+			flush()
+		}
+		runColor = color
+		run.WriteRune(meterChar(i))
+	}
+	flush()
 
 	return b.String()
 }
@@ -216,7 +230,7 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
 func renderOverallProgress(m Model) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#888888")).
+		BorderForeground(cli.ColorMuted).
 		Padding(0, 1)
 
 	content := fmt.Sprintf("Processing %d files, %d complete, %d failed",
@@ -232,7 +246,7 @@ func renderCompletionSummary(m Model) string {
 	// Completion header
 	header := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#00AA00")).
+		Foreground(cli.ColorGreen).
 		Render("✨ Processing Complete!")
 	b.WriteString(header)
 	b.WriteString("\n\n")
@@ -260,7 +274,7 @@ func renderCompletedFile(file FileProgress) string {
 	fileName := filepath.Base(file.InputPath)
 	outputName := filepath.Base(file.OutputPath)
 
-	icon := lipgloss.NewStyle().Foreground(lipgloss.Color("#00AA00")).Render("✓")
+	icon := lipgloss.NewStyle().Foreground(cli.ColorGreen).Render("✓")
 
 	quality := "★★★★★" // Always 5 stars
 

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -129,13 +129,10 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 	content.WriteString(prog.ViewAs(easedProgress))
 	content.WriteString("\n\n")
 
-	// Time estimates
-	elapsed := file.ElapsedTime.Seconds()
-	var remaining float64
-	if file.Progress > 0 {
-		remaining = (elapsed / file.Progress) - elapsed
-	}
-	fmt.Fprintf(&content, "Time: %.1fs | ETA: ~%.1fs\n", elapsed, remaining)
+	// Time block: elapsed clock, mini dot timeline, projected total clock, and a
+	// realtime-speed badge.
+	content.WriteString(renderTimeline(file))
+	content.WriteByte('\n')
 
 	// Audio level visualization. The displayed level eases toward the target
 	// via the spring; the peak marker stays driven by the measured peak.
@@ -147,6 +144,52 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 	return box.Render(content.String())
 }
 
+// timelineWidth is the cell count of the mini dot timeline in the Time block.
+// Kept small (8) so the whole "⏱ MM:SS ▰… MM:SS · ⚡ N×" line stays within the
+// meterWidth-cell box inner width.
+const timelineWidth = 8
+
+// renderTimeline renders the Time block: an elapsed clock, a mini dot timeline
+// filled to the pass progress, a projected total-pass clock, and a realtime
+// speed badge. The whole line stays within the box inner width (~meterWidth).
+func renderTimeline(file FileProgress) string {
+	elapsed := file.ElapsedTime
+	elapsedSecs := elapsed.Seconds()
+
+	// Projected total pass time = elapsed / progress (consistent with the prior
+	// ETA derivation). Show placeholder until progress is meaningful.
+	rightClock := "--:--"
+	if file.Progress > 0 {
+		rightClock = formatElapsed(time.Duration(elapsedSecs / file.Progress * float64(time.Second)))
+	}
+
+	// Mini dot timeline filled to progress. Filled dots muted, empty dots use the
+	// meter empty-track colour, so the timeline reads as secondary to the main
+	// gradient bar above.
+	filled := int(file.Progress*float64(timelineWidth) + 0.5)
+	filled = max(0, min(filled, timelineWidth))
+	filledStyle := lipgloss.NewStyle().Foreground(cli.ColorMuted)
+	emptyStyle := lipgloss.NewStyle().Foreground(cli.ColorFill)
+	timeline := filledStyle.Render(strings.Repeat("▰", filled)) +
+		emptyStyle.Render(strings.Repeat("▱", timelineWidth-filled))
+
+	// Realtime speed badge: (progress × duration) / elapsed. Guard against
+	// start-up garbage and missing duration.
+	badge := "⚡ —×"
+	if file.Duration > 0 && file.Progress > 0.02 && elapsedSecs > 0.3 {
+		rt := (file.Progress * file.Duration) / elapsedSecs
+		badge = fmt.Sprintf("⚡ %.1f×", rt)
+	}
+
+	muted := lipgloss.NewStyle().Foreground(cli.ColorMuted)
+	return fmt.Sprintf("⏱ %s %s %s  %s  %s",
+		formatElapsed(elapsed),
+		timeline,
+		rightClock,
+		muted.Render("·"),
+		muted.Render(badge))
+}
+
 // renderAudioLevelMeter renders a live audio level meter with dB visualization.
 // elapsed drives the gentle pulse of the peak-hold marker; it is the file's
 // running elapsed time, advanced once per meter tick, so no second tick loop is
@@ -154,8 +197,8 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duration) string {
 	var b strings.Builder
 
-	// Display current and peak levels
-	fmt.Fprintf(&b, "Level: %.1f ㏈ | Peak: %.1f ㏈\n", currentLevel, peakLevel)
+	// Display current level only; the peak value is tethered to its marker below.
+	fmt.Fprintf(&b, "Level: %.1f ㏈\n", currentLevel)
 
 	// Create visual meter
 	// dB range: -70 dB (silence) to 0 dB (maximum)
@@ -218,13 +261,37 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	}
 	flush()
 
-	// Peak-hold marker: a coloured triangle on its own line beneath the bar,
-	// aligned to the peak column. Skip it when there is no meaningful peak yet
-	// (peak still at the silence floor), so no stray triangle sits at column 0.
+	// Peak-hold marker: a pulsing triangle on its own line beneath the bar,
+	// aligned to the peak column, plus an elbow connector line that tethers the
+	// peak value to the marker. Skip both when there is no meaningful peak yet
+	// (peak still at the silence floor), so no stray marker sits at column 0.
 	if peakLevel > minDB {
+		pulseColor := peakMarkerColor(elapsed)
+		elbowStyle := lipgloss.NewStyle().Foreground(pulseColor)
+		valueStyle := lipgloss.NewStyle().Foreground(cli.ColorOrange)
+		value := fmt.Sprintf("%.1f ㏈", peakLevel)
+
 		b.WriteByte('\n')
 		b.WriteString(strings.Repeat(" ", peakPos))
-		b.WriteString(lipgloss.NewStyle().Foreground(peakMarkerColor(elapsed)).Render("▲"))
+		b.WriteString(elbowStyle.Render("▲"))
+
+		b.WriteByte('\n')
+		// Default: elbow drops to the right (└ value). When the right-elbow form
+		// would overflow the bar, flip to the left (value ┘) so the label stays
+		// within meterWidth.
+		if peakPos+len(" "+value)+1 <= width {
+			b.WriteString(strings.Repeat(" ", peakPos))
+			b.WriteString(elbowStyle.Render("└"))
+			b.WriteByte(' ')
+			b.WriteString(valueStyle.Render(value))
+		} else {
+			// value then a right-elbow ┘ ending under the peak column.
+			lead := max(peakPos-(len(value)+1), 0)
+			b.WriteString(strings.Repeat(" ", lead))
+			b.WriteString(valueStyle.Render(value))
+			b.WriteByte(' ')
+			b.WriteString(elbowStyle.Render("┘"))
+		}
 	}
 
 	return b.String()

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -18,33 +18,28 @@ import (
 func renderProcessingView(m Model) string {
 	var b strings.Builder
 
-	// Header
-	b.WriteString(renderHeader(m))
+	// Header (title only)
+	b.WriteString(renderHeader())
+	b.WriteString("\n\n")
+
+	// Overall progress box, directly under the title
+	b.WriteString(renderOverallProgress(m))
 	b.WriteString("\n\n")
 
 	// File queue
 	b.WriteString(renderFileQueue(m, m.progress))
-	b.WriteString("\n\n")
-
-	// Overall progress
-	b.WriteString(renderOverallProgress(m))
 
 	return b.String()
 }
 
 // renderHeader renders the application header
-func renderHeader(m Model) string {
+func renderHeader() string {
 	title := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(cli.ColorRed).
 		Render("Jivetalking 🕺")
 
-	subtitle := lipgloss.NewStyle().
-		Foreground(cli.ColorMuted).
-		Italic(true).
-		Render(fmt.Sprintf("Processing %d file(s)", m.TotalFiles))
-
-	return title + "\n" + subtitle
+	return title
 }
 
 // renderFileQueue renders the list of files with their status
@@ -145,7 +140,7 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 }
 
 // timelineWidth is the cell count of the mini dot timeline in the Time block.
-// Kept small (8) so the whole "⏱ MM:SS ▰… MM:SS · ⚡ N×" line stays within the
+// Kept small (8) so the whole "MM:SS ▰… MM:SS · ⚡ N×" line stays within the
 // meterWidth-cell box inner width.
 const timelineWidth = 8
 
@@ -182,13 +177,17 @@ func renderTimeline(file FileProgress) string {
 	}
 
 	muted := lipgloss.NewStyle().Foreground(cli.ColorMuted)
-	return fmt.Sprintf("⏱ %s %s %s  %s  %s",
+	return fmt.Sprintf("%s %s %s  %s  %s",
 		formatElapsed(elapsed),
 		timeline,
 		rightClock,
 		muted.Render("·"),
 		muted.Render(badge))
 }
+
+// peakMarkerGlyph is the peak-hold marker drawn on its own line beneath the bar,
+// its point meeting the elbow corner directly below at the peak column.
+const peakMarkerGlyph = "🭯"
 
 // renderAudioLevelMeter renders a live audio level meter with dB visualization.
 // elapsed drives the gentle pulse of the peak-hold marker; it is the file's
@@ -261,10 +260,12 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	}
 	flush()
 
-	// Peak-hold marker: a pulsing triangle on its own line beneath the bar,
-	// aligned to the peak column, plus an elbow connector line that tethers the
-	// peak value to the marker. Skip both when there is no meaningful peak yet
-	// (peak still at the silence floor), so no stray marker sits at column 0.
+	// Peak-hold marker: a pulsing 🭯 on its own line beneath the bar, aligned to
+	// the peak column, plus an elbow connector line that tethers the peak value to
+	// the marker. Skip both when there is no meaningful peak yet (peak still at the
+	// silence floor), so no stray marker sits at column 0. Alignment uses
+	// lipgloss.Width (display columns), not byte length, so the wide ㏈ glyph in
+	// the value does not shift the elbow corner off the marker column.
 	if peakLevel > minDB {
 		pulseColor := peakMarkerColor(elapsed)
 		elbowStyle := lipgloss.NewStyle().Foreground(pulseColor)
@@ -273,20 +274,21 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 
 		b.WriteByte('\n')
 		b.WriteString(strings.Repeat(" ", peakPos))
-		b.WriteString(elbowStyle.Render("▲"))
-
+		b.WriteString(elbowStyle.Render(peakMarkerGlyph))
 		b.WriteByte('\n')
 		// Default: elbow drops to the right (└ value). When the right-elbow form
 		// would overflow the bar, flip to the left (value ┘) so the label stays
-		// within meterWidth.
-		if peakPos+len(" "+value)+1 <= width {
+		// within meterWidth. The right form renders as `<peakPos spaces>└ <value>`
+		// = peakPos + 1 (└) + 1 (space) + lipgloss.Width(value) columns.
+		if peakPos+lipgloss.Width(value)+2 <= width {
 			b.WriteString(strings.Repeat(" ", peakPos))
 			b.WriteString(elbowStyle.Render("└"))
 			b.WriteByte(' ')
 			b.WriteString(valueStyle.Render(value))
 		} else {
-			// value then a right-elbow ┘ ending under the peak column.
-			lead := max(peakPos-(len(value)+1), 0)
+			// value then a right-elbow ┘ ending under the peak column. The form is
+			// `<lead spaces><value> ┘`, so lead + width(value) + 1 == peakPos.
+			lead := max(peakPos-(lipgloss.Width(value)+1), 0)
 			b.WriteString(strings.Repeat(" ", lead))
 			b.WriteString(valueStyle.Render(value))
 			b.WriteByte(' ')
@@ -297,7 +299,7 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	return b.String()
 }
 
-// peakMarkerColor returns the peak-hold triangle colour for the current pulse
+// peakMarkerColor returns the peak-hold marker colour for the current pulse
 // phase. It oscillates gently between a deep orange and the full orange at about
 // 1.2 Hz, driven by elapsed wall-clock time so it reuses the existing meter tick
 // cadence. The interpolation runs straight in sRGB between two oranges so the
@@ -333,6 +335,13 @@ func renderOverallProgress(m Model) string {
 		m.TotalFiles, m.CompletedFiles, m.FailedFiles)
 
 	return box.Render(content)
+}
+
+// FinalSummary returns the completion-summary string for persisting to the
+// normal screen after the alt-screen program exits. Callers gate on Model.Done
+// so an early user quit does not print a misleading "complete" summary.
+func FinalSummary(m Model) string {
+	return renderCompletionSummary(m)
 }
 
 // renderCompletionSummary renders the final completion summary

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -3,8 +3,10 @@ package ui
 import (
 	"fmt"
 	"image/color"
+	"math"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/progress"
 	"charm.land/lipgloss/v2"
@@ -79,8 +81,8 @@ func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedPr
 		return fmt.Sprintf(" %s %s → %s\n   %s", icon, fileName, filepath.Base(file.OutputPath), summary)
 
 	case StatusAnalyzing, StatusProcessing, StatusNormalising:
-		// 🞽 active file with detailed progress
-		icon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("🞽")
+		// active file with detailed progress
+		icon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("∿")
 		return fmt.Sprintf(" %s %s\n%s",
 			icon, fileName,
 			renderFileDetails(file, prog, easedLevel, easedProgress))
@@ -102,7 +104,7 @@ func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedPr
 func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, easedProgress float64) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(cli.ColorRed).
+		BorderForeground(cli.ColorSkyBlue).
 		Padding(0, 1)
 
 	var content strings.Builder
@@ -133,30 +135,33 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 	if file.Progress > 0 {
 		remaining = (elapsed / file.Progress) - elapsed
 	}
-	fmt.Fprintf(&content, "✇ Elapsed: %.1fs | Remaining: ~%.1fs\n", elapsed, remaining)
+	fmt.Fprintf(&content, "Time: %.1fs | ETA: ~%.1fs\n", elapsed, remaining)
 
 	// Audio level visualization. The displayed level eases toward the target
 	// via the spring; the peak marker stays driven by the measured peak.
 	if file.CurrentLevel != 0 {
 		content.WriteString("\n")
-		content.WriteString(renderAudioLevelMeter(easedLevel, file.PeakLevel))
+		content.WriteString(renderAudioLevelMeter(easedLevel, file.PeakLevel, file.ElapsedTime))
 	}
 
 	return box.Render(content.String())
 }
 
-// renderAudioLevelMeter renders a live audio level meter with dB visualization
-func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
+// renderAudioLevelMeter renders a live audio level meter with dB visualization.
+// elapsed drives the gentle pulse of the peak-hold marker; it is the file's
+// running elapsed time, advanced once per meter tick, so no second tick loop is
+// needed.
+func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duration) string {
 	var b strings.Builder
 
 	// Display current and peak levels
-	fmt.Fprintf(&b, "🕪 Audio Level: %.1f dB | Peak: %.1f dB\n", currentLevel, peakLevel)
+	fmt.Fprintf(&b, "Level: %.1f ㏈ | Peak: %.1f ㏈\n", currentLevel, peakLevel)
 
 	// Create visual meter
-	// dB range: -60 dB (silence) to 0 dB (maximum)
+	// dB range: -70 dB (silence) to 0 dB (maximum)
 	// Map to meterWidth-character width meter
 	width := meterWidth
-	minDB := -60.0
+	minDB := meterFloorDB
 	maxDB := 0.0
 
 	// Calculate fill position for current level
@@ -185,18 +190,10 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
 	}
 
 	meterChar := func(i int) rune {
-		switch {
-		case i == peakPos && i > currentPos:
-			// Show peak marker only if it's ahead of current position
-			return '|'
-		case i < currentPos:
+		if i < currentPos {
 			return '▓' // Filled
-		case i == currentPos && currentPos == peakPos:
-			// When current level is at peak, show filled bar
-			return '▓'
-		default:
-			return '░' // Empty
 		}
+		return '░' // Empty
 	}
 
 	// Build contiguous same-colour runs and style each as one segment so
@@ -221,7 +218,41 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
 	}
 	flush()
 
+	// Peak-hold marker: a coloured triangle on its own line beneath the bar,
+	// aligned to the peak column. Skip it when there is no meaningful peak yet
+	// (peak still at the silence floor), so no stray triangle sits at column 0.
+	if peakLevel > minDB {
+		b.WriteByte('\n')
+		b.WriteString(strings.Repeat(" ", peakPos))
+		b.WriteString(lipgloss.NewStyle().Foreground(peakMarkerColor(elapsed)).Render("▲"))
+	}
+
 	return b.String()
+}
+
+// peakMarkerColor returns the peak-hold triangle colour for the current pulse
+// phase. It oscillates gently between a deep orange and the full orange at about
+// 1.2 Hz, driven by elapsed wall-clock time so it reuses the existing meter tick
+// cadence. The interpolation runs straight in sRGB between two oranges so the
+// marker stays a clear orange shade at both ends and never drifts off-hue.
+func peakMarkerColor(elapsed time.Duration) color.Color {
+	const pulseHz = 1.2
+	// 0.0 at the dim trough, 1.0 at the bright crest.
+	phase := 0.5 * (1 + math.Sin(2*math.Pi*pulseHz*elapsed.Seconds()))
+
+	dr, dg, db := rgb8(cli.ColorOrangeDim)
+	br, bg, bb := rgb8(cli.ColorOrange)
+	lerp := func(a, b uint8) uint8 {
+		return uint8(float64(a) + phase*(float64(b)-float64(a)) + 0.5)
+	}
+	return lipgloss.Color(fmt.Sprintf("#%02X%02X%02X",
+		lerp(dr, br), lerp(dg, bg), lerp(db, bb)))
+}
+
+// rgb8 resolves a color.Color to 8-bit sRGB channels.
+func rgb8(c color.Color) (r, g, b uint8) {
+	r16, g16, b16, _ := c.RGBA()
+	return uint8((r16 >> 8) & 0xFF), uint8((g16 >> 8) & 0xFF), uint8((b16 >> 8) & 0xFF)
 }
 
 // renderOverallProgress renders the overall progress footer

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -32,14 +32,11 @@ func renderProcessingView(m Model) string {
 	return b.String()
 }
 
-// renderHeader renders the application header
+// renderHeader renders the application header. The title word is drawn as a
+// per-letter cyan→sky-blue gradient via the shared cli.RenderTitle() helper, so
+// the TUI and the --version banner share one wordmark implementation.
 func renderHeader() string {
-	title := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(cli.ColorRed).
-		Render("Jivetalking 🕺")
-
-	return title
+	return cli.RenderTitle()
 }
 
 // renderFileQueue renders the list of files with their status

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -48,11 +48,13 @@ func renderFileQueue(m Model, prog progress.Model) string {
 		// fall back to the raw values when no spring slot exists.
 		easedLevel := m.Files[i].CurrentLevel
 		easedProgress := m.Files[i].Progress
+		easedPeak := m.Files[i].PeakLevel
 		if i < len(m.meters) {
 			easedLevel = m.meters[i].pos
 			easedProgress = m.meters[i].progPos
+			easedPeak = m.meters[i].peakPos
 		}
-		b.WriteString(renderFileEntry(m.Files[i], prog, easedLevel, easedProgress))
+		b.WriteString(renderFileEntry(m.Files[i], prog, easedLevel, easedProgress, easedPeak))
 		b.WriteString("\n")
 	}
 
@@ -60,7 +62,7 @@ func renderFileQueue(m Model, prog progress.Model) string {
 }
 
 // renderFileEntry renders a single file entry in the queue
-func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedProgress float64) string {
+func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedProgress, easedPeak float64) string {
 	fileName := filepath.Base(file.InputPath)
 
 	switch file.Status {
@@ -77,7 +79,7 @@ func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedPr
 		icon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("∿")
 		return fmt.Sprintf(" %s %s\n%s",
 			icon, fileName,
-			renderFileDetails(file, prog, easedLevel, easedProgress))
+			renderFileDetails(file, prog, easedLevel, easedProgress, easedPeak))
 
 	case StatusError:
 		// ✗ failed file
@@ -93,7 +95,7 @@ func renderFileEntry(file FileProgress, prog progress.Model, easedLevel, easedPr
 
 // renderFileDetails renders detailed progress for the active file. easedLevel is
 // the spring-smoothed audio level used for the meter display.
-func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, easedProgress float64) string {
+func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, easedProgress, easedPeak float64) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cli.ColorSkyBlue).
@@ -126,11 +128,12 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 	content.WriteString(renderTimeline(file))
 	content.WriteByte('\n')
 
-	// Audio level visualization. The displayed level eases toward the target
-	// via the spring; the peak marker stays driven by the measured peak.
+	// Audio level visualization. Both the displayed level and the peak marker ease
+	// toward their targets via springs; the critically-damped peak spring keeps the
+	// eased peak from ever exceeding the measured peak-hold value.
 	if file.CurrentLevel != 0 {
 		content.WriteString("\n")
-		content.WriteString(renderAudioLevelMeter(easedLevel, file.PeakLevel, file.ElapsedTime))
+		content.WriteString(renderAudioLevelMeter(easedLevel, easedPeak, file.ElapsedTime))
 	}
 
 	return box.Render(content.String())

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -165,27 +165,23 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
 	// Calculate position for peak marker
 	peakPos := max(0, min(int(((peakLevel-minDB)/(maxDB-minDB))*float64(width)), width))
 
-	// Build the meter bar with color zones
-	// Green: -60 to -16 dB (safe)
-	// Orange: -16 to -6 dB (approaching loud)
-	// Red: -6 to 0 dB (loud/clipping risk)
+	// Build a continuous green→yellow→orange→red colour ramp once per render.
+	// Real VU meters keep green dominant across the low range and compress the
+	// warm colours into the hot end, so the ramp is built from two piecewise
+	// Blend1D segments keyed to the -16 dB threshold: green→yellow fills the low
+	// zone, then yellow→orange→red is squeezed into the top ~16 dB.
 	greenZone := int((((-16.0) - minDB) / (maxDB - minDB)) * float64(width))
-	orangeZone := int((((-6.0) - minDB) / (maxDB - minDB)) * float64(width))
+	greenZone = max(0, min(greenZone, width))
 
-	// Zone colours sourced from the centralised palette.
-	greenColor := cli.ColorGreen
-	orangeColor := cli.ColorOrange
-	redColor := cli.ColorRed
+	ramp := make([]color.Color, 0, width)
+	ramp = append(ramp, lipgloss.Blend1D(greenZone, cli.ColorGreen, cli.ColorYellow)...)
+	ramp = append(ramp, lipgloss.Blend1D(width-greenZone, cli.ColorYellow, cli.ColorOrange, cli.ColorRed)...)
 
-	zoneColor := func(i int) color.Color {
-		switch {
-		case i < greenZone:
-			return greenColor
-		case i < orangeZone:
-			return orangeColor
-		default:
-			return redColor
+	cellColor := func(i int) color.Color {
+		if i < 0 || i >= len(ramp) {
+			return cli.ColorRed
 		}
+		return ramp[i]
 	}
 
 	meterChar := func(i int) rune {
@@ -216,7 +212,7 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64) string {
 	}
 
 	for i := range width {
-		color := zoneColor(i)
+		color := cellColor(i)
 		if run.Len() > 0 && color != runColor {
 			flush()
 		}


### PR DESCRIPTION
Replace hand-rolled spinner, progress bars, metric table, and level meter with first-party Charm v2 components (bubbles/spinner, bubbles/progress, lipgloss/table, harmonica springs). Centralise colour palette to cli/styles.go with adaptive downsampling via lipgloss v2. CLI help and version now honour NO_COLOR and COLORPROFILE. Spinner, progress bars, and eased meter work as intended; progress bar now fits terminal cleanly in brand red.

All tests pass. Metric table retains all formatters and edge-case coverage; 50+ lines of manual column-width maths eliminated.