### PR TITLE
refactor(processor,audio): clarify callback semantics, frame aliasing, and cgo cleanup

### DIFF
--- a/internal/audio/reader.go
+++ b/internal/audio/reader.go
@@ -36,12 +36,25 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 	filenameC := ffmpeg.ToCStr(filename)
 	defer filenameC.Free()
 
+	// cleanup frees the cgo resources allocated so far in reverse order (decCtx
+	// before fmtCtx). It only runs on an error return; the success path hands
+	// ownership to the Reader and frees nothing.
+	decCtx := (*ffmpeg.AVCodecContext)(nil)
+	cleanup := func() {
+		if decCtx != nil {
+			ffmpeg.AVCodecFreeContext(&decCtx)
+		}
+		if fmtCtx != nil {
+			ffmpeg.AVFormatCloseInput(&fmtCtx)
+		}
+	}
+
 	if _, err := ffmpeg.AVFormatOpenInput(&fmtCtx, filenameC, nil, nil); err != nil {
 		return nil, nil, fmt.Errorf("failed to open input file: %w", err)
 	}
 
 	if _, err := ffmpeg.AVFormatFindStreamInfo(fmtCtx, nil); err != nil {
-		ffmpeg.AVFormatCloseInput(&fmtCtx)
+		cleanup()
 		return nil, nil, fmt.Errorf("failed to find stream info: %w", err)
 	}
 
@@ -58,32 +71,30 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 	}
 
 	if streamIdx == -1 {
-		ffmpeg.AVFormatCloseInput(&fmtCtx)
+		cleanup()
 		return nil, nil, fmt.Errorf("no audio stream found in file: %s", filename)
 	}
 
 	codecPar := audioStream.Codecpar()
 	decoder := ffmpeg.AVCodecFindDecoder(codecPar.CodecId())
 	if decoder == nil {
-		ffmpeg.AVFormatCloseInput(&fmtCtx)
+		cleanup()
 		return nil, nil, fmt.Errorf("decoder not found for codec ID %d in file: %s", codecPar.CodecId(), filename)
 	}
 
-	decCtx := ffmpeg.AVCodecAllocContext3(decoder)
+	decCtx = ffmpeg.AVCodecAllocContext3(decoder)
 	if decCtx == nil {
-		ffmpeg.AVFormatCloseInput(&fmtCtx)
+		cleanup()
 		return nil, nil, fmt.Errorf("failed to allocate decoder context for file: %s", filename)
 	}
 
 	if _, err := ffmpeg.AVCodecParametersToContext(decCtx, codecPar); err != nil {
-		ffmpeg.AVCodecFreeContext(&decCtx)
-		ffmpeg.AVFormatCloseInput(&fmtCtx)
+		cleanup()
 		return nil, nil, fmt.Errorf("failed to copy codec parameters: %w", err)
 	}
 
 	if _, err := ffmpeg.AVCodecOpen2(decCtx, decoder, nil); err != nil {
-		ffmpeg.AVCodecFreeContext(&decCtx)
-		ffmpeg.AVFormatCloseInput(&fmtCtx)
+		cleanup()
 		return nil, nil, fmt.Errorf("failed to open decoder: %w", err)
 	}
 
@@ -93,8 +104,7 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 	defer layoutPtr.Free()
 
 	if _, err := ffmpeg.AVChannelLayoutDescribe(decCtx.ChLayout(), layoutPtr, 64); err != nil {
-		ffmpeg.AVCodecFreeContext(&decCtx)
-		ffmpeg.AVFormatCloseInput(&fmtCtx)
+		cleanup()
 		return nil, nil, fmt.Errorf("failed to get channel layout: %w", err)
 	}
 
@@ -123,6 +133,8 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 
 // ReadFrame reads the next decoded audio frame
 // Returns nil when end of file is reached
+// The returned frame is reused by the next ReadFrame call: consume it before
+// calling ReadFrame again and do not retain it.
 func (r *Reader) ReadFrame() (*ffmpeg.AVFrame, error) {
 	for {
 		// Try to receive a frame from the decoder

--- a/internal/processor/frame_processor.go
+++ b/internal/processor/frame_processor.go
@@ -10,23 +10,37 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/audio"
 )
 
+// breakOnError is the lenient error policy: swallow the error so the caller's
+// loop stops (read loop) or skips (pull loop) without aborting the whole run.
+func breakOnError(error) error { return nil }
+
+// abortOnError is the strict error policy: propagate the error so the whole
+// run aborts.
+func abortOnError(err error) error { return err }
+
 // FrameLoopConfig controls the behaviour of runFilterGraph.
+//
+// Each error callback returns nil to continue leniently or the error to abort
+// strictly. A nil callback is normalised to an explicit default policy at the
+// top of runFilterGraph: OnReadError defaults to breakOnError (lenient),
+// OnPushError and OnPullError default to abortOnError (strict). Set a field to
+// breakOnError or abortOnError to make the policy explicit at the call site.
 type FrameLoopConfig struct {
 	// OnReadError is called when reader.ReadFrame returns an error.
 	// Return nil to break the read loop (lenient); return the error to abort (strict).
-	// nil callback = break on any error (lenient default).
+	// nil = breakOnError (lenient).
 	OnReadError func(err error) error
 
 	// OnPushError is called when AVBuffersrcAddFrameFlags returns an error.
 	// Return nil to continue reading (lenient); return the error to abort (strict).
-	// nil callback = return the error (strict default).
+	// nil = abortOnError (strict).
 	OnPushError func(err error) error
 
 	// OnPullError is called when AVBuffersinkGetFrame returns an error that is
 	// NOT EAGAIN and NOT EOF (those are handled internally by breaking the pull loop).
 	// Return nil to break the pull loop and continue reading (lenient);
 	// return the error to abort both loops (strict).
-	// nil callback = return the error (strict default).
+	// nil = abortOnError (strict).
 	OnPullError func(err error) error
 
 	// OnFrame is called for each filtered frame pulled from the sink.
@@ -53,6 +67,20 @@ func runFilterGraph(
 	bufferSrcCtx, bufferSinkCtx *ffmpeg.AVFilterContext,
 	config FrameLoopConfig,
 ) error {
+	// Normalise nil callbacks to explicit default policies so the loop bodies
+	// read one uniform rule: call the handler, abort on non-nil, otherwise act
+	// leniently. OnReadError is lenient by default; OnPushError and OnPullError
+	// are strict by default.
+	if config.OnReadError == nil {
+		config.OnReadError = breakOnError
+	}
+	if config.OnPushError == nil {
+		config.OnPushError = abortOnError
+	}
+	if config.OnPullError == nil {
+		config.OnPullError = abortOnError
+	}
+
 	filteredFrame := ffmpeg.AVFrameAlloc()
 	defer ffmpeg.AVFrameFree(&filteredFrame)
 
@@ -64,13 +92,10 @@ func runFilterGraph(
 				if errors.Is(err, ffmpeg.EAgain) || errors.Is(err, ffmpeg.AVErrorEOF) {
 					break
 				}
-				if config.OnPullError != nil {
-					if cbErr := config.OnPullError(err); cbErr != nil {
-						return cbErr
-					}
-					break // callback returned nil = lenient, break inner loop
+				if cbErr := config.OnPullError(err); cbErr != nil {
+					return cbErr
 				}
-				return err // nil callback = strict default
+				break // handler returned nil = lenient, break inner loop
 			}
 
 			if config.OnFrame != nil {
@@ -94,13 +119,10 @@ func runFilterGraph(
 
 		frame, err := reader.ReadFrame()
 		if err != nil {
-			if config.OnReadError != nil {
-				if cbErr := config.OnReadError(err); cbErr != nil {
-					return cbErr
-				}
-				break // callback returned nil = lenient, stop reading
+			if cbErr := config.OnReadError(err); cbErr != nil {
+				return cbErr
 			}
-			break // nil callback = break (lenient default)
+			break // handler returned nil = lenient, stop reading
 		}
 		if frame == nil {
 			break // EOF
@@ -112,13 +134,10 @@ func runFilterGraph(
 
 		// Push frame into filter graph
 		if _, err := ffmpeg.AVBuffersrcAddFrameFlags(bufferSrcCtx, frame, 0); err != nil {
-			if config.OnPushError != nil {
-				if cbErr := config.OnPushError(err); cbErr != nil {
-					return cbErr
-				}
-				continue // callback returned nil = lenient, skip this frame
+			if cbErr := config.OnPushError(err); cbErr != nil {
+				return cbErr
 			}
-			return err // nil callback = strict default
+			continue // handler returned nil = lenient, skip this frame
 		}
 
 		// Pull filtered frames
@@ -129,13 +148,10 @@ func runFilterGraph(
 
 	// Flush the filter graph by sending nil frame
 	if _, err := ffmpeg.AVBuffersrcAddFrameFlags(bufferSrcCtx, nil, 0); err != nil {
-		if config.OnPushError != nil {
-			if cbErr := config.OnPushError(err); cbErr != nil {
-				return cbErr
-			}
-			return nil // flush push failed but callback swallowed it
+		if cbErr := config.OnPushError(err); cbErr != nil {
+			return cbErr
 		}
-		return err // nil callback = strict default
+		return nil // flush push failed but handler swallowed it
 	}
 
 	// Drain remaining filtered frames


### PR DESCRIPTION
- Normalise FrameLoopConfig nil-callback defaults: OnReadError nil → lenient (break), OnPushError/OnPullError nil → strict (abort). Collapse uniform handlers with named policies (breakOnError/abortOnError) to eliminate asymmetric nil semantics footgun.
- Add sharp doc comment to ReadFrame: returned frame is reused on next call, do not retain it.
- Deduplicate seven repeated cgo cleanup ladders in OpenAudioFile with single closure guarding both decCtx free and fmtCtx close, preserving reverse unwind order (decCtx before fmtCtx).

All behaviour-preserving. No call-site semantics changed.