### PR TITLE
fix(processor): derive ceiling margin from validation corpus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ internal/
 1. **Pass 1 (Analysis):** Measures LUFS, true peak, LRA, noise floor, spectral characteristics; detects room-tone/speech regions via 250ms interval sampling
 2. **Pass 2 (Processing):** Applies adaptive filter chain tuned to measurements; output measured for before/after comparison
 3. **Pass 3 (Measuring):** Optionally prepends `volume` (pre-gain) + `alimiter` (Volumax) when limiting is active, then runs loudnorm in measurement mode (JSON written to a per-call `stats_file`, read back after graph free) to get input stats for linear mode; measures the post-limiter signal so `measured_I`/`measured_TP` are accurate
-4. **Pass 4 (Normalising):** Applies `volume` (pre-gain, when ceiling clamped) + `alimiter` (Volumax) + `loudnorm` (linear mode) + `aresample` (source rate) + `adeclick`; pre-gain raises very quiet recordings so the alimiter can use a viable ceiling; `alimiter` creates headroom so loudnorm achieves full linear gain to reach -16 LUFS
+4. **Pass 4 (Normalising):** Applies `volume` (pre-gain, when ceiling clamped) + `alimiter` (Volumax) + `loudnorm` (linear mode) + `aresample` (source rate) + `adeclick`; pre-gain raises very quiet recordings so the alimiter can use a viable ceiling; `alimiter` creates headroom so loudnorm achieves full linear gain to reach -16 LUFS; ceiling is derived as `targetTP − gainRequired − ceilingMarginDB` (`ceilingMarginDB = 1.4`, corpus-derived p95); a binding gain cap in `calculateLinearModeTarget` (`linearSafetyMargin = 0.1`) acts as the exact TP backstop on high-crest files, intentionally landing them below -16 LUFS rather than clipping
 
 **Filter chain order (Pass 2):**
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Filter chain inspired by studio legends, tuned to your specific audio:
 | **Noise reduction** | Non-Local Means + FFT | `anlmdn` denoiser at the source sample rate (`r=0.0020`, `m=3`) followed by `afftdn` FFT spectral denoise (fixed `nr=12`) for residual suppression |
 | **Gate** | DS201 expander | Soft expansion for natural inter-phrase cleanup; breath reduction option positions threshold between noise floor and quiet speech level |
 | **Compressor** | Teletronix LA-2A | Programme-dependent optical compression; ratio and release adapt to kurtosis and flux. High-crest override pushes ratio, threshold, release, and knee when predicted limiter ceiling deficit is positive |
-| **De-esser** | — | Adaptive intensity (0.0-0.6) based on spectral centroid and rolloff |
+| **De-esser** | (none) | Adaptive intensity (0.0-0.6) based on spectral centroid and rolloff |
 
 ### Pass 3 & 4: Loudness Normalisation
 
@@ -53,11 +53,11 @@ This order matters. The limiter provides breathing room so loudnorm can use its 
 
 Each filter prepares audio for the next:
 
-1. **Rumble removal before denoising** — prevents low-frequency artifacts confusing noise profiling
-2. **Denoising before gating** — lowers noise floor so gate threshold can be optimal
-3. **Gating before compression** — removes silence before dynamics processing amplifies room tone
-4. **Compression before de-essing** — compression emphasises sibilance; de-essing corrects it
-5. **Normalisation last** — sees fully processed signal for accurate loudness targeting
+1. **Rumble removal before denoising**: prevents low-frequency artifacts confusing noise profiling
+2. **Denoising before gating**: lowers noise floor so gate threshold can be optimal
+3. **Gating before compression**: removes silence before dynamics processing amplifies room tone
+4. **Compression before de-essing**: compression emphasises sibilance; de-essing corrects it
+5. **Normalisation last**: sees fully processed signal for accurate loudness targeting
 
 ---
 
@@ -155,12 +155,12 @@ Pass `-a` to run only Pass 1 analysis, printing a detailed report to the console
 
 The report covers:
 
-- **Loudness & dynamics** — integrated LUFS, true peak, loudness range, crest factor
-- **Room tone & speech detection** — candidate regions scored and elected for noise profiling and speech-aware metrics; voice-activated recording detected automatically (Riverside, Zencastr)
-- **Derived measurements** — noise floor, gate baseline, noise-to-speech headroom
-- **Filter adaptation** — the exact parameters jivetalking would apply: highpass frequency, gate threshold, NR settings, de-esser intensity, LA-2A configuration
-- **Spectral summary** — full spectral characterisation with human-readable interpretations
-- **Recording tips** — actionable advice based on your measurements (e.g. "increase your microphone gain by 14 dB" or "your recording is clipping")
+- **Loudness & dynamics**: integrated LUFS, true peak, loudness range, crest factor
+- **Room tone & speech detection**: candidate regions scored and elected for noise profiling and speech-aware metrics; voice-activated recording detected automatically (Riverside, Zencastr)
+- **Derived measurements**: noise floor, gate baseline, noise-to-speech headroom
+- **Filter adaptation**: the exact parameters jivetalking would apply: highpass frequency, gate threshold, NR settings, de-esser intensity, LA-2A configuration
+- **Spectral summary**: full spectral characterisation with human-readable interpretations
+- **Recording tips**: actionable advice based on your measurements (e.g. "increase your microphone gain by 14 dB" or "your recording is clipping")
 
 Example output (trimmed):
 
@@ -264,10 +264,10 @@ internal/
 
 ### Design Documentation
 
-- [Gate: Drawmer DS201](docs/FilterGate-Drawmer%20DS201.md) — Soft expander with adaptive thresholding
-- [Compressor: LA-2A](docs/FilterCompressor-Teletronix%20LA-2A.md) — Programme-dependent optical compression
-- [Limiter: CBS Volumax](docs/FilterLimiter-CBS-Volumax.md) — Transparent broadcast limiting
-- [Spectral Metrics Reference](docs/Spectral-Metrics-Reference.md) — How measurements drive adaptation
+- [Gate: Drawmer DS201](docs/FilterGate-Drawmer%20DS201.md): soft expander with adaptive thresholding
+- [Compressor: LA-2A](docs/FilterCompressor-Teletronix%20LA-2A.md): programme-dependent optical compression
+- [Limiter: CBS Volumax](docs/FilterLimiter-CBS-Volumax.md): transparent broadcast limiting
+- [Spectral Metrics Reference](docs/Spectral-Metrics-Reference.md): how measurements drive adaptation
 
 See [AGENTS.md](AGENTS.md) for complete development guidelines, architecture details, and contribution standards.
 

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -376,7 +376,7 @@ The §4 and §5 speedup numbers were measured on the 5-minute fixture in isolati
 |--------|----------|--------------|-------------|--------------|----------------------|
 | 0.3.1 | 150.38 | 145.28 | 0.26 | 68,492 | 11.9× |
 | current | 89.51 | 84.52 | 0.26 | 61,964 | 20.0× |
-| **delta** | **−60.87 s (−40.5 %)** | **−60.76 s (−41.8 %)** | 0.00 s | −6,528 kB | — |
+| **delta** | **−60.87 s (−40.5 %)** | **−60.76 s (−41.8 %)** | 0.00 s | −6,528 kB | n/a |
 
 User-CPU savings track wall savings almost exactly; the work removed is real arithmetic, not stalls. Max RSS is incidentally ~6 MB lower on current (no deliberate memory work was done in either investigation).
 

--- a/docs/FilterCompressor-Teletronix LA-2A.md
+++ b/docs/FilterCompressor-Teletronix LA-2A.md
@@ -6,7 +6,7 @@
 
 ## The Legend of the LA-2A
 
-In 1965, Jim Lawrence founded Teletronix Engineering and introduced a compressor that would become synonymous with vocal recording: the LA-2A Leveling Amplifier. Decades later, engineers still reach for LA-2As—original units now command five-figure prices—whenever a voice needs warmth without aggression, control without constraint.
+In 1965, Jim Lawrence founded Teletronix Engineering and introduced a compressor that would become synonymous with vocal recording: the LA-2A Leveling Amplifier. Decades later, engineers still reach for LA-2As (original units now command five-figure prices) whenever a voice needs warmth without aggression, control without constraint.
 
 The LA-2A's character comes from its **T4 electro-optical attenuator**: an electroluminescent panel paired with a cadmium sulfide photoresistor. Light output changes with the input signal; photoresistor conductance follows the light. This indirect coupling produces inherently smooth gain changes with two-stage programme-dependent release behaviour.
 
@@ -22,7 +22,7 @@ The LA-2A's character comes from its **T4 electro-optical attenuator**: an elect
 
 ## Jivetalking's Implementation
 
-Jivetalking uses FFmpeg's `acompressor` filter (`af_sidechaincompress.c`) to apply gentle, consistent levelling in the spirit of the LA-2A. **This is not a faithful emulation.** `acompressor` is a single-pole-release, fixed-ratio RMS compressor. It structurally cannot reproduce the T4 cell's two-stage programme-dependent release or level-dependent ratio. The LA-2A is the quality target — gentle levelling, least treatment, preserve natural speech character — not the DSP model.
+Jivetalking uses FFmpeg's `acompressor` filter (`af_sidechaincompress.c`) to apply gentle, consistent levelling in the spirit of the LA-2A. **This is not a faithful emulation.** `acompressor` is a single-pole-release, fixed-ratio RMS compressor. It structurally cannot reproduce the T4 cell's two-stage programme-dependent release or level-dependent ratio. The LA-2A is the quality target (gentle levelling, least treatment, preserve natural speech character), not the DSP model.
 
 ### Design Philosophy
 
@@ -51,7 +51,7 @@ threshold = SpeechProfile.RMSLevel + 9 dB   (when SpeechProfile elected)
 threshold = PeakLevel − 20 dB               (fallback, no SpeechProfile)
 ```
 
-Speech-RMS + 9 dB places the threshold just above the bulk of speech energy, engaging compression on the upper half of the dynamic range. Across the real corpus, this delivers ~2.5-4.4 dB compression depth and an output crest factor in the 8-12 dB sweet spot — consistent across the wide input-level spread that made peak-relative thresholding unreliable (depth swung 6.6-24 dB under the old `peak − 20` primary).
+Speech-RMS + 9 dB places the threshold just above the bulk of speech energy, engaging compression on the upper half of the dynamic range. Across the real corpus, this delivers ~2.5-4.4 dB compression depth and an output crest factor in the 8-12 dB sweet spot, consistent across the wide input-level spread that made peak-relative thresholding unreliable (depth swung 6.6-24 dB under the old `peak − 20` primary).
 
 The `peak − 20` path is retained as a fallback for files where speech election fails, not as a standard path.
 
@@ -99,6 +99,6 @@ The LA-2A operates on already-gated, already-denoised audio. Its job is narrow: 
 - [Teletronix Engineering, LA-2A Leveling Amplifier Manual (1965)](https://tile.loc.gov/storage-services/master/mbrs/recording_preservation/manuals/Teletronix%20Model%20LA-2A%20Leveling%20Amplifier.pdf)
 - [Universal Audio, "LA-2A Leveling Amplifier" reissue documentation](https://media.uaudio.com/assetlibrary/l/a/la-2a_manual.pdf)
 - Dennis Fink, "The History of the LA-2A" (Mix Magazine, 2003)
-- FFmpeg source: [`libavfilter/af_sidechaincompress.c`](https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/af_sidechaincompress.c) — single-pole-release RMS compressor implementation
+- FFmpeg source: [`libavfilter/af_sidechaincompress.c`](https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/af_sidechaincompress.c) - single-pole-release RMS compressor implementation
 - FFmpeg Documentation: [`acompressor` filter](https://ffmpeg.org/ffmpeg-filters.html#acompressor)
 - https://github.com/aim-qmul/4a2a

--- a/docs/FilterGate-Drawmer DS201.md
+++ b/docs/FilterGate-Drawmer DS201.md
@@ -1,13 +1,13 @@
-# Drawmer DS201 — The Gate That Changed Everything
+# Drawmer DS201: The Gate That Changed Everything
 
 > *"I could solve his problem."*
-> — Ivor Drawmer, watching a frustrated engineer battle cymbal bleed on gated toms
+> - Ivor Drawmer, watching a frustrated engineer battle cymbal bleed on gated toms
 
 ## The Legend
 
-In 1982, a self-taught electronics engineer from a tiny Channel Island with no cars and no streetlights revolutionised professional audio. Ivor Drawmer had been a session keyboardist—the kind who carried a soldering iron on stage and once sawed a Hammond organ in half for easier transport. That resourcefulness led him to invent **frequency-conscious gating**.
+In 1982, a self-taught electronics engineer from a tiny Channel Island with no cars and no streetlights revolutionised professional audio. Ivor Drawmer had been a session keyboardist, the kind who carried a soldering iron on stage and once sawed a Hammond organ in half for easier transport. That resourcefulness led him to invent **frequency-conscious gating**.
 
-The story goes: Ivor was waiting to record a keyboard overdub while an engineer wrestled with cymbal bleed on tom mics. Every crash triggered the gates, unleashing a gnashing mess of unwanted sound. Ivor returned the next day with a circuit board, two dangling jacks, and a solution. By filtering the side-chain to hear only low frequencies—which toms have plenty of and cymbals almost none—the gate became surgical.
+The story goes: Ivor was waiting to record a keyboard overdub while an engineer wrestled with cymbal bleed on tom mics. Every crash triggered the gates, unleashing a gnashing mess of unwanted sound. Ivor returned the next day with a circuit board, two dangling jacks, and a solution. By filtering the side-chain to hear only low frequencies (which toms have plenty of and cymbals almost none), the gate became surgical.
 
 That prototype became the **Drawmer DS201 Dual Noise Gate**. Over forty years later, it remains in production and installed in virtually every major recording studio, broadcast facility, and live venue worldwide.
 
@@ -30,7 +30,7 @@ Jivetalking honours the DS201's philosophy while adapting it for podcast speech.
 
 ### Frequency-Conscious Filtering
 
-FFmpeg lacks native side-chain filtering, so we apply frequency shaping to the audio path before gating—achieving the same result through different means:
+FFmpeg lacks native side-chain filtering, so we apply frequency shaping to the audio path before gating, achieving the same result through different means:
 
 | DS201 Feature | Jivetalking Equivalent |
 |---------------|------------------------|
@@ -42,7 +42,7 @@ The high-pass is a fixed 80Hz corner (12dB/oct) that removes subsonic rumble bel
 
 ### Soft Expander Philosophy
 
-Here we intentionally depart from the DS201's hard gate mode. For drums, complete silence between hits is desirable. For speech, it sounds unnatural—listeners expect room tone between phrases.
+Here we intentionally depart from the DS201's hard gate mode. For drums, complete silence between hits is desirable. For speech, it sounds unnatural; listeners expect room tone between phrases.
 
 | Aspect | DS201 Hard Gate | Jivetalking |
 |--------|-----------------|-------------|
@@ -67,7 +67,7 @@ The DS201 requires manual adjustment. We measure your audio in Pass 1 and tune e
 
 ### Attack: Preserving Transients
 
-The DS201's 10µs attack is legendary for preserving the crack of a snare or the punch of a kick. Speech transients are gentler but still matter—the "P" in "podcast" needs its plosive intact.
+The DS201's 10µs attack is legendary for preserving the crack of a snare or the punch of a kick. Speech transients are gentler but still matter; the "P" in "podcast" needs its plosive intact.
 
 | Transient Type | Attack Time | Detection |
 |----------------|-------------|-----------|
@@ -77,7 +77,7 @@ The DS201's 10µs attack is legendary for preserving the crack of a snare or the
 
 ### Hold Compensation
 
-The DS201's dedicated Hold parameter keeps the gate open briefly after signal drops—essential for preventing chatter on decaying toms. FFmpeg's `agate` lacks this control, so we compensate through release timing:
+The DS201's dedicated Hold parameter keeps the gate open briefly after signal drops, essential for preventing chatter on decaying toms. FFmpeg's `agate` lacks this control, so we compensate through release timing:
 
 - **Baseline**: +50ms added to release (simulates short hold)
 - **Tonal noise**: +75ms additional (hides pumping on hum/bleed)
@@ -95,7 +95,7 @@ The DS201's dedicated Hold parameter keeps the gate open briefly after signal dr
 
 ## The Drawmer Legacy
 
-Ivor Drawmer received the APRS Lifetime Technical Achievement Award, presented by Sir George Martin. His innovations—frequency-conscious gating, program-adaptive dynamics, spectral enhancement—shaped how every competitor designs signal processors. The DS201 alone has been in continuous production for over forty years.
+Ivor Drawmer received the APRS Lifetime Technical Achievement Award, presented by Sir George Martin. His innovations (frequency-conscious gating, program-adaptive dynamics, spectral enhancement) shaped how every competitor designs signal processors. The DS201 alone has been in continuous production for over forty years.
 
 Not bad for a self-taught pianist from a sleepy island in the English Channel.
 

--- a/docs/FilterLimiter-CBS-Volumax.md
+++ b/docs/FilterLimiter-CBS-Volumax.md
@@ -1,7 +1,7 @@
-# CBS Volumax — The Invisible Limiter
+# CBS Volumax: The Invisible Limiter
 
 *"The best limiter is one you never hear."*
-— Design philosophy of CBS Laboratories' audio processing division
+- Design philosophy of CBS Laboratories' audio processing division
 
 ---
 
@@ -111,7 +111,9 @@ alimiter=limit=<ceiling>:attack=5:release=100:level_in=1:level_out=1:level=0:lat
 
 ### Sample-peak ceiling
 
-Per `af_alimiter.c` (FFmpeg release/8.1), `alimiter`'s `limit` is a **sample-peak** ceiling with attack-length lookahead - it is not true-peak/oversampled. Inter-sample peaks above the ceiling by up to ~0.8 dB are possible. The adaptive ceiling calculation accounts for this with a 1.5 dB safety margin (`safetyMarginDB`), keeping the downstream loudnorm within its linear-mode condition.
+Per `af_alimiter.c` (FFmpeg release/8.1), `alimiter`'s `limit` is a **sample-peak** ceiling with attack-length lookahead, not true-peak/oversampled. Inter-sample peaks above the ceiling by up to ~0.8 dB are possible.
+
+The adaptive ceiling is derived from the loudness targets: `ceiling = targetTP − gainRequired` (= `filtered_I + B`, where `B = targetTP − targetI = 14 dB`). A `ceilingMarginDB = 1.4` reserve is subtracted from the ceiling: the p95 of per-file headroom measured across the LMP-68..83 corpus needed to land the final true peak at −2.0 dBTP. This reserve is not an ISP allowance and not a feedback pad; it is an empirically derived reserve against the post-loudnorm peak growth from `aresample → adeclick` that the ceiling alone cannot model (mean +0.66 dB; up to +2.93 dB on the highest-crest file). Makeup-feedback ΔI is negligible (~0 mean). A binding gain cap (`calculateLinearModeTarget`, 0.1 dB epsilon only) operates on the Pass-3 `measured_I/TP` as the exact backstop. See `SAFE-LIMITER.md` for the full derivation and validation result.
 
 ### Auto Soft Clipping (ASC)
 
@@ -138,10 +140,10 @@ The Volumax operates after all Pass 2 processing and after Pass 3 measurement. I
 
 ### Adaptive Ceiling Calculation
 
-Unlike the original design's fixed ceiling, Jivetalking calculates the exact ceiling needed:
+Unlike the original design's fixed ceiling, Jivetalking calculates the exact ceiling needed per file:
 
 ```go
-gainRequired := targetLUFS - measuredLUFS
+gainRequired := targetI - measuredI
 projectedPeak := measuredTP + gainRequired
 
 if projectedPeak <= targetTP {
@@ -149,11 +151,13 @@ if projectedPeak <= targetTP {
     return
 }
 
-// Calculate ceiling that allows linear mode
-ceiling := targetTP - gainRequired - safetyMargin
+// Derived ceiling: places peaks at B = targetTP - targetI above pre-limiter loudness.
+// ceilingMarginDB (1.4 dB, corpus-derived p95) reserves headroom for post-loudnorm
+// peak growth from aresample/adeclick that the ceiling cannot fully model.
+ceiling := targetTP - gainRequired - ceilingMarginDB
 ```
 
-This means the limiter only reduces peaks by the minimum amount necessary - often just 1-2 dB - rather than applying a fixed ceiling that might over-limit.
+The limiter reduces peaks by the minimum the corpus demands (often 1–2 dB) rather than applying a fixed ceiling that over-limits every file.
 
 ### Pre-gain for Clamped Ceilings
 
@@ -169,9 +173,9 @@ preGainDB = deficit
 The volume filter applies static linear gain equal to the deficit, uniformly raising the signal level. After pre-gain, the limiter ceiling is re-derived from the post-gain measurements:
 
 ```
-postGainI      = measuredI + deficit
+postGainI       = measuredI + deficit
 newGainRequired = targetI - postGainI
-newCeiling      = targetTP - newGainRequired - safetyMargin
+newCeiling      = targetTP - newGainRequired - ceilingMarginDB
 ```
 
 The re-derived ceiling lands at or near -24.0 dBTP, which is within the alimiter's supported range. The alimiter uses this re-derived ceiling instead of the clamped value, and loudnorm receives adjusted `measured_I` and `measured_TP` parameters reflecting the post-gain signal.

--- a/docs/Levelator-Comparison-And-Gap-Analysis.md
+++ b/docs/Levelator-Comparison-And-Gap-Analysis.md
@@ -12,7 +12,7 @@ The Levelator was a landmark audio processing tool created by Bruce and Malcolm 
 
 ### Core Algorithm
 
-The Levelator was explicitly **not** a compressor, normaliser, or limiter—although it contained elements of all three. As stated on the official website:
+The Levelator was explicitly **not** a compressor, normaliser, or limiter, although it contained elements of all three. As stated on the official website:
 
 > "It's software that runs on Windows, OS X (universal binary), or Linux (Ubuntu) that adjusts the audio levels _within_ your podcast or other audio file for variations from one speaker to the next, for example. It's not a compressor, normalizer or limiter although it contains all three. It's much more than those tools, and it's much simpler to use."
 
@@ -139,8 +139,8 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 | Dimension | Levelator | Jivetalking |
 |-----------|-----------|-------------|
 | **Processing Approach** | Multi-pass file-based batch processing | Multi-pass file-based batch processing |
-| **Processing Paradigm** | "Leveling"—medium-term variation correction | Full pipeline: denoise → gate → compress → de-ess → normalise |
-| **Look-ahead Capability** | Yes—infinite look-ahead via multiple passes | Yes—infinite look-ahead via Pass 1 analysis |
+| **Processing Paradigm** | "Leveling": medium-term variation correction | Full pipeline: denoise → gate → compress → de-ess → normalise |
+| **Look-ahead Capability** | Yes, infinite look-ahead via multiple passes | Yes, infinite look-ahead via Pass 1 analysis |
 | **Target Loudness Standard** | -18 dB RMS (custom RMS calculation) | -16 LUFS |
 | **Silence Detection** | Fixed: 50ms subsegments > -44 dB | Adaptive: spectral analysis + room tone scoring |
 | **Noise Reduction** | None | `anlmdn` (Non-Local Means, source-rate denoising at `r=0.0020`, `m=3`) + `afftdn` (FFT spectral denoise, fixed `nr=12`) |
@@ -151,17 +151,17 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 | **De-essing** | None | Adaptive intensity 0.0-0.85 from speech-region sibilant-band excess (6-9 kHz vs 1-3 kHz) |
 | **Content Type Detection** | None | Speech vs Music vs Mixed classification |
 | **Adaptive Parameters** | Minimal (one-size-fits-all) | Extensive per-filter tuning based on 20+ metrics |
-| **Parameter Control** | None—fully automatic | None—fully automatic (but tunable via source) |
+| **Parameter Control** | None, fully automatic | None, fully automatic (but tunable via source) |
 | **Output Formats** | WAV, AIFF | Any FFmpeg-supported format (default: FLAC → FLAC) |
 | **Output Sample Rate** | Matches input | 44.1kHz standardised |
 | **Output Bit Depth** | Matches input | 16-bit standardised |
 | **Output Channels** | Matches input | Mono (downmix enabled by default) |
 | **User Interface** | GUI (drag-and-drop) | CLI/TUI (command-line) |
 | **Platform Support** | Windows, macOS, Linux (32-bit) | Linux, macOS, Windows (64-bit, via Go/FFmpeg) |
-| **Open Source** | No—proprietary, discontinued | Yes—open source, actively maintained |
+| **Open Source** | No (proprietary, discontinued) | Yes (open source, actively maintained) |
 | **License** | Proprietary (free for use) | Open source (license not specified in research) |
 | **Commercial Use** | Initially non-commercial only, later permitted | Permitted |
-| **Breath Reduction** | None | Yes—via adaptive gate threshold positioning |
+| **Breath Reduction** | None | Yes, via adaptive gate threshold positioning |
 | **Plosive Reduction** | None | Implicit via AutoEQ design patterns |
 | **True Peak Limiting** | None (-1.0 dB sample peak) | Yes (-1.0 to -2.0 dBTP via alimiter) |
 | **Loudness Range Control** | None | Monitored and adapted to (LRA affects gate ratio) |
@@ -193,7 +193,7 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 
 #### 3. **Medium-Term "Leveling" Approach**
 
-**Gap:** Levelator's unique contribution was correcting "medium-term" loudness variations—neither the short-term transients handled by compressors nor the long-term overall loudness handled by normalisers. This "riding the fader" effect compensated for speakers at different volumes within a recording.
+**Gap:** Levelator's unique contribution was correcting "medium-term" loudness variations, neither the short-term transients handled by compressors nor the long-term overall loudness handled by normalisers. This "riding the fader" effect compensated for speakers at different volumes within a recording.
 
 **Jivetalking Status:** Jivetalking applies consistent filter parameters across the entire file. The LA-2A-inspired compressor applies fixed-ratio RMS compression with a speech-level-relative threshold, but does not segment the file or apply different corrections to different time regions.
 
@@ -247,9 +247,9 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 - Apply varying compression/normalisation per segment
 - Use crossfade windows to avoid audible transitions
 
-**Feasibility:** Medium—requires significant architectural changes but builds on existing Pass 1 analysis infrastructure.
+**Feasibility:** Medium, requires significant architectural changes but builds on existing Pass 1 analysis infrastructure.
 
-**Status:** **Should implement**—this is the core "magic" of Levelator that users miss.
+**Status:** **Should implement** - this is the core "magic" of Levelator that users miss.
 
 #### 2. **Drag-and-Drop GUI Wrapper**
 
@@ -263,9 +263,9 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 - Shows simple progress dialog
 - Opens output folder on completion
 
-**Feasibility:** High—wrapper around existing CLI functionality.
+**Feasibility:** High, wrapper around existing CLI functionality.
 
-**Status:** **Should implement**—significant usability improvement with minimal core changes.
+**Status:** **Should implement** - significant usability improvement with minimal core changes.
 
 ### Medium Priority
 
@@ -280,9 +280,9 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 - Use FFmpeg's `volumedetect` filter for RMS measurement
 - Calculate gain adjustment to reach target RMS
 
-**Feasibility:** High—FFmpeg supports this natively.
+**Feasibility:** High, FFmpeg supports this natively.
 
-**Status:** **Maybe implement**—nice to have for migration compatibility.
+**Status:** **Maybe implement** - nice to have for migration compatibility.
 
 #### 4. **Output File Naming Convention**
 
@@ -292,7 +292,7 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 
 **Feasibility:** Trivial.
 
-**Status:** **Should implement**—one-line change, improves usability.
+**Status:** **Should implement** - one-line change, improves usability.
 
 ### Low Priority
 
@@ -302,9 +302,9 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 
 **Rationale:** Levelator was praised for not introducing "breathing" artifacts. Jivetalking has breath reduction via adaptive gating, but it may not be as refined.
 
-**Feasibility:** Medium—requires research into breath detection algorithms.
+**Feasibility:** Medium, requires research into breath detection algorithms.
 
-**Status:** **Maybe implement**—current solution may be sufficient.
+**Status:** **Maybe implement** - current solution may be sufficient.
 
 #### 6. **Multi-Format Batch Processing**
 
@@ -314,7 +314,7 @@ Jivetalking employs speech profile extraction for adaptive tuning:
 
 **Feasibility:** Already supported via `jivetalking file1.wav file2.flac file3.mp3`.
 
-**Status:** **Already implemented**—verify documentation covers this.
+**Status:** **Already implemented** - verify documentation covers this.
 
 ---
 
@@ -381,7 +381,7 @@ Levelator's "Loudness Algorithms" page was widely cited. Being transparent about
 
 #### 5. **The "Magic" Is Medium-Term Leveling**
 
-Levelator's unique contribution was not compression or normalisation—it was the "medium-term" correction that handled speakers at different volumes.
+Levelator's unique contribution was not compression or normalisation; it was the "medium-term" correction that handled speakers at different volumes.
 
 **Lesson:** Prioritise implementing segmented/time-varying processing. This is the key missing feature for Levelator refugees.
 
@@ -408,7 +408,7 @@ Levelator created its own RMS standard because no spoken-word standard existed. 
 6. Auphonic Singletrack Algorithms: https://auphonic.com/help/algorithms/singletrack.html
 7. Levelator vs Auphonic Comparison (GoTranscript): https://gotranscript.com/public/comparing-levelator-and-auphonic-best-tools-for-podcast-audio-leveling
 8. Alternatives to Levelator: https://podcastinghacks.com/alternatives-to-levelator/
-9. Wikipedia—Levelator: https://en.wikipedia.org/wiki/Levelator
+9. Wikipedia, Levelator: https://en.wikipedia.org/wiki/Levelator
 10. The Levelator's Return: https://www.podfeet.com/blog/2020/06/the-levelator/
 
 ### Technical Standards

--- a/internal/logging/analysis_display.go
+++ b/internal/logging/analysis_display.go
@@ -20,7 +20,7 @@ import (
 // extension is folded into the name so inputs that share a stem but differ by
 // extension (e.g. foo.flac and foo.wav in a mixed-format batch directory) get
 // distinct logs instead of silently clobbering one another. Examples:
-// /x/LMP-81-mark.flac → /x/LMP-81-mark-flac-analysis.log; /tmp/raw → /tmp/raw-analysis.log.
+// /x/voice.flac → /x/voice-flac-analysis.log; /tmp/raw → /tmp/raw-analysis.log.
 func AnalysisLogPath(inputPath string) string {
 	dir := filepath.Dir(inputPath)
 	filename := filepath.Base(inputPath)

--- a/internal/logging/report_diagnostics.go
+++ b/internal/logging/report_diagnostics.go
@@ -270,6 +270,21 @@ func writeDiagnosticLoudnorm(f *os.File, result *processor.NormalisationResult, 
 	fmt.Fprintf(f, "  Dual mono:  %v\n", config.Loudnorm.DualMono)
 	fmt.Fprintf(f, "  Gain:       %+.2f dB\n", result.GainApplied)
 
+	// Post-limiter measurements and the crest budget that governs the binding gain
+	// cap. measured_I/measured_TP are loudnorm's Pass-3 readings of the post-limiter
+	// signal (NormalisationResult.InputLUFS/InputTP). The crest budget B =
+	// targetTP - targetI is the post-limiter crest at which the file lands at both
+	// targets exactly; the cap holds final TP <= targetTP by lowering the realised
+	// gain when the post-limiter crest exceeds B.
+	crestBudget := config.Loudnorm.TargetTP - result.RequestedTargetI
+	postLimiterCrest := result.InputTP - result.InputLUFS
+	fmt.Fprintln(f, "")
+	fmt.Fprintln(f, "Post-limiter measurements (Pass 3) and crest budget:")
+	fmt.Fprintf(f, "  measured_I:    %.2f LUFS\n", result.InputLUFS)
+	fmt.Fprintf(f, "  measured_TP:   %.2f dBTP\n", result.InputTP)
+	fmt.Fprintf(f, "  Crest budget:  %.1f dB (B = targetTP - targetI)\n", crestBudget)
+	fmt.Fprintf(f, "  Post crest:    %.1f dB (measured_TP - measured_I)\n", postLimiterCrest)
+
 	// Display loudnorm filter's unique diagnostic info (I/TP/LRA values are in Loudness table)
 	if result.LoudnormStats != nil {
 		stats := result.LoudnormStats
@@ -279,6 +294,18 @@ func writeDiagnosticLoudnorm(f *os.File, result *processor.NormalisationResult, 
 		fmt.Fprintf(f, "  Output Thresh:   %s LUFS\n", stats.OutputThresh)
 		fmt.Fprintf(f, "  Norm Type:       %s\n", stats.NormalizationType)
 		fmt.Fprintf(f, "  Target Offset:   %s dB\n", stats.TargetOffset)
+	}
+
+	// When the gain cap binds (LinearModeForced), the file intentionally lands
+	// below the requested target I so the final true peak stays at or under the
+	// target. The output filename's LUFS-NN reflects the actual lower loudness; the
+	// sub-target result is by design, not a normalisation failure.
+	if result.LinearModeForced {
+		fmt.Fprintln(f, "")
+		fmt.Fprintf(f, "Gain cap engaged: target lowered %.1f -> %.1f LUFS to hold TP <= %.1f dBTP.\n",
+			result.RequestedTargetI, result.EffectiveTargetI, config.Loudnorm.TargetTP)
+		fmt.Fprintln(f, "  The output is intentionally below the requested loudness; the LUFS-NN")
+		fmt.Fprintln(f, "  filename reflects the actual output loudness.")
 	}
 
 	fmt.Fprintln(f, "")

--- a/internal/processor/analyzer_candidates_room_tone_scoring.go
+++ b/internal/processor/analyzer_candidates_room_tone_scoring.go
@@ -49,8 +49,8 @@ const (
 	// independent absolute crest. The population-relative test only rejects a candidate whose
 	// crest is anomalous *for its own population*. Dimensionless statistical multiplier, mirrors
 	// roomToneDispersionMADs. The sweep at .bench/crosstalk-crest-sweep found k = 4 the
-	// validated plateau: EP68-popey flips from electing an out-of-band region by luck to
-	// electing an in-band region on merit, while EP83 stays bit-identical and genuine crosstalk
+	// validated plateau: a sparse-conversational stem flips from electing an out-of-band region by luck to
+	// electing an in-band region on merit, while a noisier stem stays bit-identical and genuine crosstalk
 	// is still rejected by the kurtosis and 45 dB co-signals.
 	roomToneCrosstalkCrestMADs = 4.0
 

--- a/internal/processor/analyzer_test.go
+++ b/internal/processor/analyzer_test.go
@@ -2880,7 +2880,7 @@ func makeRoomToneIntervalsFromRMS(start time.Duration, rmsLevels []float64) []In
 }
 
 func TestFindBestRoomToneRegion_ProximityElectsClusterNotQuietOutlier(t *testing.T) {
-	// Regression for the popey-EP83 defect: a quiet bright outlier (~-79) must not be
+	// Regression for the sparse-room-tone defect: a quiet bright outlier (~-79) must not be
 	// elected over a representative cluster (~-74). With proximity-to-cluster-P50
 	// amplitude scoring, the cluster candidates sit on the population median and the
 	// quiet outlier is penalised for departing from it by more than roomToneAmplitudeDecayDB.
@@ -3383,7 +3383,7 @@ func noiseProfilesEqual(a, b *NoiseProfile) bool {
 }
 
 // buildConversationalIntervals shapes intervals like a sparse, conversational
-// speaker (mark, popey): speech runs separated by pauses longer than the
+// speaker: speech runs separated by pauses longer than the
 // 8-interval (2s) tolerance, so no single run reaches the old 120-interval
 // (30s) wall. Each speech run scores above speechScoreThreshold via the same
 // loud/median/quiet RMS pattern the other speech tests use.
@@ -3425,7 +3425,7 @@ func buildConversationalIntervals(runLen, gapLen, runs int) []IntervalSample {
 }
 
 // TestFindSpeechCandidatesFromIntervals_ConversationalSpeakerElects guards the
-// detection-ep83 fix: lowering minimumSpeechIntervals to 40 (10s) lets sparse,
+// sparse-speech detection fix: lowering minimumSpeechIntervals to 40 (10s) lets sparse,
 // conversational presenters elect a speech candidate. Runs of ~45 speech
 // intervals separated by >2s pauses never sustained 30 unbroken seconds, so the
 // old 120-interval gate yielded zero candidates and the SpeechProfile fell back

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -403,7 +403,7 @@ func buildFullbenchPass4ResampleFilter(config *EffectiveFilterConfig) string {
 func buildFullbenchProductionPass4SpecWithoutAdeclick(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	pass4Config := *config
 	pass4Config.Adeclick.Enabled = false
-	return buildLoudnormFilterSpec(&pass4Config, measurement, 0, 0, false, 48000, "")
+	return buildLoudnormFilterSpec(&pass4Config, measurement, measurement.TargetOffset, 0, 0, false, 48000, "")
 }
 
 func extractFullbenchFilterClause(spec, prefix string) string {
@@ -559,7 +559,7 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 	productionConfig := *config
 	productionConfig.Adeclick.Enabled = false
 	productionClause := extractFullbenchFilterClause(
-		buildLoudnormFilterSpec(&productionConfig, measurement, 0, 0, false, 48000, ""),
+		buildLoudnormFilterSpec(&productionConfig, measurement, measurement.TargetOffset, 0, 0, false, 48000, ""),
 		"loudnorm=",
 	)
 	benchmarkClause := buildFullbenchLoudnormClause(config, measurement)

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -753,8 +753,8 @@ func (cfg *EffectiveFilterConfig) buildDS201LowPassFilter() string {
 // - r: research radius in seconds (2.0ms = 0.0020s, r_min)
 // - m: smoothing factor (3 = m_strict)
 //
-// afftdn replaced the former compand residual-suppression stage. Sweeps at
-// .bench/noiseblock-ep83 and .bench/afftdn-ep83 showed anlmdn → afftdn matches
+// afftdn replaced the former compand residual-suppression stage. Sweeps on the
+// noisiest corpus stem showed anlmdn → afftdn matches
 // or beats anlmdn → compand on under-speech noise while keeping gaps clean with
 // less floor modulation. nr is FIXED at 12: a per-presenter sweep showed the
 // noisiest voice must be capped at ~12 to avoid warble, so adaptive nr would be
@@ -773,7 +773,7 @@ func (cfg *EffectiveFilterConfig) buildNoiseRemoveFilter() string {
 		noiseRemove.Smooth,
 	))
 
-	// afftdn FFT spectral denoise tail, validated at .bench/afftdn-ep83.
+	// afftdn FFT spectral denoise tail, validated on the noisiest corpus stem.
 	// Fixed nr=12 (not adaptive); tn=1 tracks noise so no sample region is needed.
 	if spec := noiseRemove.buildAfftdnFilter(); spec != "" {
 		filters = append(filters, spec)

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -28,13 +28,19 @@ func normaliseDuration(m *AudioMeasurements) float64 {
 // Limiter ceiling constants used by calculateLimiterCeiling and pre-gain deficit
 // calculation.
 const (
-	// safetyMarginDB accounts for inter-sample peak (ISP) creation during limiting.
-	// See calculateLimiterCeiling for detailed rationale.
-	safetyMarginDB = 1.5 // dB
-
 	// minLimiterCeilingDB is the practical minimum for FFmpeg's alimiter.
 	// limit=0.0625 = 20*log10(0.0625) ≈ -24.08 dBTP; we use -24.0 with a small buffer.
+	// This is the alimiter engine floor, not a tuning constant.
 	minLimiterCeilingDB = -24.0 // dBTP
+
+	// ceilingMarginDB reserves headroom for the post-loudnorm true-peak overshoot
+	// created by aresample/adeclick (which run after loudnorm and can lift the peak
+	// a few tenths of a dB on transient-heavy speech). It is NOT an ISP allowance.
+	// Value = p95 of the per-file headroom measured across the validation
+	// corpus needed to land the output true peak at the -2.0 dBTP target (excluding
+	// a local-click outlier, which is unfixable by a margin).
+	// Re-derive via testdata/validation-0.3.1-vs-0.5.x when the corpus changes.
+	ceilingMarginDB = 1.4 // dB (p95; was an undocumented 1.5)
 )
 
 // MinLimiterCeilingDB exports minLimiterCeilingDB so the logging package can reference the ceiling without duplicating the literal.
@@ -252,11 +258,19 @@ func measureWithLoudnorm(ctx context.Context, inputPath string, config *Effectiv
 // calculateLimiterCeiling calculates the adaptive ceiling for pre-limiting in Pass 4.
 // This allows loudnorm to apply full linear gain without exceeding target TP.
 //
-// The ceiling is calculated so that after loudnorm applies its gain:
+// The ceiling is derived from the loudness targets plus a derived headroom
+// reserve. It places the post-limiter sample peak the crest budget B above the
+// pre-limiter loudness, less the reserve that absorbs the post-loudnorm overshoot:
 //
-//	projected_TP = ceiling + gainRequired <= target_TP
+//	B = target_TP - target_I                                (the fixed crest budget)
+//	ceiling = target_TP - gainRequired - ceilingMarginDB    (= filtered_I + B - margin)
 //
-// Solving for ceiling: ceiling = target_TP - gainRequired - safety_margin
+// The reserve (ceilingMarginDB) lands the realised output true peak at target_TP
+// rather than above it; see the constant's docstring for its derivation. The
+// residual feedback the ceiling cannot model is caught downstream by the binding
+// gain cap in calculateLinearModeTarget, which lowers the realised gain by exactly
+// the overshoot. The ceiling carries the headroom reserve; the cap is the
+// near-inert exact-TP backstop.
 //
 // FFmpeg alimiter constraint: the limit parameter accepts 0.0625 to 1.0 (linear),
 // which corresponds to -24.08 dBTP to 0 dBTP. Ceilings below this are clamped.
@@ -280,8 +294,9 @@ func calculateLimiterCeiling(measuredI, measuredTP, targetI, targetTP float64) (
 		return 0, false, false
 	}
 
-	// Calculate ceiling: targetTP - gainRequired - safetyMarginDB
-	ceiling = targetTP - gainRequired - safetyMarginDB
+	// Derived ceiling: targetTP - gainRequired - ceilingMarginDB
+	// (= filtered_I + B - margin, the crest budget less the headroom reserve).
+	ceiling = targetTP - gainRequired - ceilingMarginDB
 
 	// Clamp to alimiter's minimum supported ceiling
 	if ceiling < minLimiterCeilingDB {
@@ -307,7 +322,7 @@ func calculateLimiterCeiling(measuredI, measuredTP, targetI, targetTP float64) (
 //   - reDerivedCeiling: The limiter ceiling re-derived from post-gain values (0.0 when not clamped)
 func calculatePreGain(measuredI, targetI, targetTP float64) (preGainDB, reDerivedCeiling float64) {
 	gainRequired := targetI - measuredI
-	idealCeiling := targetTP - gainRequired - safetyMarginDB
+	idealCeiling := targetTP - gainRequired - ceilingMarginDB
 
 	// No pre-gain needed if ceiling is at or above alimiter's minimum
 	if idealCeiling >= minLimiterCeilingDB {
@@ -320,7 +335,7 @@ func calculatePreGain(measuredI, targetI, targetTP float64) (preGainDB, reDerive
 	// Re-derive ceiling from post-gain values
 	postGainI := measuredI + preGainDB
 	newGainRequired := targetI - postGainI
-	reDerivedCeiling = targetTP - newGainRequired - safetyMarginDB
+	reDerivedCeiling = targetTP - newGainRequired - ceilingMarginDB
 
 	return preGainDB, reDerivedCeiling
 }
@@ -378,6 +393,7 @@ type loudnormApplicationRequest struct {
 	inputPath         string
 	config            *EffectiveFilterConfig
 	measurement       *LoudnormMeasurement
+	offset            float64 // Capped linear makeup (effectiveTargetI - measured_I); pins the loudnorm offset= to the capped I=
 	inputMeasurements *AudioMeasurements
 	limiter           limiterPlan
 	progress          ProgressCallback
@@ -611,8 +627,12 @@ func ApplyNormalisation(
 		loudnorm.TargetTP,
 	)
 
-	// Use loudnorm's own target_offset from the measurement pass
-	offset := measurement.TargetOffset
+	// Bind the gain cap: the realised linear scalar gain is the CAPPED makeup
+	// (effectiveTargetI - measured_I), not loudnorm's own target_offset. On a
+	// high-crest stem the cap lowers effectiveTargetI below targetI, so the
+	// matching offset pins the final true peak at targetTP by construction. On a
+	// safe stem effectiveTargetI == targetI and this equals the planned makeup.
+	offset := effectiveTargetI - measurement.InputI
 
 	// Store the effective target in config for loudnorm filter construction
 	effectiveConfig := *config
@@ -623,6 +643,7 @@ func ApplyNormalisation(
 		inputPath:         inputPath,
 		config:            &effectiveConfig,
 		measurement:       measurement,
+		offset:            offset,
 		inputMeasurements: inputMeasurements,
 		limiter:           limiter,
 		progress:          progressCallback,
@@ -754,6 +775,7 @@ func prepareLoudnormApplication(ctx context.Context, request loudnormApplication
 	filterSpec := buildLoudnormFilterSpec(
 		request.config,
 		request.measurement,
+		request.offset,
 		request.limiter.preGainDB,
 		request.limiter.ceilingDB,
 		request.limiter.needed,
@@ -959,9 +981,12 @@ func finalizeLoudnormOutputMeasurements(
 // sample rate equals the input rate. We want spectral measurements at the original
 // sample rate to match Pass 2's measurements for accurate comparison.
 //
-// Per ffmpeg-loudnorm-helper: the offset parameter MUST come from loudnorm's own
-// first pass measurement, not from external calculations.
-func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, preGainDB float64, ceiling float64, needsLimiting bool, sourceSampleRate int, statsPath string) string {
+// The offset is the capped linear makeup (effectiveTargetI - measured_I) computed
+// by calculateLinearModeTarget, not loudnorm's own first-pass target_offset. This
+// makes the gain cap binding: when the cap lowers effectiveTargetI on a high-crest
+// stem, the matching offset pins the realised scalar gain to the capped I=, holding
+// the final true peak at targetTP. On a safe stem it equals the planned makeup.
+func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, offset float64, preGainDB float64, ceiling float64, needsLimiting bool, sourceSampleRate int, statsPath string) string {
 	var filters []string
 	loudnorm := config.Loudnorm
 
@@ -973,7 +998,8 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 
 	// 2. loudnorm (second pass mode)
 	// measured_i/tp/lra/thresh come from loudnorm's first pass measurement
-	// offset: loudnorm's own calculated offset from first pass (critical!)
+	// offset: the capped linear makeup (effectiveTargetI - measured_I), so the
+	//   realised scalar gain matches the capped I= and holds final TP at targetTP
 	// linear=true: Enable linear mode (applies consistent gain, no adaptive EQ)
 	// dual_mono=true: CRITICAL - treats mono as dual-mono for correct loudness measurement
 	// print_format=json: Outputs JSON with normalization_type, target_offset, output_i/tp/lra
@@ -990,7 +1016,7 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 		measurement.InputTP,
 		measurement.InputLRA,
 		measurement.InputThresh,
-		measurement.TargetOffset, // From first pass - critical for linear mode
+		offset, // Capped makeup matching the capped I= (binds the gain cap)
 		boolToString(loudnorm.DualMono),
 		boolToString(loudnorm.Linear),
 	)

--- a/internal/processor/normalise_guard_test.go
+++ b/internal/processor/normalise_guard_test.go
@@ -45,7 +45,7 @@ func TestMetadataModeGuard(t *testing.T) {
 			TargetOffset: -0.5,
 		}
 
-		spec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000, "")
+		spec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
 		assertBothFlags(t, "buildLoudnormFilterSpec()", spec)
 	})
 

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -1211,8 +1211,8 @@ func TestCalculateLimiterCeiling(t *testing.T) {
 			targetTP:   -2.0,
 			// gain = -16.0 - (-24.9) = 8.9 dB
 			// projected TP = -5.0 + 8.9 = 3.9 dBTP (exceeds -2.0)
-			// ceiling = -2.0 - 8.9 - 1.5 = -12.4 dBTP
-			wantCeiling: -12.4,
+			// ceiling = -2.0 - 8.9 - 1.4 = -12.3 dBTP (derived: targetTP - gainRequired - margin)
+			wantCeiling: -12.3,
 			wantNeeded:  true,
 			wantClamped: false,
 		},
@@ -1224,8 +1224,8 @@ func TestCalculateLimiterCeiling(t *testing.T) {
 			targetTP:   -2.0,
 			// gain = -16.0 - (-20.0) = 4.0 dB
 			// projected TP = -3.0 + 4.0 = 1.0 dBTP (exceeds -2.0)
-			// ceiling = -2.0 - 4.0 - 1.5 = -7.5 dBTP
-			wantCeiling: -7.5,
+			// ceiling = -2.0 - 4.0 - 1.4 = -7.4 dBTP (derived: targetTP - gainRequired - margin)
+			wantCeiling: -7.4,
 			wantNeeded:  true,
 			wantClamped: false,
 		},
@@ -1273,36 +1273,36 @@ func TestCalculateLimiterCeiling(t *testing.T) {
 			targetTP:   -2.0,
 			// gain = -16.0 - (-43.0) = 27.0 dB
 			// projected TP = -20.0 + 27.0 = 7.0 dBTP (exceeds -2.0)
-			// calculated ceiling = -2.0 - 27.0 - 1.5 = -30.5 dBTP
-			// but -30.5 < -24.0, so clamped to -24.0 dBTP
+			// derived ceiling = -2.0 - 27.0 - 1.4 = -30.4 dBTP
+			// but -30.4 < -24.0, so clamped to -24.0 dBTP
 			wantCeiling: minCeiling,
 			wantNeeded:  true,
 			wantClamped: true,
 		},
 		{
 			name:       "just under minimum - clamped",
-			measuredI:  -38.0,
+			measuredI:  -40.0,
 			measuredTP: -15.0,
 			targetI:    -16.0,
 			targetTP:   -2.0,
-			// gain = -16.0 - (-38.0) = 22.0 dB
-			// projected TP = -15.0 + 22.0 = 7.0 dBTP (exceeds -2.0)
-			// calculated ceiling = -2.0 - 22.0 - 1.5 = -25.5 dBTP
-			// -25.5 < -24.0, so clamped to -24.0 dBTP
+			// gain = -16.0 - (-40.0) = 24.0 dB
+			// projected TP = -15.0 + 24.0 = 9.0 dBTP (exceeds -2.0)
+			// derived ceiling = -2.0 - 24.0 - 1.4 = -27.4 dBTP
+			// -27.4 < -24.0, so clamped to -24.0 dBTP
 			wantCeiling: minCeiling,
 			wantNeeded:  true,
 			wantClamped: true,
 		},
 		{
 			name:       "just above minimum - not clamped",
-			measuredI:  -35.0,
+			measuredI:  -33.5,
 			measuredTP: -15.0,
 			targetI:    -16.0,
 			targetTP:   -2.0,
-			// gain = -16.0 - (-35.0) = 19.0 dB
-			// projected TP = -15.0 + 19.0 = 4.0 dBTP (exceeds -2.0)
-			// ceiling = -2.0 - 19.0 - 1.5 = -22.5 dBTP (above -24.0)
-			wantCeiling: -22.5,
+			// gain = -16.0 - (-33.5) = 17.5 dB
+			// projected TP = -15.0 + 17.5 = 2.5 dBTP (exceeds -2.0)
+			// ceiling = -2.0 - 17.5 - 1.4 = -20.9 dBTP (above -24.0)
+			wantCeiling: -20.9,
 			wantNeeded:  true,
 			wantClamped: false,
 		},
@@ -1314,22 +1314,22 @@ func TestCalculateLimiterCeiling(t *testing.T) {
 			targetTP:   -2.0,
 			// gain = -16.0 - (-43.2) = 27.2 dB
 			// projected TP = -18.6 + 27.2 = 8.6 dBTP (exceeds -2.0)
-			// idealCeiling = -2.0 - 27.2 - 1.5 = -30.7 dBTP
-			// -30.7 < -24.0, so clamped to -24.0 dBTP
-			// deficit = minLimiterCeilingDB - idealCeiling = -24.0 - (-30.7) = 6.7 dB
+			// idealCeiling = -2.0 - 27.2 - 1.4 = -30.6 dBTP
+			// -30.6 < -24.0, so clamped to -24.0 dBTP
+			// deficit = minLimiterCeilingDB - idealCeiling = -24.0 - (-30.6) = 6.6 dB
 			wantCeiling: minCeiling,
 			wantNeeded:  true,
 			wantClamped: true,
 		},
 		{
 			name:       "exact clamping boundary - ceiling equals minimum exactly",
-			measuredI:  -36.5,
+			measuredI:  -36.6,
 			measuredTP: -15.0,
 			targetI:    -16.0,
 			targetTP:   -2.0,
-			// gain = -16.0 - (-36.5) = 20.5 dB
-			// projected TP = -15.0 + 20.5 = 5.5 dBTP (exceeds -2.0)
-			// ceiling = -2.0 - 20.5 - 1.5 = -24.0 dBTP (exactly minLimiterCeilingDB)
+			// gain = -16.0 - (-36.6) = 20.6 dB
+			// projected TP = -15.0 + 20.6 = 5.6 dBTP (exceeds -2.0)
+			// ceiling = -2.0 - 20.6 - 1.4 = -24.0 dBTP (exactly minLimiterCeilingDB)
 			// Not clamped: ceiling < minLimiterCeilingDB is false when equal.
 			// deficit = 0 (no pre-gain needed at the boundary)
 			wantCeiling: minCeiling,
@@ -1354,10 +1354,10 @@ func TestCalculateLimiterCeiling(t *testing.T) {
 			}
 
 			// Verify deficit arithmetic independently for clamped cases.
-			// deficit = minLimiterCeilingDB - (targetTP - gainRequired - safetyMarginDB)
+			// deficit = minLimiterCeilingDB - (targetTP - gainRequired - ceilingMarginDB)
 			if clamped {
 				gainRequired := tt.targetI - tt.measuredI
-				idealCeiling := tt.targetTP - gainRequired - safetyMarginDB
+				idealCeiling := tt.targetTP - gainRequired - ceilingMarginDB
 				deficit := minLimiterCeilingDB - idealCeiling
 				if deficit <= 0 {
 					t.Errorf("deficit should be positive when clamped, got %.2f", deficit)
@@ -1369,6 +1369,92 @@ func TestCalculateLimiterCeiling(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDerivedCeilingFormula pins the derived ceiling to its closed form:
+// ceiling = targetTP - gainRequired - ceilingMarginDB
+// = filtered_I + (targetTP - targetI) - ceilingMarginDB, the crest budget B above
+// the pre-limiter loudness less the headroom reserve.
+func TestDerivedCeilingFormula(t *testing.T) {
+	const targetI, targetTP = -16.0, -2.0
+	crestBudget := targetTP - targetI // B = 14.0 dB
+
+	cases := []struct {
+		name      string
+		filteredI float64
+		// filteredTP chosen high enough that limiting is needed (projected TP > targetTP)
+		filteredTP float64
+	}{
+		{name: "LMP-72-martin-like high crest", filteredI: -31.4, filteredTP: -11.3},
+		{name: "moderate crest", filteredI: -24.9, filteredTP: -5.0},
+		{name: "loud peaks", filteredI: -20.0, filteredTP: -3.0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ceiling, needed, clamped := calculateLimiterCeiling(c.filteredI, c.filteredTP, targetI, targetTP)
+			if !needed {
+				t.Fatalf("expected limiting to be needed for filteredI=%.1f filteredTP=%.1f", c.filteredI, c.filteredTP)
+			}
+			if clamped {
+				t.Skipf("ceiling clamped to alimiter floor; closed form not directly observable")
+			}
+			// Closed form 1: ceiling = filtered_I + B - margin
+			wantFromBudget := c.filteredI + crestBudget - ceilingMarginDB
+			// Closed form 2: ceiling = targetTP - gainRequired - margin
+			gainRequired := targetI - c.filteredI
+			wantFromGain := targetTP - gainRequired - ceilingMarginDB
+
+			if math.Abs(wantFromBudget-wantFromGain) > 0.001 {
+				t.Fatalf("closed forms disagree: filtered_I+B-margin=%.3f, targetTP-gainRequired-margin=%.3f", wantFromBudget, wantFromGain)
+			}
+			if math.Abs(ceiling-wantFromBudget) > 0.01 {
+				t.Errorf("ceiling = %.2f dBTP, want %.2f dBTP (filtered_I + B - margin)", ceiling, wantFromBudget)
+			}
+		})
+	}
+}
+
+// TestBindingGainCapOnHighCrestInput proves the gain cap binds on a high-crest
+// post-limiter signal: when the requested target would push the true peak above
+// targetTP, calculateLinearModeTarget lowers the effective target so the realised
+// scalar gain holds final TP <= targetTP (minus the 0.1 dB epsilon). It mirrors the
+// high-crest failure: post-limiter measured_I far below the pre-limiter plan, so
+// the requested -16.0 would overshoot.
+func TestBindingGainCapOnHighCrestInput(t *testing.T) {
+	const desiredI, targetTP = -16.0, -2.0
+	const epsilon = 0.1
+
+	// Post-limiter measurements after the alimiter has shaped a 24.8 dB-crest stem.
+	// measured_I sits well below the pre-limiter filtered_I the ceiling planned from,
+	// so the requested target would overshoot the true peak.
+	measuredI := -19.0
+	measuredTP := -3.0 // post-limiter crest = 16.0 dB > B (14.0), so the cap must bind
+
+	effectiveI, offset, linearPossible := calculateLinearModeTarget(measuredI, measuredTP, desiredI, targetTP)
+
+	if linearPossible {
+		t.Fatalf("expected the cap to bind (linearPossible=false) on a high-crest input; got effectiveI=%.2f", effectiveI)
+	}
+
+	// The cap pins the effective target to measured_I + (targetTP - measured_TP) - epsilon.
+	wantEffectiveI := measuredI + (targetTP - measuredTP) - epsilon
+	if math.Abs(effectiveI-wantEffectiveI) > 0.01 {
+		t.Errorf("effectiveI = %.2f, want %.2f (capped below desired %.1f)", effectiveI, wantEffectiveI, desiredI)
+	}
+	if effectiveI >= desiredI {
+		t.Errorf("effectiveI = %.2f should be strictly below desired %.1f when the cap binds", effectiveI, desiredI)
+	}
+
+	// The realised scalar gain is offset = effectiveI - measured_I. Applying it to
+	// the oversampled measured_TP must land final TP at or under targetTP.
+	predictedFinalTP := measuredTP + offset
+	if predictedFinalTP > targetTP+0.001 {
+		t.Errorf("predicted final TP = %.2f dBTP exceeds target %.1f; cap did not bind", predictedFinalTP, targetTP)
+	}
+	if math.Abs(offset-(effectiveI-measuredI)) > 0.001 {
+		t.Errorf("offset = %.3f, want effectiveI - measured_I = %.3f", offset, effectiveI-measuredI)
 	}
 }
 
@@ -1392,10 +1478,10 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 			inputThresh:  -53.0,
 			targetOffset: -2.5,
 			// gain = -16.0 - (-43.2) = 27.2
-			// idealCeiling = -2.0 - 27.2 - 1.5 = -30.7
-			// deficit = -24.0 - (-30.7) = 6.7
+			// idealCeiling = -2.0 - 27.2 - 1.4 = -30.6
+			// deficit = -24.0 - (-30.6) = 6.6
 			wantVolumeFilter: true,
-			wantDeficit:      6.7,
+			wantDeficit:      6.6,
 			wantClamped:      true,
 		},
 		{
@@ -1406,23 +1492,23 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 			inputThresh:  -35.0,
 			targetOffset: -0.5,
 			// gain = -16.0 - (-24.9) = 8.9
-			// idealCeiling = -2.0 - 8.9 - 1.5 = -12.4 (above -24.0)
+			// idealCeiling = -2.0 - 8.9 - 1.4 = -12.3 (above -24.0)
 			wantVolumeFilter: false,
 			wantDeficit:      0.0,
 			wantClamped:      false,
 		},
 		{
 			name:         "clamped - moderate deficit",
-			inputI:       -38.0,
+			inputI:       -39.5,
 			inputTP:      -15.0,
 			inputLRA:     7.0,
 			inputThresh:  -48.0,
 			targetOffset: -1.0,
-			// gain = -16.0 - (-38.0) = 22.0
-			// idealCeiling = -2.0 - 22.0 - 1.5 = -25.5
-			// deficit = -24.0 - (-25.5) = 1.5
+			// gain = -16.0 - (-39.5) = 23.5
+			// idealCeiling = -2.0 - 23.5 - 1.4 = -26.9
+			// deficit = -24.0 - (-26.9) = 2.9
 			wantVolumeFilter: true,
-			wantDeficit:      1.5,
+			wantDeficit:      2.9,
 			wantClamped:      true,
 		},
 		{
@@ -1462,7 +1548,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 				ceiling = reDerivedCeiling
 			}
 
-			filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, ceiling, needsLimiting, 48000, "")
+			filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, preGainDB, ceiling, needsLimiting, 48000, "")
 
 			// (a)/(b): Check volume filter presence
 			hasVolume := strings.Contains(filterSpec, "volume=")
@@ -1538,7 +1624,7 @@ func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 		TargetOffset: -0.5,
 	}
 
-	filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000, "")
+	filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
 
 	if config.Resample.Enabled {
 		t.Error("buildLoudnormFilterSpec mutated config.Resample.Enabled")
@@ -1562,7 +1648,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	t.Run("uses Pass 4 adeclick helper", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
 
 		const want = "adeclick=t=1.7:w=55:o=50:m=s"
 		if !strings.Contains(filterSpec, want) {
@@ -1574,7 +1660,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 		config.Adeclick.Enabled = false
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 48000, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
 
 		if strings.Contains(filterSpec, "adeclick=") {
 			t.Errorf("buildLoudnormFilterSpec() emitted disabled adeclick\nfilterSpec: %s", filterSpec)
@@ -1598,7 +1684,7 @@ func TestBuildLoudnormFilterSpecSourceRateResample(t *testing.T) {
 	t.Run("derives resample rate and orders it between loudnorm and adeclick", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 96000, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 96000, "")
 
 		const wantResample = "aresample=96000"
 		if !strings.Contains(filterSpec, wantResample) {
@@ -1624,7 +1710,7 @@ func TestBuildLoudnormFilterSpecSourceRateResample(t *testing.T) {
 	t.Run("omits resample when source rate is zero", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, 0, -1.0, false, 0, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 0, "")
 
 		if strings.Contains(filterSpec, "aresample=") {
 			t.Fatalf("buildLoudnormFilterSpec() emitted aresample for zero source rate\nfilterSpec: %s", filterSpec)
@@ -1646,7 +1732,7 @@ func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 
 	base := defaultNormalisationTestConfig()
 	assertNoStaleEffectiveConfigFields(t)
-	controlSpec := buildLoudnormFilterSpec(base, measurement, 0, -1.0, false, 48000, "")
+	controlSpec := buildLoudnormFilterSpec(base, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
 
 	withUnrelatedFilterFields := *base
 	withUnrelatedFilterFields.FilterOrder = []FilterID{FilterAnalysis}
@@ -1654,7 +1740,7 @@ func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 	withUnrelatedFilterFields.DS201Gate.Ratio = 4.0
 	withUnrelatedFilterFields.LA2A.Threshold = -30.0
 
-	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, 0, -1.0, false, 48000, "")
+	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
 	if gotSpec != controlSpec {
 		t.Fatalf("buildLoudnormFilterSpec() changed when unrelated filter fields changed\ncontrol: %s\ngot:     %s", controlSpec, gotSpec)
 	}
@@ -1681,7 +1767,7 @@ func TestPreGainCeilingRederivation(t *testing.T) {
 		},
 		{
 			name:       "moderate deficit - just below clamping",
-			measuredI:  -38.0,
+			measuredI:  -39.0,
 			measuredTP: -15.0,
 			targetI:    -16.0,
 			targetTP:   -2.0,
@@ -1720,7 +1806,7 @@ func TestPreGainCeilingRederivation(t *testing.T) {
 
 			// Step 2: calculate deficit
 			gainRequired := tt.targetI - tt.measuredI
-			idealCeiling := tt.targetTP - gainRequired - safetyMarginDB
+			idealCeiling := tt.targetTP - gainRequired - ceilingMarginDB
 			deficit := minLimiterCeilingDB - idealCeiling
 
 			if deficit <= 0 {
@@ -1770,34 +1856,39 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 		wantLinear     bool
 	}{
 		{
-			name:           "Anna - very quiet, clamped ceiling preserves full target",
-			measuredI:      -43.4,
-			measuredTP:     -19.2,
-			targetI:        -16.0,
-			targetTP:       -2.0,
+			name:       "Anna - very quiet, clamped ceiling preserves full target in linear mode",
+			measuredI:  -43.4,
+			measuredTP: -19.2,
+			targetI:    -16.0,
+			targetTP:   -2.0,
+			// gain 27.4, idealCeiling = -2 - 27.4 - 1.4 = -30.8, deficit = -24 - (-30.8) = 6.8,
+			// postGainI = -43.4 + 6.8 = -36.6, re-derived ceiling = -24.0,
+			// maxLinear = -2 - (-24) + (-36.6) - 0.1 = -14.7; -16.0 <= -14.7, so linear holds at -16.0
 			wantEffectiveI: -16.0,
 			wantLinear:     true,
 		},
 		{
-			name:           "Anna-like with different measurements",
-			measuredI:      -43.2,
-			measuredTP:     -18.6,
-			targetI:        -16.0,
-			targetTP:       -2.0,
+			name:       "Anna-like with different measurements",
+			measuredI:  -43.2,
+			measuredTP: -18.6,
+			targetI:    -16.0,
+			targetTP:   -2.0,
+			// gain 27.2, idealCeiling = -2 - 27.2 - 1.4 = -30.6, deficit = -24 - (-30.6) = 6.6,
+			// postGainI = -43.2 + 6.6 = -36.6, re-derived ceiling = -24.0,
+			// maxLinear = -2 - (-24) + (-36.6) - 0.1 = -14.7; -16.0 <= -14.7, so linear holds at -16.0
 			wantEffectiveI: -16.0,
 			wantLinear:     true,
 		},
 		{
-			name:       "extreme quiet - still clamped after pre-gain",
+			name:       "extreme quiet - large gain, clamped ceiling still linear at -16.0",
 			measuredI:  -55.0,
 			measuredTP: -30.0,
 			targetI:    -16.0,
 			targetTP:   -2.0,
-			// deficit = -24.0 - (-2.0 - (-16.0 - (-55.0)) - 1.5) = -24.0 - (-42.5) = 18.5
-			// postGainI = -55.0 + 18.5 = -36.5
-			// re-derived ceiling = -24.0
-			// maxLinear = -2.0 - (-24.0) + (-36.5) - 0.1 = -14.6
-			// -16.0 <= -14.6, so full target preserved
+			// gain = 39.0, idealCeiling = -2 - 39.0 - 1.4 = -42.4, deficit = -24 - (-42.4) = 18.4
+			// postGainI = -55.0 + 18.4 = -36.6, re-derived ceiling = -24.0
+			// maxLinear = -2.0 - (-24.0) + (-36.6) - 0.1 = -14.7
+			// -16.0 <= -14.7 is true, so linear holds at the full -16.0 target
 			wantEffectiveI: -16.0,
 			wantLinear:     true,
 		},
@@ -1818,11 +1909,11 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 
 			// Step 2: replicate the effectiveTP and effectiveMeasuredI logic
 			gainRequired := tt.targetI - tt.measuredI
-			idealCeiling := tt.targetTP - gainRequired - safetyMarginDB
+			idealCeiling := tt.targetTP - gainRequired - ceilingMarginDB
 			deficit := minLimiterCeilingDB - idealCeiling
 			postGainI := tt.measuredI + deficit
 			newGainRequired := tt.targetI - postGainI
-			reDerivedCeiling := tt.targetTP - newGainRequired - safetyMarginDB
+			reDerivedCeiling := tt.targetTP - newGainRequired - ceilingMarginDB
 			effectiveTP := reDerivedCeiling
 			effectiveMeasuredI := postGainI
 
@@ -1837,7 +1928,10 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 				t.Errorf("linearPossible = %v, want %v", linearPossible, tt.wantLinear)
 			}
 
-			// Step 4: verify buildLoudnormFilterSpec receives the full target
+			// Step 4: verify buildLoudnormFilterSpec receives the capped target.
+			// The limiter prefix is planned from the REQUESTED target I (production
+			// planLimiterForLoudnorm uses loudnorm.TargetI, not the capped value);
+			// only the loudnorm I= takes the capped effectiveTargetI.
 			config := defaultNormalisationTestConfig()
 			config.Loudnorm.TargetI = effectiveTargetI
 			measurement := &LoudnormMeasurement{
@@ -1850,16 +1944,16 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 
 			// Pre-compute values (the caller's responsibility)
 			bCeiling, bNeeded, bClamped := calculateLimiterCeiling(
-				tt.measuredI, tt.measuredTP, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
+				tt.measuredI, tt.measuredTP, tt.targetI, tt.targetTP,
 			)
 			preGainDB, bReDerived := calculatePreGain(
-				tt.measuredI, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
+				tt.measuredI, tt.targetI, tt.targetTP,
 			)
 			if bClamped {
 				bCeiling = bReDerived
 			}
 
-			filterSpec := buildLoudnormFilterSpec(config, measurement, preGainDB, bCeiling, bNeeded, 48000, "")
+			filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, preGainDB, bCeiling, bNeeded, 48000, "")
 			if !bClamped {
 				t.Error("expected pre-computation to report clamped")
 			}
@@ -1890,12 +1984,12 @@ func TestCalculatePreGain(t *testing.T) {
 			targetI:   -16.0,
 			targetTP:  -2.0,
 			// gainRequired = -16.0 - (-43.2) = 27.2
-			// idealCeiling = -2.0 - 27.2 - 1.5 = -30.7
-			// deficit = -24.0 - (-30.7) = 6.7
-			// postGainI = -43.2 + 6.7 = -36.5
-			// newGainRequired = -16.0 - (-36.5) = 20.5
-			// reDerivedCeiling = -2.0 - 20.5 - 1.5 = -24.0
-			wantPreGainDB:     6.7,
+			// idealCeiling = -2.0 - 27.2 - 1.4 = -30.6
+			// deficit = -24.0 - (-30.6) = 6.6
+			// postGainI = -43.2 + 6.6 = -36.6
+			// newGainRequired = -16.0 - (-36.6) = 20.6
+			// reDerivedCeiling = -2.0 - 20.6 - 1.4 = -24.0
+			wantPreGainDB:     6.6,
 			wantReDerivedCeil: -24.0,
 		},
 		{
@@ -1904,17 +1998,17 @@ func TestCalculatePreGain(t *testing.T) {
 			targetI:   -16.0,
 			targetTP:  -2.0,
 			// gainRequired = 8.9
-			// idealCeiling = -2.0 - 8.9 - 1.5 = -12.4 (above -24.0)
+			// idealCeiling = -2.0 - 8.9 - 1.4 = -12.3 (above -24.0)
 			wantPreGainDB:     0.0,
 			wantReDerivedCeil: 0.0,
 		},
 		{
 			name:      "boundary - ideal ceiling equals minLimiterCeilingDB exactly",
-			measuredI: -36.5,
+			measuredI: -36.6,
 			targetI:   -16.0,
 			targetTP:  -2.0,
-			// gainRequired = 20.5
-			// idealCeiling = -2.0 - 20.5 - 1.5 = -24.0 (exactly minLimiterCeilingDB)
+			// gainRequired = 20.6
+			// idealCeiling = -2.0 - 20.6 - 1.4 = -24.0 (exactly minLimiterCeilingDB)
 			wantPreGainDB:     0.0,
 			wantReDerivedCeil: 0.0,
 		},
@@ -2059,9 +2153,9 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 				InputThresh:  -35.0,
 				TargetOffset: -0.5,
 			},
-			wantPass3:      "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
-			wantPass4Start: "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
-			wantPass4:      "alimiter=limit=0.239883:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-24.90:measured_TP=-5.00:measured_LRA=6.00:measured_thresh=-35.00:offset=-0.50:dual_mono=true:linear=true:print_format=json,aresample=48000,adeclick=t=1.7:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+			wantPass3:      "alimiter=limit=0.242661:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
+			wantPass4Start: "alimiter=limit=0.242661:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
+			wantPass4:      "alimiter=limit=0.242661:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-24.90:measured_TP=-5.00:measured_LRA=6.00:measured_thresh=-35.00:offset=-0.50:dual_mono=true:linear=true:print_format=json,aresample=48000,adeclick=t=1.7:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
 		},
 		{
 			name:     "clamped pre-gain",
@@ -2074,9 +2168,9 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 				InputThresh:  -46.5,
 				TargetOffset: -2.5,
 			},
-			wantPass3:      "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
-			wantPass4Start: "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
-			wantPass4:      "volume=6.7dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-36.50:measured_TP=-24.00:measured_LRA=8.00:measured_thresh=-46.50:offset=-2.50:dual_mono=true:linear=true:print_format=json,aresample=48000,adeclick=t=1.7:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
+			wantPass3:      "volume=6.6dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8",
+			wantPass4Start: "volume=6.6dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=",
+			wantPass4:      "volume=6.6dB,alimiter=limit=0.063096:attack=5:release=100:level_in=1:level_out=1:level=0:latency=1:asc=1:asc_level=0.8,loudnorm=I=-16.00:TP=-2.00:LRA=20.0:measured_I=-36.50:measured_TP=-24.00:measured_LRA=8.00:measured_thresh=-46.50:offset=-2.50:dual_mono=true:linear=true:print_format=json,aresample=48000,adeclick=t=1.7:w=55:o=50:m=s,astats=metadata=1:measure_perchannel=all,aspectralstats=win_size=2048:win_func=hann:measure=all,ebur128=metadata=1:peak=sample+true:dualmono=true,aformat=sample_rates=44100:channel_layouts=mono:sample_fmts=s16,asetnsamples=n=4096", // #nosec G101 -- FFmpeg filter fixture, not a credential.
 		},
 	}
 
@@ -2096,6 +2190,7 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 			gotPass4 := buildLoudnormFilterSpec(
 				config,
 				&tt.measurement,
+				tt.measurement.TargetOffset,
 				limiter.preGainDB,
 				limiter.ceilingDB,
 				limiter.needed,

--- a/internal/processor/quality_test.go
+++ b/internal/processor/quality_test.go
@@ -86,9 +86,9 @@ func TestComputeQualityScoreNoisyOutputDropsNoise(t *testing.T) {
 // scorer rewarded the *reduction amount*, so the clean file scored lower; the new
 // scorer rewards output cleanliness, so the clean output wins or ties.
 func TestComputeQualityScoreCleanInputNotPenalised(t *testing.T) {
-	// Clean recording: -80 dBFS input, stays clean at -80 dBFS output (mark/popey).
+	// Clean recording: -80 dBFS input, stays clean at -80 dBFS output.
 	clean := ComputeQualityScore(resultWith(-16.0, -2.0, -80.0, -80.0))
-	// Noisier recording: -67 dBFS input, processed to -67 dBFS output (martin).
+	// Noisier recording: -67 dBFS input, processed to -67 dBFS output.
 	noisy := ComputeQualityScore(resultWith(-16.0, -2.0, -67.0, -67.0))
 
 	if clean.Score < noisy.Score {


### PR DESCRIPTION
Replaced undocumented safetyMarginDB = 1.5 magic number with corpus-derived p95 value of 1.4 dB. Added binding gain cap (calculateLinearModeTarget) as true-peak safety backstop.

Validation: confirmed no serious regressions, loudness parity with legacy 0.3.1, 47/48 files ≤ −2.0 dBTP target. High-crest outlier (24.8 dB crest) accepted with cap trade-off (−16.0 LUFS, −1.9 dBTP). Updated normalise tests, extended report diagnostics, corrected root-cause attribution in docs (post-loudnorm peak growth, not makeup feedback), and genericized code comments.