### PR TITLE
refactor: consolidate codebase with resource safety and performance fixes

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -72,6 +72,8 @@ jobs:
           cd third_party/ffmpeg-statigo
           go run ./cmd/download-lib
       - uses: robherley/go-test-action@v1
+        env:
+          CGO_ENABLED: 1
         with:
           testArguments: -coverprofile=coverage.out -covermode=atomic ./...
           omit: untested
@@ -111,6 +113,8 @@ jobs:
           cd third_party/ffmpeg-statigo
           go run ./cmd/download-lib
       - name: Test
+        env:
+          CGO_ENABLED: 1
         run: go test ./...
 
   security:
@@ -214,6 +218,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Building jivetalking $VERSION for ${{ matrix.os }}/${{ matrix.arch }}"
       - name: Build binary
+        env:
+          CGO_ENABLED: 1
         run: |
           go build -ldflags="-X main.version=${{ steps.version.outputs.version }}" -o jivetalking-${{ matrix.os }}-${{ matrix.arch }} ./cmd/jivetalking
       - name: Upload artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ Pass 3: [volume (pre-gain, when clamped) → alimiter (levelling limiter)] → l
 Pass 4: volume (pre-gain, when clamped) → alimiter (levelling limiter, peak reduction) → loudnorm (linear mode, input stats from Pass 3) → aresample (source rate) → adeclick → alimiter (final-stage brickwall, source rate) → astats → aspectralstats → ebur128
 ```
 
+> The corpus derivation for the loudnorm and limiter tuning constants (`brickwallTruePeakHeadroomDB`, `measurementCushionDB`, `linearSafetyMargin`, the `loudnormTP`/`minLimiterCeiling` bounds) lives in `docs/Normalisation-Tuning.md`. The code comments in `normalise.go` point there; do not re-inline the rationale.
+
 **Output filename:** `<name>-LUFS-NN-processed.<ext>` where NN is the rounded (nearest whole) absolute LUFS value of the final output (e.g., -26.8 LUFS produces `LUFS-27`). The matching always-on report is `<name>-LUFS-NN-processed.md`; analysis-only writes `<input>-analysis.md`.
 
 **Diagnostic artefacts (`--diagnostics`, default OFF):** the flag gates three bulk diagnostic outputs written beside the `.md`/`.json`/`.flac`:

--- a/README.md
+++ b/README.md
@@ -221,3 +221,4 @@ The full source layout, architecture, and contribution standards live in [AGENTS
 - [Audio Pipeline](docs/Pipeline.md): how and why the processing pipeline is built and tuned, with a diagram
 - [The hardware that taught me](docs/Inspiration.md): the influences and heritage behind jivetalking's processing approach
 - [Spectral Metrics Reference](docs/Spectral-Metrics-Reference.md): how measurements drive adaptation
+- [Normalisation Tuning](docs/Normalisation-Tuning.md): why the loudnorm and limiter constants hold their corpus-derived values

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Record → Process → Edit → Export
   └─ Each presenter records separately, exports FLAC
 ```
 
-**Include 10-15 seconds of room tone somewhere in your recording.** Just sit quietly and let the room breathe - at the start, between sections, or at the end. Jivetalking scans the entire file to find the cleanest room-tone section for building a noise profile, which calibrates the adaptive gate and highpass in Pass 2. The `anlmdn → afftdn` noise reduction runs regardless, so recordings without a clean room-tone section are still denoised.
+**Include 10-15 seconds of room tone somewhere in your recording.** Just sit quietly and let the room breathe - at the start, between sections, or at the end. Jivetalking scans the entire file to find the cleanest quiet stretch and builds a noise profile from it, used by the noise-reduction and gate stages in Pass 2. The `anlmdn → afftdn` noise reduction runs regardless, so recordings without a clean room-tone section are still denoised.
 
 ---
 

--- a/cmd/jivetalking/analysispool.go
+++ b/cmd/jivetalking/analysispool.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"sync"
 
 	"github.com/linuxmatters/jivetalking/internal/audio"
 	"github.com/linuxmatters/jivetalking/internal/processor"
@@ -39,96 +38,74 @@ func defaultAnalysisPoolDeps() analysisPoolDeps {
 }
 
 // runAnalysisPool analyses files concurrently under a bounded worker pool
-// sharing one tea.Program. A buffered semaphore of size env.jobs caps in-flight
-// workers; a sync.WaitGroup tracks completion. Each worker owns its file index,
-// a per-file prefixed logger, and a per-worker config clone, mirroring
-// runWorkerPool in pool.go. After all workers finish it sends ui.AllCompleteMsg.
-// With env.jobs == 1 the observable outcome matches the serial path.
+// sharing one tea.Program. It supplies its per-file body to the shared
+// runBoundedPool skeleton (which owns the semaphore, the WaitGroup, the
+// ctx.Done() acquire-or-bail, and the final ui.AllCompleteMsg send). Each worker
+// owns its file index, a per-file prefixed logger, and a per-worker config
+// clone, mirroring runWorkerPool in pool.go. With env.jobs == 1 the observable
+// outcome matches the serial path.
 //
 // The caller pre-allocates slots to len(env.files); each worker writes only its
 // own slots[i], so no slot is shared. Ordered printing happens in the caller
 // after this returns.
 //
 // When env.p is nil the same body runs the no-TTY path with no p.Send calls:
-// every p.Send is gated by a p != nil check.
+// every p.Send is gated by a p != nil check (runBoundedPool gates the final
+// AllCompleteMsg the same way).
 //
 // On cancellation a not-yet-started worker skips its work via the ctx.Done()
 // select at acquire, while an in-flight worker aborts mid-frame because ctx is
 // threaded into deps.analyse. Either way wg.Done() fires so wg.Wait() returns
 // and ui.AllCompleteMsg is sent.
 func runAnalysisPool(env poolEnv, slots []analysisSlot, deps analysisPoolDeps) {
-	sem := make(chan struct{}, env.jobs)
-	var wg sync.WaitGroup
+	runBoundedPool(env, nil, func(i int, inputPath string, wlog func(string, ...any)) {
+		if env.p != nil {
+			wlog("[ANALYSIS-POOL] Sending AnalysisStartMsg for file %d: %s", i, inputPath)
+			env.p.Send(ui.AnalysisStartMsg{
+				FileIndex: i,
+				FileName:  inputPath,
+				FilePath:  inputPath,
+			})
+		}
 
-	for i, inputPath := range env.files {
-		wg.Go(func() {
-			// Acquire the semaphore, but bail out if ctx is already cancelled so
-			// a not-yet-started worker skips its work cleanly. Only release the
-			// slot when this branch actually took one.
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-env.ctx.Done():
-				return
-			}
-
-			wlog := withFilePrefix(inputPath, env.sharedLog)
-
+		meta, err := deps.openMetadata(inputPath)
+		slots[i].meta = meta
+		if err != nil {
+			wlog("[ANALYSIS-POOL] openMetadata failed: %v", err)
+			slots[i].err = err
 			if env.p != nil {
-				wlog("[ANALYSIS-POOL] Sending AnalysisStartMsg for file %d: %s", i, inputPath)
-				env.p.Send(ui.AnalysisStartMsg{
-					FileIndex: i,
-					FileName:  inputPath,
-					FilePath:  inputPath,
-				})
-			}
-
-			meta, err := deps.openMetadata(inputPath)
-			slots[i].meta = meta
-			if err != nil {
-				wlog("[ANALYSIS-POOL] openMetadata failed: %v", err)
-				slots[i].err = err
-				if env.p != nil {
-					env.p.Send(ui.AnalysisCompleteMsg{
-						FileIndex: i,
-						Error:     err,
-					})
-				}
-				return
-			}
-
-			clone := env.base.CloneForWorker(wlog)
-
-			var cb processor.ProgressCallback
-			if env.p != nil {
-				cb = func(update processor.ProgressUpdate) {
-					wlog("[ANALYSIS-POOL] Progress: Pass %d (%s), %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
-					env.p.Send(ui.AnalysisProgressMsg{
-						FileIndex: i,
-						Progress:  update.Progress,
-						Level:     update.Level,
-					})
-				}
-			}
-
-			wlog("[ANALYSIS-POOL] Starting AnalyseOnlyDetailed for %s", inputPath)
-			slots[i].result, slots[i].err = deps.analyse(env.ctx, inputPath, clone, cb)
-
-			if env.p != nil {
-				wlog("[ANALYSIS-POOL] Sending AnalysisCompleteMsg for file %d", i)
 				env.p.Send(ui.AnalysisCompleteMsg{
 					FileIndex: i,
-					Result:    slots[i].result,
-					Error:     slots[i].err,
+					Error:     err,
 				})
 			}
-		})
-	}
+			return
+		}
 
-	wg.Wait()
+		clone := env.base.CloneForWorker(wlog)
 
-	if env.p != nil {
-		env.sharedLog("[ANALYSIS-POOL] Sending AllCompleteMsg")
-		env.p.Send(ui.AllCompleteMsg{})
-	}
+		var cb processor.ProgressCallback
+		if env.p != nil {
+			cb = func(update processor.ProgressUpdate) {
+				wlog("[ANALYSIS-POOL] Progress: Pass %d (%s), %.1f%%, Level %.1f dB", update.Pass, update.PassName, update.Progress*100, update.Level)
+				env.p.Send(ui.AnalysisProgressMsg{
+					FileIndex: i,
+					Progress:  update.Progress,
+					Level:     update.Level,
+				})
+			}
+		}
+
+		wlog("[ANALYSIS-POOL] Starting AnalyseOnlyDetailed for %s", inputPath)
+		slots[i].result, slots[i].err = deps.analyse(env.ctx, inputPath, clone, cb)
+
+		if env.p != nil {
+			wlog("[ANALYSIS-POOL] Sending AnalysisCompleteMsg for file %d", i)
+			env.p.Send(ui.AnalysisCompleteMsg{
+				FileIndex: i,
+				Result:    slots[i].result,
+				Error:     slots[i].err,
+			})
+		}
+	})
 }

--- a/cmd/jivetalking/analysispool.go
+++ b/cmd/jivetalking/analysispool.go
@@ -61,13 +61,7 @@ func runAnalysisPool(env poolEnv, slots []analysisSlot, deps analysisPoolDeps) {
 	var wg sync.WaitGroup
 
 	for i, inputPath := range env.files {
-		wg.Add(1)
-		go func(i int, inputPath string) {
-			// Register wg.Done() before the acquire select so a worker skipped
-			// on a cancelled ctx still decrements the WaitGroup; otherwise
-			// wg.Wait() hangs.
-			defer wg.Done()
-
+		wg.Go(func() {
 			// Acquire the semaphore, but bail out if ctx is already cancelled so
 			// a not-yet-started worker skips its work cleanly. Only release the
 			// slot when this branch actually took one.
@@ -128,7 +122,7 @@ func runAnalysisPool(env poolEnv, slots []analysisSlot, deps analysisPoolDeps) {
 					Error:     slots[i].err,
 				})
 			}
-		}(i, inputPath)
+		})
 	}
 
 	wg.Wait()

--- a/cmd/jivetalking/analysispool_integration_test.go
+++ b/cmd/jivetalking/analysispool_integration_test.go
@@ -39,7 +39,7 @@ import (
 //
 // Driven with p == nil so no real terminal is needed. Production sends
 // ui.AllCompleteMsg after wg.Wait() unconditionally when p != nil; that TTY path
-// is covered by the model quit tests (1.5 / 5.1). [AC5 / 5.6]
+// is covered by the model quit tests.
 func TestRunAnalysisPool_CancellationAbortsPromptly(t *testing.T) {
 	const n = 6
 	const jobs = 2 // < n so the other n-jobs workers stay queued at the acquire select
@@ -122,13 +122,13 @@ func waitForExtraEntry(entered <-chan struct{}, d time.Duration) bool {
 // TestRunAnalysisPool_ConcurrentRaceClean drives runAnalysisPool with jobs >= 2
 // over two distinct REAL fixture copies through the REAL
 // processor.AnalyseOnlyDetailed and the REAL openAudioMetadata opener. Unlike the
-// seam-based 2.3 tests, it runs actual concurrent FFmpeg analysis so `-race`
+// seam-based unit tests, it runs actual concurrent FFmpeg analysis so `-race`
 // observes the genuine concurrent paths: the shared debugSink-backed logger
 // (whole-line atomic writes), the per-worker CloneForWorker config clones, and the
 // pre-allocated results/metas/errs slots each worker writes only its own slot of.
 // It drives with p == nil (no tea.Program, no TTY) to keep the race test focused
 // on the pool internals. After the run every slot must be populated
-// (results[i] != nil, errs[i] == nil, metas[i] != nil). [AC2 / 5.1]
+// (results[i] != nil, errs[i] == nil, metas[i] != nil).
 func TestRunAnalysisPool_ConcurrentRaceClean(t *testing.T) {
 	src := findPoolTestAudio(t)
 	if src == "" {

--- a/cmd/jivetalking/analysispool_test.go
+++ b/cmd/jivetalking/analysispool_test.go
@@ -96,7 +96,7 @@ func (f *inflightAnalysisFake) fn(_ context.Context, inputPath string, _ *proces
 // TestRunAnalysisPool_InFlightBoundedToJobs asserts jobs == 3 caps in-flight
 // analysis workers at 3 over 8 files while still reaching real concurrency (>1),
 // proving the semaphore both bounds and permits parallelism. Drives the pool
-// with p == nil (no real tea.Program). [AC3 / 2.3(a)]
+// with p == nil (no real tea.Program).
 func TestRunAnalysisPool_InFlightBoundedToJobs(t *testing.T) {
 	const n = 8
 	const jobs = 3
@@ -126,7 +126,7 @@ func TestRunAnalysisPool_InFlightBoundedToJobs(t *testing.T) {
 
 // TestRunAnalysisPool_SerialParityJobs1 asserts jobs == 1 holds in-flight
 // analysis workers to a single concurrent call (high-water == 1), the serial
-// outcome under the pool. [AC3 / 2.3(b)]
+// outcome under the pool.
 func TestRunAnalysisPool_SerialParityJobs1(t *testing.T) {
 	const n = 8
 
@@ -160,7 +160,7 @@ func TestRunAnalysisPool_SerialParityJobs1(t *testing.T) {
 // barrier, then blocks on barrier.Wait(), so no worker proceeds until all three
 // are simultaneously in-flight. high-water therefore reaches exactly 3 every run.
 // Were the pool to cap below 3, fewer than 3 workers would enter, barrier.Wait()
-// would never release, and the test would hang rather than flake. [AC3 / 5.2]
+// would never release, and the test would hang rather than flake.
 func TestRunAnalysisPool_JobsAboveFileCountNoCap(t *testing.T) {
 	const n = 3
 	const jobs = 64 // > n and > any realistic NumCPU
@@ -215,7 +215,7 @@ func TestRunAnalysisPool_JobsAboveFileCountNoCap(t *testing.T) {
 // first, so completion order is the reverse of submission order. With jobs >= n
 // every worker runs concurrently, so the staggered delays decide completion
 // order. Each slot must still carry its own index (encoded in
-// AdaptationDuration and in metas' SampleRate). [AC1 / 2.3(c)]
+// AdaptationDuration and in metas' SampleRate).
 func TestRunAnalysisPool_OrderedSlots(t *testing.T) {
 	const n = 6
 
@@ -280,7 +280,7 @@ func TestRunAnalysisPool_OrderedSlots(t *testing.T) {
 // TestRunAnalysisPool_FailureIsolation drives the pool where one index errors and
 // the rest succeed. It asserts errs[failIdx] is set, sibling results are non-nil
 // with nil errs, and (with p == nil) runAnalysisPool returns only after ALL
-// workers finish (no early abort). [AC4 / 2.3(d)]
+// workers finish (no early abort).
 func TestRunAnalysisPool_FailureIsolation(t *testing.T) {
 	const n = 6
 	const failIdx = 1

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -144,9 +144,10 @@ func main() {
 	// AllComplete sends do not block, and the acquire-time ctx.Done() select
 	// lets not-yet-started workers exit at once.
 	<-poolDone
+	close(reportWarnings)
 
-	if err := runErr; err != nil {
-		cli.PrintError(fmt.Sprintf("UI error: %v", err))
+	if runErr != nil {
+		cli.PrintError(fmt.Sprintf("UI error: %v", runErr))
 		if debugLog != nil {
 			debugLog.Close()
 		}
@@ -161,13 +162,8 @@ func main() {
 		fmt.Fprintln(colorprofile.NewWriter(os.Stdout, os.Environ()), ui.FinalSummary(m))
 	}
 
-	for {
-		select {
-		case warning := <-reportWarnings:
-			cli.PrintWarning(warning)
-		default:
-			return
-		}
+	for warning := range reportWarnings {
+		cli.PrintWarning(warning)
 	}
 }
 

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -183,7 +183,7 @@ type analysisOnlyDeps struct {
 	stdout              io.Writer
 	hasTTY              func() bool
 	openMetadata        func(string) (*audio.Metadata, error)
-	analyseDetailed     func(context.Context, string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)
+	analyse             func(context.Context, string, *processor.BaseFilterConfig, processor.ProgressCallback) (*processor.AnalysisResult, error)
 	printError          func(string)
 	writeMarkdownReport func(*processor.RunRecord, report.Timings, string) error
 	writeRunRecord      func(*processor.RunRecord, string) error
@@ -196,7 +196,7 @@ func defaultAnalysisOnlyDeps() analysisOnlyDeps {
 		stdout:              os.Stdout,
 		hasTTY:              isTTY,
 		openMetadata:        pool.openMetadata,
-		analyseDetailed:     pool.analyse,
+		analyse:             pool.analyse,
 		printError:          cli.PrintError,
 		writeMarkdownReport: report.WriteMarkdownReport,
 		writeRunRecord:      processor.WriteRunRecord,
@@ -322,7 +322,7 @@ func runAnalysisOnlyWithDeps(files []string, config *processor.BaseFilterConfig,
 	slots := make([]analysisSlot, len(files))
 
 	poolDeps := analysisPoolDeps{
-		analyse:      deps.analyseDetailed,
+		analyse:      deps.analyse,
 		openMetadata: deps.openMetadata,
 	}
 

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -103,19 +103,19 @@ func TestProgressCallbackBoundariesUseProcessorEvent(t *testing.T) {
 	progressUpdateType := reflect.TypeFor[processor.ProgressUpdate]()
 
 	depsType := reflect.TypeFor[analysisOnlyDeps]()
-	analyseDetailed, ok := depsType.FieldByName("analyseDetailed")
+	analyse, ok := depsType.FieldByName("analyse")
 	if !ok {
-		t.Fatal("analysisOnlyDeps has no analyseDetailed field")
+		t.Fatal("analysisOnlyDeps has no analyse field")
 	}
-	if analyseDetailed.Type.Kind() != reflect.Func {
-		t.Fatalf("analysisOnlyDeps.analyseDetailed = %s, want func", analyseDetailed.Type)
+	if analyse.Type.Kind() != reflect.Func {
+		t.Fatalf("analysisOnlyDeps.analyse = %s, want func", analyse.Type)
 	}
-	if analyseDetailed.Type.NumIn() != 4 {
-		t.Fatalf("analysisOnlyDeps.analyseDetailed has %d parameters, want 4", analyseDetailed.Type.NumIn())
+	if analyse.Type.NumIn() != 4 {
+		t.Fatalf("analysisOnlyDeps.analyse has %d parameters, want 4", analyse.Type.NumIn())
 	}
-	if analyseDetailed.Type.In(3) != progressCallbackType {
-		t.Fatalf("analysisOnlyDeps.analyseDetailed progress callback = %s, want %s",
-			analyseDetailed.Type.In(3), progressCallbackType)
+	if analyse.Type.In(3) != progressCallbackType {
+		t.Fatalf("analysisOnlyDeps.analyse progress callback = %s, want %s",
+			analyse.Type.In(3), progressCallbackType)
 	}
 
 	callbackType := reflect.TypeOf((&progressHandler{}).callback)
@@ -135,7 +135,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 
 	analyse := func(_ context.Context, path string, cfg *processor.BaseFilterConfig, progress processor.ProgressCallback) (*processor.AnalysisResult, error) {
 		if path != inputPath {
-			t.Fatalf("analyseDetailed path = %q, want %q", path, inputPath)
+			t.Fatalf("analyse path = %q, want %q", path, inputPath)
 		}
 		effective, diagnostics := processor.AdaptConfig(cfg, makeAnalysisOnlyTestMeasurements())
 		return &processor.AnalysisResult{
@@ -163,7 +163,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		analyseDetailed: analyse,
+		analyse: analyse,
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
 		},
@@ -240,7 +240,7 @@ func TestRunAnalysisOnlyWithDeps_DiagnosticsGatesSidecars(t *testing.T) {
 			openMetadata: func(string) (*audio.Metadata, error) {
 				return &audio.Metadata{Duration: 120, SampleRate: 48000, Channels: 1}, nil
 			},
-			analyseDetailed: analyse,
+			analyse: analyse,
 			// The synthetic input (stem.wav) does not exist on disk, so the
 			// diagnostics-on spectrogram renders fail to open it and surface a
 			// non-fatal "Failed to render analysis spectrogram" message. That is
@@ -335,7 +335,7 @@ func TestRunAnalysisOnlyWithDeps_PassesPerWorkerConfigClones(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		analyseDetailed: analyse,
+		analyse: analyse,
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
 		},
@@ -381,7 +381,7 @@ func TestRunAnalysisOnlyWithDeps_OrderedOutputParityAcrossJobs(t *testing.T) {
 	analyse := func(_ context.Context, path string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) { //nolint:unparam // signature must match processor.AnalyseOnlyDetailed
 		index, ok := fileIndex[path]
 		if !ok {
-			t.Fatalf("analyseDetailed unexpected path %q", path)
+			t.Fatalf("analyse unexpected path %q", path)
 		}
 
 		// Later indices sleep less, so under concurrency they complete first.
@@ -420,7 +420,7 @@ func TestRunAnalysisOnlyWithDeps_OrderedOutputParityAcrossJobs(t *testing.T) {
 					Channels:   1,
 				}, nil
 			},
-			analyseDetailed:     analyse,
+			analyse:             analyse,
 			writeMarkdownReport: reports.write,
 			printError: func(message string) {
 				t.Fatalf("printError called: %s", message)
@@ -489,7 +489,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYBannerThenOrderedReports(t *testing.T) {
 	analyse := func(_ context.Context, path string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
 		index, ok := fileIndex[path]
 		if !ok {
-			t.Fatalf("analyseDetailed unexpected path %q", path)
+			t.Fatalf("analyse unexpected path %q", path)
 		}
 
 		delay := time.Duration(len(files)-index) * 20 * time.Millisecond
@@ -524,7 +524,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYBannerThenOrderedReports(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		analyseDetailed:     analyse,
+		analyse:             analyse,
 		writeMarkdownReport: reports.write,
 		printError: func(message string) {
 			t.Fatalf("printError called: %s", message)
@@ -599,7 +599,7 @@ func TestRunAnalysisOnlyWithDeps_FailureIsolation(t *testing.T) {
 	analyse := func(_ context.Context, path string, _ *processor.BaseFilterConfig, _ processor.ProgressCallback) (*processor.AnalysisResult, error) {
 		index, ok := fileIndex[path]
 		if !ok {
-			t.Fatalf("analyseDetailed unexpected path %q", path)
+			t.Fatalf("analyse unexpected path %q", path)
 		}
 		if index == failIndex {
 			return nil, boom
@@ -633,7 +633,7 @@ func TestRunAnalysisOnlyWithDeps_FailureIsolation(t *testing.T) {
 				Channels:   1,
 			}, nil
 		},
-		analyseDetailed:     analyse,
+		analyse:             analyse,
 		writeMarkdownReport: reports.write,
 		printError: func(message string) {
 			printErrMu.Lock()

--- a/cmd/jivetalking/main_test.go
+++ b/cmd/jivetalking/main_test.go
@@ -209,8 +209,8 @@ func TestRunAnalysisOnlyWithDeps_NonTTYOmitsBenchPath(t *testing.T) {
 	}
 }
 
-// TestRunAnalysisOnlyWithDeps_DiagnosticsGatesSidecars proves the T2.2 contract
-// on the analysis-only path: with --diagnostics off the .jsonl sidecar write is
+// TestRunAnalysisOnlyWithDeps_DiagnosticsGatesSidecars proves the diagnostics
+// gate on the analysis-only path: with --diagnostics off the .jsonl sidecar write is
 // skipped while the .md report and .json record still write; with it on the
 // sidecar write fires exactly once, beside the record. The deps stubs record
 // each write so the test asserts the gate without touching the filesystem.
@@ -537,7 +537,7 @@ func TestRunAnalysisOnlyWithDeps_NonTTYBannerThenOrderedReports(t *testing.T) {
 
 	// stdout starts with the up-front banner (byte-for-byte: single U+2026
 	// ellipsis, trailing newline), matching the production main.go no-TTY
-	// branch and the 3.3 test assertion.
+	// branch.
 	banner := "Analysing 3 files…\n"
 	if !strings.HasPrefix(got, banner) {
 		t.Fatalf("output does not start with banner %q:\n%s", banner, got)

--- a/cmd/jivetalking/pool.go
+++ b/cmd/jivetalking/pool.go
@@ -104,33 +104,24 @@ func launchWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- strin
 	return done
 }
 
-// runWorkerPool processes files concurrently under a bounded worker pool sharing
-// one tea.Program. A buffered semaphore of size jobs caps in-flight workers; a
-// sync.WaitGroup tracks completion. Each worker owns its file index, a per-file
-// prefixed logger, and a per-worker config clone, mirroring the serial loop's
-// per-file body. After all workers finish it sends ui.AllCompleteMsg. With
-// jobs == 1 the observable outcome matches the serial path.
+// runBoundedPool is the shared bounded-worker-pool skeleton both pools run. A
+// buffered semaphore of size env.jobs caps in-flight workers; a sync.WaitGroup
+// tracks completion. For each file it spawns a worker that acquires the
+// semaphore or bails on env.ctx.Done() (a not-yet-started worker skips its work
+// cleanly; the slot is released only on the branch that took one), derives a
+// per-file prefixed logger, and runs the caller's body with the file index,
+// input path, and that logger. wg.Done() always fires - including the
+// cancellation bail - so wg.Wait() returns even when ctx is cancelled.
 //
-// On cancellation a not-yet-started worker skips its work via the ctx.Done()
-// select at acquire, while an in-flight worker aborts mid-frame because ctx is
-// threaded into ProcessAudio. Either way wg.Done() fires so wg.Wait() returns
-// and ui.AllCompleteMsg is sent.
-//
-// diagnostics gates the bulk diagnostic artefacts (the .jsonl sidecars and the
-// spectrogram PNGs). When false the always-on set (.flac/.md/.json) still
-// writes; only the opt-in sidecars are skipped.
-func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, deps workerPoolDeps) {
+// After wg.Wait() it runs the optional afterWait hook (the processing pool
+// drains its spectrogram-render WaitGroup here so the process does not exit
+// until every PNG lands), then sends ui.AllCompleteMsg gated on env.p != nil:
+// the processing pool always has a non-nil program, while the no-TTY analysis
+// path passes nil and must not call p.Send. Each body owns every other p.Send
+// and self-gates on env.p, so a nil program never deadlocks a worker.
+func runBoundedPool(env poolEnv, afterWait func(), body func(i int, inputPath string, wlog func(string, ...any))) {
 	sem := make(chan struct{}, env.jobs)
 	var wg sync.WaitGroup
-
-	// Spectrogram renders run in background goroutines off the file-worker critical
-	// path. specSem bounds them to the jobs budget shared across ALL files - one
-	// pool-level semaphore, never one unbounded goroutine per PNG, so ffmpeg is not
-	// oversubscribed beyond the worker budget. specWG tracks every render so the
-	// pool waits for all PNGs before AllCompleteMsg / program exit.
-	specSem := make(chan struct{}, env.jobs)
-	var specWG sync.WaitGroup
-	render := processingRenderScheduler{sem: specSem, wg: &specWG}
 
 	for i, inputPath := range env.files {
 		wg.Go(func() {
@@ -144,9 +135,60 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 				return
 			}
 
-			fileStartTime := time.Now()
-
 			wlog := withFilePrefix(inputPath, env.sharedLog)
+			body(i, inputPath, wlog)
+		})
+	}
+
+	wg.Wait()
+
+	if afterWait != nil {
+		afterWait()
+	}
+
+	if env.p != nil {
+		env.sharedLog("[POOL] Sending AllCompleteMsg")
+		env.p.Send(ui.AllCompleteMsg{})
+	}
+}
+
+// runWorkerPool processes files concurrently under a bounded worker pool sharing
+// one tea.Program. It supplies its per-file body to the shared runBoundedPool
+// skeleton (which owns the semaphore, the WaitGroup, the ctx.Done() acquire-or-
+// bail, and the final ui.AllCompleteMsg send). Each worker owns its file index,
+// a per-file prefixed logger, and a per-worker config clone, mirroring the
+// serial loop's per-file body. With jobs == 1 the observable outcome matches the
+// serial path.
+//
+// On cancellation a not-yet-started worker skips its work via the ctx.Done()
+// select at acquire, while an in-flight worker aborts mid-frame because ctx is
+// threaded into ProcessAudio. Either way wg.Done() fires so wg.Wait() returns
+// and ui.AllCompleteMsg is sent.
+//
+// diagnostics gates the bulk diagnostic artefacts (the .jsonl sidecars and the
+// spectrogram PNGs). When false the always-on set (.flac/.md/.json) still
+// writes; only the opt-in sidecars are skipped.
+func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, deps workerPoolDeps) {
+	// Spectrogram renders run in background goroutines off the file-worker critical
+	// path. specSem bounds them to the jobs budget shared across ALL files - one
+	// pool-level semaphore, never one unbounded goroutine per PNG, so ffmpeg is not
+	// oversubscribed beyond the worker budget. specWG tracks every render so the
+	// pool waits for all PNGs before AllCompleteMsg / program exit.
+	specSem := make(chan struct{}, env.jobs)
+	var specWG sync.WaitGroup
+	render := processingRenderScheduler{sem: specSem, wg: &specWG}
+
+	runBoundedPool(env,
+		// Gate program exit on the spectrogram renders: every file's per-file
+		// FileCompleteMsg has already fired (wg drained), so the file-worker TUI
+		// is not held up; only AllCompleteMsg (which quits the program) waits
+		// here, so the process does not exit until every PNG lands. On a user ctx
+		// cancel the in-flight renders abort and clean their partials, then specWG
+		// drains. With --diagnostics off nothing was launched, so this returns at
+		// once.
+		specWG.Wait,
+		func(i int, inputPath string, wlog func(string, ...any)) {
+			fileStartTime := time.Now()
 
 			wlog("[POOL] Sending FileStartMsg for file %d: %s", i, inputPath)
 			env.p.Send(ui.FileStartMsg{
@@ -168,8 +210,8 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 			if err != nil {
 				wlog("[POOL] ProcessAudio failed: %v", err)
 				env.p.Send(ui.FileCompleteMsg{
-					FileIndex: i,
-					Error:     err,
+					FileIndex:        i,
+					CompletionResult: ui.CompletionResult{Error: err},
 				})
 				return
 			}
@@ -180,20 +222,6 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 
 			emitProcessingReport(env, inputPath, result, ph, processingTimings{fileStart: fileStartTime, pass2: pass2Time}, diagnostics, reportWarnings, render)
 		})
-	}
-
-	wg.Wait()
-
-	// Gate program exit on the spectrogram renders: every file's per-file
-	// FileCompleteMsg has already fired (wg drained), so the file-worker TUI is not
-	// held up; only AllCompleteMsg (which quits the program) waits here, so the
-	// process does not exit until every PNG lands. On a user ctx cancel the
-	// in-flight renders abort and clean their partials, then specWG drains. With
-	// --diagnostics off nothing was launched, so this returns at once.
-	specWG.Wait()
-
-	env.sharedLog("[POOL] Sending AllCompleteMsg")
-	env.p.Send(ui.AllCompleteMsg{})
 }
 
 // processingRenderScheduler bundles the pool-level background spectrogram-render
@@ -381,16 +409,11 @@ func emitProcessingReport(env poolEnv, inputPath string, result *processor.Proce
 
 	// Surface the final-output true peak and loudness range from NormResult for
 	// the done-box before→after rows. Read-only: both are measured by ebur128 on
-	// the final output during normalisation, never recomputed here. NormResult is
-	// nil when normalisation was disabled/skipped; FinalMeasurements may also be
-	// nil, so guard both and leave the value at 0 (the UI gates the row).
-	var outputTP, outputLRA float64
-	if result.NormResult != nil {
-		outputTP = result.NormResult.OutputTP
-		if fm := result.NormResult.FinalMeasurements; fm != nil {
-			outputLRA = fm.Loudness.OutputLRA
-		}
-	}
+	// the final output during normalisation, never recomputed here. The accessors
+	// guard a nil NormResult/FinalMeasurements and return 0 when absent (the UI
+	// gates the row), mirroring OutputNoiseFloor/InputNoiseFloor above.
+	outputTP, _ := processor.OutputTP(result)
+	outputLRA, _ := processor.OutputLRA(result)
 
 	// Confirm the Limiter row at completion. The row already lit during Pass 4
 	// (progressHandler resends the summary with the ceiling on the Pass-4-start
@@ -405,18 +428,20 @@ func emitProcessingReport(env poolEnv, inputPath string, result *processor.Proce
 
 	wlog("[POOL] Sending FileCompleteMsg for file %d", i)
 	env.p.Send(ui.FileCompleteMsg{
-		FileIndex:           i,
-		InputLUFS:           result.InputLUFS,
-		OutputLUFS:          result.OutputLUFS,
-		FinalNoiseFloor:     finalNoiseFloor,
-		InputNoiseFloor:     inputNoiseFloor,
-		HaveFinalNoiseFloor: haveFinalNoiseFloor,
-		HaveInputNoiseFloor: haveInputNoiseFloor,
-		OutputTP:            outputTP,
-		OutputLRA:           outputLRA,
-		OutputPath:          result.OutputPath,
-		Quality:             processor.ComputeQualityScore(result),
-		RecordingQuality:    processor.ComputeRecordingScore(result.Measurements),
-		ProcessingTime:      time.Since(t.fileStart),
+		FileIndex: i,
+		CompletionResult: ui.CompletionResult{
+			InputLUFS:           result.InputLUFS,
+			OutputLUFS:          result.OutputLUFS,
+			FinalNoiseFloor:     finalNoiseFloor,
+			InputNoiseFloor:     inputNoiseFloor,
+			HaveFinalNoiseFloor: haveFinalNoiseFloor,
+			HaveInputNoiseFloor: haveInputNoiseFloor,
+			OutputTP:            outputTP,
+			OutputLRA:           outputLRA,
+			OutputPath:          result.OutputPath,
+			Quality:             processor.ComputeQualityScore(result),
+			RecordingQuality:    processor.ComputeRecordingScore(result.Measurements),
+			ProcessingTime:      time.Since(t.fileStart),
+		},
 	})
 }

--- a/cmd/jivetalking/pool.go
+++ b/cmd/jivetalking/pool.go
@@ -49,10 +49,7 @@ func launchSpectrogramRenders(
 	onError func(processor.SpectrogramImage, error),
 ) {
 	for _, img := range imgs {
-		specWG.Add(1)
-		go func(img processor.SpectrogramImage) {
-			defer specWG.Done()
-
+		specWG.Go(func() {
 			select {
 			case specSem <- struct{}{}:
 				defer func() { <-specSem }()
@@ -63,7 +60,7 @@ func launchSpectrogramRenders(
 			if err := render(ctx, img); err != nil {
 				onError(img, err)
 			}
-		}(img)
+		})
 	}
 }
 
@@ -136,13 +133,7 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 	render := processingRenderScheduler{sem: specSem, wg: &specWG}
 
 	for i, inputPath := range env.files {
-		wg.Add(1)
-		go func(i int, inputPath string) {
-			// Register wg.Done() before the acquire select so a worker skipped
-			// on a cancelled ctx still decrements the WaitGroup; otherwise
-			// wg.Wait() hangs.
-			defer wg.Done()
-
+		wg.Go(func() {
 			// Acquire the semaphore, but bail out if ctx is already cancelled so
 			// a not-yet-started worker skips its work cleanly. Only release the
 			// slot when this branch actually took one.
@@ -188,7 +179,7 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 			pass2Time := time.Since(pass2Start) - ph.pass1Time - ph.pass3Time - ph.pass4Time
 
 			emitProcessingReport(env, inputPath, result, ph, processingTimings{fileStart: fileStartTime, pass2: pass2Time}, diagnostics, reportWarnings, render)
-		}(i, inputPath)
+		})
 	}
 
 	wg.Wait()

--- a/cmd/jivetalking/pool_integration_test.go
+++ b/cmd/jivetalking/pool_integration_test.go
@@ -200,8 +200,8 @@ func TestProcessAudio_ConcurrentRaceClean(t *testing.T) {
 	}
 }
 
-// TestRunWorkerPool_CancellationNoTempResidue exercises AC5 against REAL audio:
-// the real processor creates the .processing-* / .loudnorm-* temp dotfiles, so
+// TestRunWorkerPool_CancellationNoTempResidue exercises cancellation against REAL
+// audio: the real processor creates the .processing-* / .loudnorm-* temp dotfiles, so
 // the seam fake cannot stand in here. It copies a fixture into a dedicated input
 // dir, launches the pool with jobs >= 2, cancels mid-run, waits for the pool to
 // unwind, then lists the input dir to prove no temp dotfile residue remains.
@@ -276,7 +276,7 @@ func TestRunWorkerPool_CancellationNoTempResidue(t *testing.T) {
 		t.Logf("report warning (non-fatal): %s", warning)
 	}
 
-	// Hard AC5 requirement: zero temp dotfiles remain in the input dir.
+	// Hard requirement: zero temp dotfiles remain in the input dir.
 	for _, pattern := range []string{
 		filepath.Join(dir, ".processing-*.tmp.flac"),
 		filepath.Join(dir, ".loudnorm-*.tmp.flac"),

--- a/cmd/jivetalking/pool_integration_test.go
+++ b/cmd/jivetalking/pool_integration_test.go
@@ -180,12 +180,10 @@ func TestProcessAudio_ConcurrentRaceClean(t *testing.T) {
 	results := make([]*processor.ProcessingResult, len(files))
 
 	for i, inputPath := range files {
-		wg.Add(1)
-		go func(i int, inputPath string) {
-			defer wg.Done()
+		wg.Go(func() {
 			clone := base.CloneForWorker(withFilePrefix(inputPath, sharedLog))
 			results[i], errs[i] = processor.ProcessAudio(context.Background(), inputPath, clone, nil)
-		}(i, inputPath)
+		})
 	}
 	wg.Wait()
 

--- a/cmd/jivetalking/pool_test.go
+++ b/cmd/jivetalking/pool_test.go
@@ -79,7 +79,7 @@ func (m recordingModel) View() tea.View { return tea.NewView("") }
 
 // runPoolWithFake drives runWorkerPool over n synthetic file paths under a
 // headless recording program, returning the fake plus observed completion
-// counts. It reuses 6.1's headless tea.Program setup (no renderer, nil input).
+// counts under a headless tea.Program (no renderer, nil input).
 func runPoolWithFake(t *testing.T, jobs, n int) (*inflightFake, int, bool) {
 	t.Helper()
 
@@ -158,8 +158,8 @@ func TestRunWorkerPool_BoundHonouredForN(t *testing.T) {
 // exactly one designated input path errors while every sibling succeeds.
 // Successful calls return a
 // ProcessingResult whose OutputPath sits next to the (synthetic) input so the
-// pool's report write produces its .md without a report warning. It mirrors
-// AC4: one failing input must leave siblings unaffected.
+// pool's report write produces its .md without a report warning. One failing
+// input must leave siblings unaffected.
 type isolationFake struct {
 	failPath string
 }
@@ -182,7 +182,7 @@ func (f *isolationFake) fn(_ context.Context, inputPath string, _ *processor.Bas
 
 // isolationModel records per-file completion detail: how many FileCompleteMsg
 // arrived, which file indices carried an Error, and whether AllCompleteMsg fired.
-// It is a richer sibling of recordingModel for AC4 assertions.
+// It is a richer sibling of recordingModel for failure-isolation assertions.
 type isolationModel struct {
 	mu          *sync.Mutex
 	completed   *int
@@ -213,7 +213,7 @@ func (m isolationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m isolationModel) View() tea.View { return tea.NewView("") }
 
 // TestRunWorkerPool_FailureIsolation drives the pool over several files where one
-// designated input errors and the rest succeed. It asserts AC4: every sibling
+// designated input errors and the rest succeed. It asserts every sibling
 // completes with no error, the failing file's FileCompleteMsg carries its Error,
 // AllCompleteMsg still fires (the partial-failure run completes), and all N files
 // report exactly once (no early abort). Seam-based, so no real audio is needed.

--- a/cmd/jivetalking/pool_test.go
+++ b/cmd/jivetalking/pool_test.go
@@ -177,7 +177,6 @@ func (f *isolationFake) fn(_ context.Context, inputPath string, _ *processor.Bas
 		OutputPath: outputPath,
 		InputLUFS:  -23.0,
 		OutputLUFS: -16.0,
-		NoiseFloor: -60.0,
 	}, nil
 }
 

--- a/docs/Normalisation-Tuning.md
+++ b/docs/Normalisation-Tuning.md
@@ -1,0 +1,77 @@
+# Normalisation Tuning
+
+Why the loudnorm and limiter constants in `internal/processor/normalise.go` hold
+the values they do. Each value is corpus-derived. The maths is correct; this doc
+keeps the long rationale out of the code, where it would rot.
+
+The corpus references name validation sweeps run by hand against gitignored audio
+that does not ship in the repo. They are evidence summaries, not files you can open.
+
+## brickwallTruePeakHeadroomDB
+
+- **Value:** 0.9 dB.
+- **What it does:** The inter-sample allowance subtracted from loudnorm's TargetTP
+  to set the brickwall limiter's sample-peak ceiling.
+- **Why this value:** The brickwall alimiter limits SAMPLE peak, but the spec
+  targets oversampled TRUE peak. The gap between them, the inter-sample excess,
+  pushes realised true peak above the sample ceiling. The headroom closes that gap.
+- **Corpus evidence:** Validated against the 0.5.x-vs-0.6.x corpus sweep
+  (combined post-Phase-2 run). The inter-sample excess (final true_peak dBTP minus
+  sample_peak dBFS) peaked at 0.817 dB on LMP-76 popey, driven up from the 0.60 dB
+  the earlier 0.7 value was sized for by the Phase-2 loudness-cap relaxation (the
+  former static loudnorm TP relax). The excess is positive on every file, so
+  realised true peak sits above the sample ceiling on all of them. 0.9 dB covers
+  the p100 of 0.817 with a ~0.08 dB safety allowance, so the sample-peak brickwall
+  keeps oversampled true peak at or below the loudnorm TargetTP on the whole corpus.
+
+## measurementCushionDB
+
+- **Value:** 0.2 dB.
+- **What it does:** The fixed measurement-disagreement cushion added to loudnorm's
+  INTERNAL true-peak target (`loudnormInternalTargetTP`).
+- **Why this value:** It guards the per-file projected post-gain peak against
+  loudnorm's OWN internal oversampled true-peak estimate disagreeing with the
+  Pass-3 measured TP. Go computes `projectedPeak` from measured_TP and measured_I.
+  FFmpeg's loudnorm computes its own output-peak estimate at a different point.
+  If loudnorm's estimate exceeds the projection by more than the cushion, loudnorm
+  can trip to DYNAMIC mode, the failure the Pass-4 levelling limiter exists to prevent.
+- **Corpus evidence:** Validated against the 0.5.x-vs-0.6.x corpus sweep
+  (out-final JSON). The delta `loudnorm_output_tp minus projectedPeak` is at or
+  below 0.05 dB across all 48 files, one-sided positive (loudnorm estimates its
+  peak about 0.04 dB hotter on every file). 0.2 clears the measured 0.05 bias about
+  4 times, leaving headroom for off-corpus material (other producers' audio) where
+  the Go-vs-FFmpeg estimator gap could be larger.
+- **Invariant:** This is the only static margin left in loudnorm's internal
+  targeting. The variable, corpus-dependent loudness shortfall the former 0.5 relax
+  constant covered is now derived per file from each file's Pass-3 measured_I and
+  measured_TP (see `loudnormInternalTargetTP`), so no corpus-tuned number remains.
+  It applies only to loudnorm's internal targeting; the brickwall ceiling stays at
+  `TargetTP - brickwallTruePeakHeadroomDB`, unchanged.
+
+## linearSafetyMargin
+
+- **Value:** 0.1 dB.
+- **What it does:** Keeps loudnorm safely inside linear-mode bounds in the
+  `calculateLinearModeTarget` guard.
+- **Why this value:** It accounts for floating-point precision differences between
+  Go and FFmpeg, rounding in filter parameter passing, and measurement variance.
+  `loudnormInternalTargetTP` folds the same value into the per-file internal TP, so
+  the linear-mode cap is inert by construction.
+
+## loudnormTPMaxDB / loudnormTPMinDB
+
+- **Values:** 0.0 dBTP and -9.0 dBTP.
+- **What they do:** Bound the value emitted into loudnorm's `TP=` option.
+- **Why these values:** This is an engine constraint, not a tuning choice.
+  FFmpeg's `af_loudnorm` rejects a TP outside [-9.0, 0.0] dBTP (`AVERROR(ERANGE)`
+  at graph build, see `set_options` in `af_loudnorm.c`). The per-file
+  `loudnormInternalTargetTP` is unbounded by construction, so the emitted `TP=` is
+  clamped to this range. The linear-mode guard keeps the unclamped value.
+
+## minLimiterCeilingDB
+
+- **Value:** -24.0 dBTP.
+- **What it does:** The practical minimum for FFmpeg's alimiter ceiling.
+- **Why this value:** This is the alimiter engine floor, not a tuning constant.
+  `limit=0.0625` equals `20*log10(0.0625)` which is about -24.08 dBTP; -24.0 sits
+  just inside it with a small buffer.

--- a/internal/audio/reader.go
+++ b/internal/audio/reader.go
@@ -38,12 +38,7 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 	// ownership to the Reader and frees nothing.
 	decCtx := (*ffmpeg.AVCodecContext)(nil)
 	cleanup := func() {
-		if decCtx != nil {
-			ffmpeg.AVCodecFreeContext(&decCtx)
-		}
-		if fmtCtx != nil {
-			ffmpeg.AVFormatCloseInput(&fmtCtx)
-		}
+		freeContexts(&decCtx, &fmtCtx)
 	}
 
 	if _, err := ffmpeg.AVFormatOpenInput(&fmtCtx, filenameC, nil, nil); err != nil {
@@ -177,6 +172,18 @@ func (r *Reader) SeekTo(timestamp int64) error {
 	return nil
 }
 
+// freeContexts releases the decoder and format contexts in reverse order of
+// acquisition (decCtx before fmtCtx), nil-guarding each. Shared by the
+// OpenAudioFile error path and Close so both free the same set in one place.
+func freeContexts(decCtx **ffmpeg.AVCodecContext, fmtCtx **ffmpeg.AVFormatContext) {
+	if *decCtx != nil {
+		ffmpeg.AVCodecFreeContext(decCtx)
+	}
+	if *fmtCtx != nil {
+		ffmpeg.AVFormatCloseInput(fmtCtx)
+	}
+}
+
 // Close releases all resources
 func (r *Reader) Close() {
 	if r.frame != nil {
@@ -185,10 +192,5 @@ func (r *Reader) Close() {
 	if r.packet != nil {
 		ffmpeg.AVPacketFree(&r.packet)
 	}
-	if r.decCtx != nil {
-		ffmpeg.AVCodecFreeContext(&r.decCtx)
-	}
-	if r.fmtCtx != nil {
-		ffmpeg.AVFormatCloseInput(&r.fmtCtx)
-	}
+	freeContexts(&r.decCtx, &r.fmtCtx)
 }

--- a/internal/audio/reader.go
+++ b/internal/audio/reader.go
@@ -98,12 +98,25 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 		Channels:   decCtx.ChLayout().NbChannels(),
 	}
 
+	frame := ffmpeg.AVFrameAlloc()
+	if frame == nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to allocate frame for file: %s", filename)
+	}
+
+	packet := ffmpeg.AVPacketAlloc()
+	if packet == nil {
+		ffmpeg.AVFrameFree(&frame)
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to allocate packet for file: %s", filename)
+	}
+
 	reader := &Reader{
 		fmtCtx:    fmtCtx,
 		decCtx:    decCtx,
 		streamIdx: streamIdx,
-		frame:     ffmpeg.AVFrameAlloc(),
-		packet:    ffmpeg.AVPacketAlloc(),
+		frame:     frame,
+		packet:    packet,
 	}
 
 	return reader, metadata, nil

--- a/internal/audio/reader.go
+++ b/internal/audio/reader.go
@@ -169,8 +169,10 @@ func (r *Reader) ReadFrame() (*ffmpeg.AVFrame, error) {
 	}
 }
 
-// GetDecoderContext returns the decoder context (needed for filter graph setup)
-func (r *Reader) GetDecoderContext() *ffmpeg.AVCodecContext {
+// DecoderContext returns the decoder context for filter graph setup. The
+// Reader owns this context and frees it in Close. Callers must not retain it
+// or use it after Close, or they read freed cgo memory.
+func (r *Reader) DecoderContext() *ffmpeg.AVCodecContext {
 	return r.decCtx
 }
 

--- a/internal/audio/reader_test.go
+++ b/internal/audio/reader_test.go
@@ -20,8 +20,8 @@ import (
 // resource pointers nil) neither panics nor double-frees, and that calling it
 // repeatedly is safe. Every Close branch is nil-guarded, so a fresh Reader{}
 // reaches each guard's false arm; a regression that dropped a guard would panic
-// here. This is the fake-backed Close idempotency check the peer review asked
-// for, with no CGO allocation required.
+// here. This is the fake-backed Close idempotency check, with no CGO
+// allocation required.
 func TestReaderClose_ZeroValueIdempotent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -10,7 +10,8 @@ import (
 	"github.com/charmbracelet/colorprofile"
 )
 
-// Custom help styles
+// Help styles for the section headers, flag names, and argument names in the
+// StyledHelpPrinter output.
 var (
 	helpDescStyle = lipgloss.NewStyle().
 			Foreground(ColorOrange).
@@ -31,7 +32,9 @@ var (
 			Bold(true)
 )
 
-// StyledHelpPrinter creates a custom help printer with Lipgloss styling
+// StyledHelpPrinter returns a Kong help printer that renders the title,
+// usage, arguments, and flags with the package Lipgloss styles, writing
+// through a colorprofile writer so colour downsamples to the terminal.
 func StyledHelpPrinter() func(kong.HelpOptions, *kong.Context) error {
 	return func(options kong.HelpOptions, ctx *kong.Context) error {
 		var sb strings.Builder
@@ -101,7 +104,6 @@ type flag struct {
 func getArguments(ctx *kong.Context) []argument {
 	var args []argument
 
-	// Parse arguments from the model
 	for _, arg := range ctx.Model.Positional {
 		name := arg.Summary()
 		help := arg.Help
@@ -114,7 +116,7 @@ func getArguments(ctx *kong.Context) []argument {
 func getFlags(ctx *kong.Context) []flag {
 	var flags []flag
 
-	// Always include help flag
+	// Kong omits --help from Model.Flags, so prepend it by hand.
 	flags = append(flags, flag{
 		flags: "-h, --help",
 		help:  "Show context-sensitive help.",
@@ -123,7 +125,7 @@ func getFlags(ctx *kong.Context) []flag {
 	// Parse flags from the model
 	for _, f := range ctx.Model.Flags {
 		if f.Name == "help" {
-			continue // Already added
+			continue // the help flag is prepended above
 		}
 
 		var flagStr string

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -51,39 +51,9 @@ func StyledHelpPrinter() func(kong.HelpOptions, *kong.Context) error {
 		fmt.Fprintf(&sb, "%s [flags] <files> ...", ctx.Model.Name)
 		sb.WriteString("\n")
 
-		// Arguments section
-		args := getArguments(ctx)
-		if len(args) > 0 {
-			sb.WriteString("\n")
-			sb.WriteString(helpSectionStyle.Render("Arguments:"))
-			sb.WriteString("\n")
-			for _, arg := range args {
-				sb.WriteString("  ")
-				sb.WriteString(helpArgStyle.Render(arg.name))
-				if arg.help != "" {
-					sb.WriteString("  ")
-					sb.WriteString(arg.help)
-				}
-				sb.WriteString("\n")
-			}
-		}
-
-		// Flags section
-		flags := getFlags(ctx)
-		if len(flags) > 0 {
-			sb.WriteString("\n")
-			sb.WriteString(helpSectionStyle.Render("Flags:"))
-			sb.WriteString("\n")
-			for _, flag := range flags {
-				sb.WriteString("  ")
-				sb.WriteString(helpFlagStyle.Render(flag.flags))
-				if flag.help != "" {
-					sb.WriteString("  ")
-					sb.WriteString(flag.help)
-				}
-				sb.WriteString("\n")
-			}
-		}
+		// Arguments and Flags sections
+		writeHelpSection(&sb, "Arguments:", helpArgStyle, getArguments(ctx))
+		writeHelpSection(&sb, "Flags:", helpFlagStyle, getFlags(ctx))
 
 		sb.WriteString("\n")
 		fmt.Fprint(colorprofile.NewWriter(ctx.Stdout, os.Environ()), sb.String())
@@ -91,34 +61,50 @@ func StyledHelpPrinter() func(kong.HelpOptions, *kong.Context) error {
 	}
 }
 
-type argument struct {
-	name string
-	help string
-}
-
-type flag struct {
-	flags string
+// helpRow is one label/help pair rendered in the Arguments or Flags section.
+type helpRow struct {
+	label string
 	help  string
 }
 
-func getArguments(ctx *kong.Context) []argument {
-	var args []argument
+// writeHelpSection renders a help section (header plus label-styled rows) to sb,
+// writing nothing when rows is empty. label is drawn with style, help follows
+// after two spaces when present.
+func writeHelpSection(sb *strings.Builder, header string, style lipgloss.Style, rows []helpRow) {
+	if len(rows) == 0 {
+		return
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(helpSectionStyle.Render(header))
+	sb.WriteString("\n")
+	for _, row := range rows {
+		sb.WriteString("  ")
+		sb.WriteString(style.Render(row.label))
+		if row.help != "" {
+			sb.WriteString("  ")
+			sb.WriteString(row.help)
+		}
+		sb.WriteString("\n")
+	}
+}
+
+func getArguments(ctx *kong.Context) []helpRow {
+	var args []helpRow
 
 	for _, arg := range ctx.Model.Positional {
-		name := arg.Summary()
-		help := arg.Help
-		args = append(args, argument{name: name, help: help})
+		args = append(args, helpRow{label: arg.Summary(), help: arg.Help})
 	}
 
 	return args
 }
 
-func getFlags(ctx *kong.Context) []flag {
-	var flags []flag
+func getFlags(ctx *kong.Context) []helpRow {
+	var flags []helpRow
 
 	// Kong omits --help from Model.Flags, so prepend it by hand.
-	flags = append(flags, flag{
-		flags: "-h, --help",
+	flags = append(flags, helpRow{
+		label: "-h, --help",
 		help:  "Show context-sensitive help.",
 	})
 
@@ -139,8 +125,8 @@ func getFlags(ctx *kong.Context) []flag {
 			flagStr += "=" + strings.ToUpper(f.PlaceHolder)
 		}
 
-		flags = append(flags, flag{
-			flags: flagStr,
+		flags = append(flags, helpRow{
+			label: flagStr,
 			help:  f.Help,
 		})
 	}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWriteHelpSectionRendersRows asserts the shared section writer produces the
+// header, the two-space indent, the styled label, the two-space help separator,
+// and a trailing newline per row, matching the prior per-section render loops.
+func TestWriteHelpSectionRendersRows(t *testing.T) {
+	var sb strings.Builder
+	writeHelpSection(&sb, "Flags:", helpFlagStyle, []helpRow{
+		{label: "-h, --help", help: "Show context-sensitive help."},
+		{label: "--debug", help: ""},
+	})
+
+	got := sb.String()
+	want := "\n" +
+		helpSectionStyle.Render("Flags:") + "\n" +
+		"  " + helpFlagStyle.Render("-h, --help") + "  Show context-sensitive help.\n" +
+		"  " + helpFlagStyle.Render("--debug") + "\n"
+
+	if got != want {
+		t.Errorf("writeHelpSection mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestWriteHelpSectionEmptyRowsWritesNothing confirms an empty row slice yields no
+// output, matching the prior len(rows) > 0 guard around each section.
+func TestWriteHelpSectionEmptyRowsWritesNothing(t *testing.T) {
+	var sb strings.Builder
+	writeHelpSection(&sb, "Arguments:", helpArgStyle, nil)
+	if got := sb.String(); got != "" {
+		t.Errorf("expected no output for empty rows, got %q", got)
+	}
+}

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -96,12 +96,17 @@ func PrintVersion(version string) {
 	lipgloss.Println()
 }
 
+// printLabelled writes a styled label followed by message to stderr.
+func printLabelled(style lipgloss.Style, label, message string) {
+	lipgloss.Fprintf(os.Stderr, "%s %s\n", style.Render(label), message)
+}
+
 // PrintError prints an error message
 func PrintError(message string) {
-	lipgloss.Fprintf(os.Stderr, "%s %s\n", errorStyle.Render("Error:"), message)
+	printLabelled(errorStyle, "Error:", message)
 }
 
 // PrintWarning prints a warning message
 func PrintWarning(message string) {
-	lipgloss.Fprintf(os.Stderr, "%s %s\n", warningStyle.Render("Warning:"), message)
+	printLabelled(warningStyle, "Warning:", message)
 }

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -44,19 +44,16 @@ var (
 	ColorBlue = compat.AdaptiveColor{Light: lipgloss.Color("#2563EB"), Dark: lipgloss.Color("#3B82F6")}
 )
 
-// Styles
+// Text styles for the version banner and the Print* helpers below.
 var (
-	// Error message style
 	errorStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(ColorRed)
 
-	// Warning message style
 	warningStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(ColorOrange)
 
-	// Key-value pair styles
 	keyStyle = lipgloss.NewStyle().
 			Foreground(ColorMuted)
 

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -50,8 +50,7 @@ const (
 // is used only when the room-tone band measurement is trustworthy: a clear
 // speech/noise gap so the elected room tone is genuine ambience, and a flat
 // (noise-like) room-tone spectrum so the measured shape describes broadband
-// noise rather than tonal bleed. Both thresholds are corpus-derived starting
-// points, to be confirmed by the A/B sweep.
+// noise rather than tonal bleed. Both thresholds are corpus-derived.
 const (
 	// afftdnCustomMinSeparationDB is the minimum gate separation (voiced p10 minus
 	// noise p95) for the custom profile. Below it the room tone may be contaminated

--- a/internal/processor/adaptive.go
+++ b/internal/processor/adaptive.go
@@ -121,7 +121,7 @@ func useCustomAfftdnProfile(measurements *AudioMeasurements) bool {
 	if measurements.Regions.GateSeparationDB < afftdnCustomMinSeparationDB {
 		return false
 	}
-	return profile.SpectralFlatness >= afftdnCustomMinFlatness
+	return profile.Spectral.Flatness >= afftdnCustomMinFlatness
 }
 
 // tuneNoiseReduction adapts the afftdn FFT denoise tail to Pass 1 measurements.

--- a/internal/processor/adaptive_bandlimit_lowpass.go
+++ b/internal/processor/adaptive_bandlimit_lowpass.go
@@ -23,8 +23,7 @@ func tuneBandlimitLowPass(config *EffectiveFilterConfig, diagnostics *AdaptiveDi
 	config.BandlimitLowPass.Frequency = bandlimitLPFreq
 	config.BandlimitLowPass.Poles = 2 // 12dB/oct - a real ceiling that attenuates before Nyquist
 	config.BandlimitLowPass.Mix = 1.0
-	if diagnostics == nil {
-		diagnostics = &AdaptiveDiagnostics{}
+	if diagnostics != nil {
+		diagnostics.BandlimitLPReason = "20.5 kHz band-limit (always on)"
 	}
-	diagnostics.BandlimitLPReason = "20.5 kHz band-limit (always on)"
 }

--- a/internal/processor/adaptive_deesser.go
+++ b/internal/processor/adaptive_deesser.go
@@ -21,6 +21,15 @@ const (
 	deessIntensityMax = 0.85 // Ceiling at/above deessExcessMaxDB
 )
 
+// SibilanceExcessDB is the speech-region sibilance excess in dB: the sibilant-band
+// RMS minus the body-band RMS (both dBFS, same astats axis). It is the single
+// source of the de-esser engagement signal, shared with the UI summary so the box
+// and the de-esser tuner never drift. Both bands must be measured (BandsMeasured)
+// for the value to mean anything; callers gate on that.
+func (m *SpeechCandidateMetrics) SibilanceExcessDB() float64 {
+	return m.SibBandRMS - m.BodyBandRMS
+}
+
 // tuneDeesser sets de-esser intensity from the speech-region sibilance excess
 // (sibilant-band RMS minus body-band RMS). It requires a SpeechProfile with both
 // bands measured; full-file metrics are diluted by silence/noise and produce
@@ -39,7 +48,7 @@ func tuneDeesser(config *EffectiveFilterConfig, measurements *AudioMeasurements)
 		return
 	}
 
-	sibilanceExcess := measurements.Regions.SpeechProfile.SibBandRMS - measurements.Regions.SpeechProfile.BodyBandRMS
+	sibilanceExcess := measurements.Regions.SpeechProfile.SibilanceExcessDB()
 
 	switch {
 	case sibilanceExcess < deessExcessOffDB:

--- a/internal/processor/adaptive_levelling_compressor.go
+++ b/internal/processor/adaptive_levelling_compressor.go
@@ -23,7 +23,7 @@ const (
 	// corpus's level spread.
 	levellingCompressorThresholdSpeechOffsetDB = 9.0
 
-	// Threshold clamp bounds (dBFS). Preserve the prior sane range.
+	// Threshold clamp bounds (dBFS): a sane operating range for the threshold.
 	levellingCompressorThresholdMin = -45.0
 	levellingCompressorThresholdMax = -6.0
 

--- a/internal/processor/adaptive_speech_gate.go
+++ b/internal/processor/adaptive_speech_gate.go
@@ -86,15 +86,11 @@ const (
 // Room-tone peak/crest are read from the noise profile extracted from the
 // elected room-tone region and feed only the no-profile legacy threshold path.
 func tuneSpeechGate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnostics, measurements *AudioMeasurements) {
-	if diagnostics != nil {
-		diagnostics.SpeechGateDynamicRange = 0
-		diagnostics.SpeechGateQuietSpeechEstimate = 0
-		diagnostics.SpeechGateSpeechSeparation = 0
-		diagnostics.SpeechGateSpeechHeadroom = 0
-		diagnostics.SpeechGateThresholdUnclamped = 0
-		diagnostics.SpeechGateClampReason = ""
-		diagnostics.SpeechGateNarrowGap = false
-	}
+	// AdaptiveDiagnostics is freshly allocated per AdaptConfig call, so the
+	// speech-gate fields written only inside the SpeechProfile branch below
+	// (narrow gap, quiet-speech estimate, separation, headroom, unclamped
+	// threshold, clamp reason) start at their zero value on the no-profile path.
+	// No explicit zeroing is needed.
 
 	// Room-tone peak/crest feed only the no-profile legacy threshold path
 	// (NoiseProfile is extracted from the elected room-tone region).

--- a/internal/processor/adaptive_speech_gate.go
+++ b/internal/processor/adaptive_speech_gate.go
@@ -3,9 +3,8 @@ package processor
 const (
 	// LUFS gap threshold used only by the no-profile legacy threshold path: above
 	// this gap the peak-reference branch is disabled (the recording is too quiet
-	// for a room-tone peak to be a trustworthy threshold anchor). The former
-	// gentle-mode override that also read this constant is gone (task 4.4);
-	// anti-hunting now comes from the narrow-separation depth reduction (task 4.3).
+	// for a room-tone peak to be a trustworthy threshold anchor). Anti-hunting
+	// comes from the narrow-separation depth reduction, not a gentle-mode override.
 	lufsGapExtreme = 25.0 // dB - extreme gap, disables the legacy peak-reference branch
 
 	// Threshold calculation: ensures sufficient gap above noise for effective soft expansion
@@ -15,15 +14,14 @@ const (
 	speechGateTargetReductionDB    = 12.0  // dB - target noise reduction from soft expander
 	speechGateTargetThresholdDB    = -40.0 // dB - target threshold for clean recordings (quiet speech/breath level)
 
-	// Voiced-anchored threshold placement (Phase 4 task 4.1). The threshold is
-	// pinned a fixed margin below the voiced-speech low percentile (p10), the soft
-	// edge of speech measured over the elected region. Sitting below that edge means
-	// the gate never attenuates a voiced word, even its quietest tail. The noise
-	// margin is the clearance above the noise high percentile (p95) we would like
-	// the threshold to keep; it is used ONLY to detect a narrow gap (when the
-	// speech-side placement cannot also clear the loud noise). On a narrow gap we
-	// stay on the speech side and let depth back off rather than raise the threshold
-	// into the voice. Both margins are tunable by ear in the Phase 5 sweep.
+	// Voiced-anchored threshold placement. The threshold is pinned a fixed margin
+	// below the voiced-speech low percentile (p10), the soft edge of speech measured
+	// over the elected region. Sitting below that edge means the gate never attenuates
+	// a voiced word, even its quietest tail. The noise margin is the clearance above
+	// the noise high percentile (p95) the threshold would like to keep; it detects a
+	// narrow gap ONLY (when the speech-side placement cannot also clear the loud
+	// noise). On a narrow gap the threshold stays on the speech side and depth backs
+	// off rather than raising the threshold into the voice.
 	speechGateThresholdSpeechMarginDB = 6.0 // dB - how far below voiced p10 the threshold sits (soft-word safety margin)
 	speechGateThresholdNoiseMarginDB  = 6.0 // dB - clearance above noise p95 used only to detect a narrow gap
 
@@ -41,27 +39,25 @@ const (
 	// Release: fixed 200 ms, with the hold folded in. agate has no hold parameter,
 	// so the release alone holds the gate open across the short gaps inside speech;
 	// 200 ms is long enough to ride those gaps without pumping and short enough to
-	// close cleanly at word ends. Light-touch testing confirmed ~200 ms is good
-	// enough, so the stacked flux/ZCR/LRA terms are dropped. Phase 4 task 4.2
-	// reuses this constant.
+	// close cleanly at word ends. A single fixed value, not a stacked flux/ZCR/LRA
+	// sum.
 	speechGateReleaseFixedMS = 200.0 // ms - fixed release (hold folded in)
 
 	// Range: fixed 14 dB of attenuation, the midpoint of the 12 to 15 dB
 	// transparent band (moderate depth, never a full mute, so the floor under
-	// speech stays natural rather than pumping to silence). The Phase 5 sweep
-	// confirms 14 dB. Phase 4 task 4.3 reuses this constant.
+	// speech stays natural rather than pumping to silence).
 	speechGateDepthFixedDB = 14.0 // dB - fixed attenuation depth (transparent band midpoint)
 
 	// Range on a narrow gap: a gentler fixed depth. A narrow gap means little
 	// headroom between the quietest voiced speech and the loud noise, so gating
 	// the full depth would pump the floor. Back off to a shallower fixed cut
 	// (never a full mute, never 0). Two fixed levels only, normal and narrow, not
-	// proportional to separation. Tunable by ear in the Phase 5 sweep.
+	// proportional to separation.
 	speechGateDepthNarrowDB = 8.0 // dB - reduced attenuation depth on a narrow gap
 
 	// Knee: fixed, within the 3 to 10 dB band. Spectral crest is the wrong signal
-	// to key it off (per the de-esser/compressor reviews), so the knee is a single
-	// value. A soft knee stands in for the hysteresis agate lacks: it smooths the
+	// to key it off, so the knee is a single value. A soft knee stands in for the
+	// hysteresis agate lacks: it smooths the
 	// open/close boundary so the gate does not chatter on level wobble near the
 	// threshold. There is no override; the knee is the same for all content.
 	speechGateKneeFixed = 3.0 // standard knee for all content (3 to 10 dB band)
@@ -77,8 +73,8 @@ const (
 //
 // Parameters are tuned as follows:
 //   - Threshold: voiced-anchored placement a fixed margin below the voiced p10 when
-//     a SpeechProfile is elected (task 4.1); the legacy noise-floor path is the
-//     no-profile safety fallback
+//     a SpeechProfile is elected; the legacy noise-floor path is the no-profile
+//     safety fallback
 //   - Ratio: based on LRA (wide dynamics = gentle ratio)
 //   - Release: fixed 200 ms, with the hold folded in (agate has no hold parameter)
 //   - Range: fixed moderate depth, reduced to a gentler fixed depth on a narrow gap
@@ -123,10 +119,10 @@ func tuneSpeechGate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnost
 	// Calculate ratio FIRST since threshold depends on it
 	config.SpeechGate.Ratio = calculateSpeechGateRatio(measurements.Loudness.InputLRA)
 
-	// 1. Threshold: voiced-anchored placement when a SpeechProfile is elected
-	// (task 4.1), otherwise the legacy noise-floor safety path. The voiced path
-	// pins the threshold a fixed margin below the voiced p10, so words never clip,
-	// and reports a narrow-gap signal that the depth step (task 4.3) consumes.
+	// 1. Threshold: voiced-anchored placement when a SpeechProfile is elected,
+	// otherwise the legacy noise-floor safety path. The voiced path pins the
+	// threshold a fixed margin below the voiced p10, so words never clip, and reports
+	// a narrow-gap signal that the depth step consumes.
 	var narrowGap bool
 	if measurements.Regions.SpeechProfile != nil {
 		threshold, gap := calculateSpeechGateThreshold(
@@ -166,8 +162,8 @@ func tuneSpeechGate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnost
 	config.SpeechGate.Release = calculateSpeechGateRelease()
 
 	// 5. Range: fixed moderate depth, reduced to a gentler fixed depth on a narrow
-	// gap (task 4.3). depthDB is a positive attenuation depth, so negate it for the
-	// config's linear-amplitude range.
+	// gap. depthDB is a positive attenuation depth, so negate it for the config's
+	// linear-amplitude range.
 	depthDB := calculateSpeechGateRangeDB(narrowGap)
 	config.SpeechGate.Range = Decibels(-depthDB).LinearAmplitude().Float64()
 	if diagnostics != nil {
@@ -182,11 +178,10 @@ func tuneSpeechGate(config *EffectiveFilterConfig, diagnostics *AdaptiveDiagnost
 
 	// Note: Makeup gain left at default (1.0 unity) - loudnorm handles all level adjustment
 	//
-	// Anti-hunting: the former gentle-mode override (extreme LUFS gap + low LRA
-	// forced ratio 1.2 and knee 2.0) is gone. Hunting on uniform quiet recordings
-	// is now prevented by the narrow-separation depth reduction in
-	// calculateSpeechGateRangeDB (task 4.3): a shallow gap takes a gentler fixed
-	// depth instead of the full cut, so a single signal (separation) governs it.
+	// Anti-hunting: there is no gentle-mode override. Hunting on uniform quiet
+	// recordings is prevented by the narrow-separation depth reduction in
+	// calculateSpeechGateRangeDB: a shallow gap takes a gentler fixed depth instead
+	// of the full cut, so a single signal (separation) governs it.
 }
 
 // noiseContext bundles the noise-floor and room-tone references the threshold
@@ -212,8 +207,8 @@ type noiseContext struct {
 // route into this function. This noise-floor maths can only place a threshold from
 // the noise references, and it runs only when there is no voiced population to clip
 // in the first place. There is no separation-based escape hatch from the voiced
-// path into the legacy maths: the old "separation < 5 dB" guard that keyed off a
-// fabricated proxy is gone (task 4.1). Selection is structural, not numeric.
+// path into the legacy maths: there is no "separation < 5 dB" guard keying off a
+// fabricated proxy. Selection is structural, not numeric.
 //
 // noise.roomTonePeak and noise.roomToneCrest describe the noise profile extracted
 // from the elected room-tone region.
@@ -252,11 +247,11 @@ func calculateSpeechGateThresholdLegacy(noise noiseContext, ratio, lufsGap float
 //
 // which is exactly GateSeparationDB < speechMargin + noiseMargin (separation =
 // VoicedLowPercentile - NoiseHighPercentile), so the noise percentile enters only
-// through the precomputed separation. On a narrow gap we resolve toward the speech
-// side per the proposal CAVEAT: the threshold stays at the speech-side value (it is
-// NOT raised to clear the noise, so residual noise is accepted) and the returned
-// narrowGap flag tells the depth step (task 4.3) to back off. The dB threshold is
-// converted to the config's linear-amplitude form with the existing Decibels helper.
+// through the precomputed separation. On a narrow gap the resolution favours the
+// speech side: the threshold stays at the speech-side value (it is NOT raised to
+// clear the noise, so residual noise is accepted) and the returned narrowGap flag
+// tells the depth step to back off. The dB threshold is converted to the config's
+// linear-amplitude form with the existing Decibels helper.
 //
 // The threshold is clamped to the global gate limits as a final safety net.
 func calculateSpeechGateThreshold(voicedLowPercentile, separation float64) (threshold float64, narrowGap bool) {
@@ -287,16 +282,15 @@ func calculateSpeechGateRatio(lra float64) float64 {
 // calculateSpeechGateRelease returns the fixed release time. agate has no hold
 // parameter, so the hold is folded into the release: a longer release holds the
 // gate open through the short intra-syllable dips inside speech so it does not
-// pump, while staying short enough to close cleanly at word ends. Light-touch
-// testing confirmed ~200 ms is good enough, so the former stacked flux/ZCR/LRA
-// compensation terms are dropped in favour of this single fixed value.
+// pump, while staying short enough to close cleanly at word ends. A single fixed
+// value (~200 ms), not a stacked flux/ZCR/LRA sum.
 func calculateSpeechGateRelease() float64 {
 	return speechGateReleaseFixedMS
 }
 
 // calculateSpeechGateRangeDB returns the gate attenuation depth in dB. It emits a
 // fixed moderate depth on a normal (wide) gap, and a gentler fixed depth when the
-// narrow-gap signal is set (from the threshold step, task 4.1). A narrow gap means
+// narrow-gap signal is set (from the threshold step). A narrow gap means
 // little headroom between the quietest voiced speech and the loud noise, so the
 // full depth would pump the floor; the gentler depth gates more softly. Two fixed
 // levels only, never proportional to separation, and never a full mute. The

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -503,15 +503,16 @@ func TestTuneDeesser(t *testing.T) {
 func TestTuneSpeechGate(t *testing.T) {
 	// Tests the comprehensive gate tuning which calculates all gate parameters
 	// based on measurements including NoiseProfile (extracted from the elected
-	// room-tone region).
+	// room-tone region). The threshold subtests below have no SpeechProfile, so
+	// they exercise the legacy noise-floor threshold path.
 	//
-	// Key constants from adaptive.go:
-	// gateThresholdMinDB = -50.0 dB (quiet speech floor)
-	// gateThresholdMaxDB = -25.0 dB (never gate above this - would cut speech)
-	// gateCrestFactorThreshold = 20.0 dB (when to use peak vs floor)
-	// gateTargetReductionDB = 12.0 dB (target noise reduction)
-	// gateTargetThresholdDB = -40.0 dB (target for clean recordings)
-	// gateRatioGentle = 1.5 (wide LRA), gateRatioMod = 2.0 (cap, all else)
+	// Key constants from adaptive_speech_gate.go:
+	// speechGateThresholdMinDB = -80.0 dB (minimum threshold)
+	// speechGateThresholdMaxDB = -25.0 dB (never gate above this - would cut speech)
+	// speechGateCrestFactorThreshold = 20.0 dB (when to use peak vs floor)
+	// speechGateTargetReductionDB = 12.0 dB (target noise reduction)
+	// speechGateTargetThresholdDB = -40.0 dB (target for clean recordings)
+	// speechGateRatioGentle = 1.5 (wide LRA), speechGateRatioMod = 2.0 (cap, all else)
 	//
 	// Gap is derived from ratio: gap = targetReduction / (1 - 1/ratio)
 	// - ratio 1.5 → gap = 12 / 0.333 = 36 dB
@@ -710,7 +711,7 @@ func TestTuneSpeechGate(t *testing.T) {
 
 	t.Run("knee is fixed", func(t *testing.T) {
 		// Knee collapsed to a single fixed value; spectral crest no longer matters
-		// and there is no override (the gentle-mode override is gone, task 4.4).
+		// and there is no override (no gentle-mode override exists).
 		tests := []struct {
 			name  string
 			crest float64
@@ -932,11 +933,11 @@ func TestTuneSpeechGate(t *testing.T) {
 	})
 }
 
-// TestCalculateSpeechGateThreshold covers the voiced-p10-anchored placement
-// (Phase 4 task 4.1): the threshold lands at voiced p10 minus the speech margin,
-// the narrow-gap signal flips at separation = speechMargin + noiseMargin (12 dB),
-// and a crossed (narrow) gap keeps the threshold on the speech side rather than
-// raising it to clear the loud noise.
+// TestCalculateSpeechGateThreshold covers the voiced-p10-anchored placement: the
+// threshold lands at voiced p10 minus the speech margin, the narrow-gap signal
+// flips at separation = speechMargin + noiseMargin (12 dB), and a crossed (narrow)
+// gap keeps the threshold on the speech side rather than raising it to clear the
+// loud noise.
 func TestCalculateSpeechGateThreshold(t *testing.T) {
 	const narrowGapBoundary = speechGateThresholdSpeechMarginDB + speechGateThresholdNoiseMarginDB // 12 dB
 
@@ -1007,8 +1008,8 @@ func TestCalculateSpeechGateThreshold(t *testing.T) {
 }
 
 // TestTuneSpeechGateNewBasis is an integration-style check over in-memory
-// AudioMeasurements that drives the whole tuneSpeechGate body (task 4.4). It
-// asserts the new basis end to end: a wide-gap profile case (full fixed depth,
+// AudioMeasurements that drives the whole tuneSpeechGate body. It asserts the
+// basis end to end: a wide-gap profile case (full fixed depth,
 // voiced-anchored threshold), a narrow-gap profile case (reduced fixed depth,
 // threshold still on the speech side), and a no-profile case (the legacy safety
 // path, which cannot place an in-speech threshold because there is no voiced
@@ -1064,7 +1065,7 @@ func TestTuneSpeechGateNewBasis(t *testing.T) {
 			t.Fatalf("expected narrow gap at separation %.1f dB", separation)
 		}
 		// Threshold stays on the speech side (voiced p10 minus margin), never raised
-		// toward the noise (research W4 / proposal CAVEAT).
+		// toward the noise.
 		wantThdDB := voicedP10 - speechGateThresholdSpeechMarginDB
 		if gotDB := linearToDB(config.SpeechGate.Threshold); math.Abs(gotDB-wantThdDB) > 0.01 {
 			t.Errorf("threshold = %.2f dB, want speech-side %.2f dB on a narrow gap", gotDB, wantThdDB)

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -363,6 +363,27 @@ func TestTuneBandlimitLowPass(t *testing.T) {
 	}
 }
 
+func TestSibilanceExcessDB(t *testing.T) {
+	tests := []struct {
+		name string
+		sib  float64
+		body float64
+		want float64
+	}{
+		{"sib above body", -12.0, -18.0, 6.0},
+		{"sib below body", -24.0, -18.0, -6.0},
+		{"equal bands", -15.0, -15.0, 0.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := &SpeechCandidateMetrics{SibBandRMS: tt.sib, BodyBandRMS: tt.body}
+			if got := sp.SibilanceExcessDB(); got != tt.want {
+				t.Errorf("SibilanceExcessDB() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTuneDeesser(t *testing.T) {
 	// New engagement model (adaptive_deesser.go):
 	//   sibilanceExcess = SpeechProfile.SibBandRMS - SpeechProfile.BodyBandRMS  (dB)
@@ -1812,8 +1833,8 @@ func TestTuneNoiseReduction(t *testing.T) {
 			Regions: RegionMetrics{
 				GateSeparationDB: 15.0,
 				NoiseProfile: &NoiseProfile{
-					SpectralFlatness: 0.6,
-					BandsMeasured:    true,
+					Spectral:      SpectralMetrics{Flatness: 0.6},
+					BandsMeasured: true,
 					// Mean is -60; shapes are values minus mean: -1, 0, +1.
 					BandNoise: []float64{-61.0, -60.0, -59.0},
 				},
@@ -1850,8 +1871,8 @@ func TestTuneNoiseReduction(t *testing.T) {
 			Regions: RegionMetrics{
 				GateSeparationDB: 15.0,
 				NoiseProfile: &NoiseProfile{
-					SpectralFlatness: 0.6,
-					BandsMeasured:    true,
+					Spectral:      SpectralMetrics{Flatness: 0.6},
+					BandsMeasured: true,
 					// Mean over the finite bands is -60; the trailing NaN flattens to 0.0.
 					BandNoise: []float64{-61.0, -60.0, -59.0, math.NaN()},
 				},
@@ -1882,9 +1903,9 @@ func TestTuneNoiseReduction(t *testing.T) {
 			Regions: RegionMetrics{
 				GateSeparationDB: 15.0,
 				NoiseProfile: &NoiseProfile{
-					SpectralFlatness: 0.6,
-					BandsMeasured:    true,
-					BandNoise:        []float64{math.NaN(), math.Inf(-1), math.Inf(1)},
+					Spectral:      SpectralMetrics{Flatness: 0.6},
+					BandsMeasured: true,
+					BandNoise:     []float64{math.NaN(), math.Inf(-1), math.Inf(1)},
 				},
 			},
 		}
@@ -1907,9 +1928,9 @@ func TestTuneNoiseReduction(t *testing.T) {
 				Regions: RegionMetrics{
 					GateSeparationDB: 15.0,
 					NoiseProfile: &NoiseProfile{
-						SpectralFlatness: 0.6,
-						BandsMeasured:    true,
-						BandNoise:        []float64{-61.0, -60.0, -59.0},
+						Spectral:      SpectralMetrics{Flatness: 0.6},
+						BandsMeasured: true,
+						BandNoise:     []float64{-61.0, -60.0, -59.0},
 					},
 				},
 			}
@@ -1918,7 +1939,7 @@ func TestTuneNoiseReduction(t *testing.T) {
 		cases := map[string]func(*AudioMeasurements){
 			"bands unmeasured":   func(m *AudioMeasurements) { m.Regions.NoiseProfile.BandsMeasured = false },
 			"separation too low": func(m *AudioMeasurements) { m.Regions.GateSeparationDB = 11.0 },
-			"too tonal":          func(m *AudioMeasurements) { m.Regions.NoiseProfile.SpectralFlatness = 0.40 },
+			"too tonal":          func(m *AudioMeasurements) { m.Regions.NoiseProfile.Spectral.Flatness = 0.40 },
 			"no noise profile":   func(m *AudioMeasurements) { m.Regions.NoiseProfile = nil },
 		}
 

--- a/internal/processor/advice.go
+++ b/internal/processor/advice.go
@@ -58,18 +58,20 @@ type GainAdviceResult struct {
 //   - inputTP < -12             -> Quiet:    raise by round(target - inputTP)
 //   - -12 <= inputTP <= -1      -> Fine:    leave it
 func GainAdvice(inputTP float64) GainAdviceResult {
+	// Clipping and Hot both lower the gain by the same amount; only Kind differs.
+	lowerDeltaDB := -math.Round(inputTP - gainAdviceTargetTP)
 	switch {
 	case inputTP >= 0:
 		return GainAdviceResult{
 			Kind:    GainClipping,
 			InputTP: inputTP,
-			DeltaDB: -math.Round(inputTP - gainAdviceTargetTP),
+			DeltaDB: lowerDeltaDB,
 		}
 	case inputTP > gainAdviceHotTP:
 		return GainAdviceResult{
 			Kind:    GainHot,
 			InputTP: inputTP,
-			DeltaDB: -math.Round(inputTP - gainAdviceTargetTP),
+			DeltaDB: lowerDeltaDB,
 		}
 	case inputTP < gainAdviceQuietTP:
 		return GainAdviceResult{

--- a/internal/processor/advice.go
+++ b/internal/processor/advice.go
@@ -7,8 +7,7 @@ import (
 
 // GainAdviceKind is the single outcome of input-gain advice. The advice keys off
 // ONE binding constraint (input true peak) against ONE target, so the direction
-// is never ambiguous: it never says "raise" and "lower" in the same breath the
-// way the scrapped per-metric advice did.
+// is never ambiguous: it never says "raise" and "lower" in the same breath.
 type GainAdviceKind int
 
 const (

--- a/internal/processor/afftdn_custom_graph_test.go
+++ b/internal/processor/afftdn_custom_graph_test.go
@@ -41,7 +41,7 @@ func TestAfftdnCustomSpecParsesInFilterGraph(t *testing.T) {
 		t.Fatalf("unexpected spec under test: %q", spec)
 	}
 
-	graph, src, sink, err := setupFilterGraph(reader.GetDecoderContext(), spec)
+	graph, src, sink, err := setupFilterGraph(reader.DecoderContext(), spec)
 	if err != nil {
 		t.Fatalf("custom afftdn spec failed to parse/init in filter graph: %v\nspec: %s", err, spec)
 	}

--- a/internal/processor/analyser.go
+++ b/internal/processor/analyser.go
@@ -33,15 +33,15 @@ type RoomToneRegion struct {
 
 // NoiseProfile contains measurements from the elected room tone region.
 // These measurements serve as a reference baseline for adaptive filter tuning:
-//   - MeasuredNoiseFloor → elected noise floor (Noise.Floor) feeding the speech
-//     gate threshold and de-esser/quality references.
+//   - MeasuredNoiseFloor → elected noise floor (Noise.Floor), which drives the
+//     VAD split, the Recording-score cleanliness axis, and the afftdn nf seed.
 //   - CrestFactor/PeakLevel → peak-reference input to the legacy speech gate
 //     threshold path (calculateSpeechGateThresholdLegacy via adaptive_speech_gate.go),
 //     reached only when no SpeechProfile is elected.
 //
 // Entropy and the spectral fields are measured here for the report and
-// contamination detection; the current adaptive gate keys its release/range on
-// flux, LRA, and noise floor, not on room-tone entropy.
+// contamination detection; the current adaptive gate uses fixed release and
+// range, so it does not key either on room-tone entropy or spectral metrics.
 //
 // Note: The room tone region is also re-measured in Pass 2 and Pass 4 for
 // before/after comparison of noise reduction effectiveness.
@@ -340,12 +340,12 @@ func AnalyseAudio(ctx stdcontext.Context, filename string, config *BaseFilterCon
 	// Unified Pass 1 voice-activity detector: one bimodal split feeds both the
 	// elected SpeechProfile and the NoiseProfile / Noise.Floor. The pre-scan floor
 	// anchors the split clamp; the hop and axis are the single configurable choices.
-	// It must finish before either band function runs: it elects the speech and
-	// room-tone regions both measure.
+	// It must finish before either band function runs, because it elects the
+	// speech and room-tone regions that both band functions go on to measure.
 	detectVoiceActivity(measurements, intervals, measurements.Noise.FloorPrescan, analysisIntervalHop, axisMomentaryLUFS, config.logger)
 
 	// Post-loop band phase: the main decode loop is capped at BandPhaseProgressStart
-	// (0.85); the two band functions drive 0.85..1.0 by reporting each completed
+	// (0.95); the two band functions drive 0.95..1.0 by reporting each completed
 	// band decode through one shared tracker (atomic counter, monotonic, clamped to
 	// 1.0). The total is the combined speech + noise band budget, so a band function
 	// that early-returns still drains its share via drainBandProgress and the phase

--- a/internal/processor/analyser.go
+++ b/internal/processor/analyser.go
@@ -56,20 +56,11 @@ type NoiseProfile struct {
 
 	// Spectral characteristics for contamination detection (added during candidate
 	// evaluation). The full 13-metric aspectralstats set averaged over the elected
-	// room-tone region, mirroring SpectralMetrics field order.
-	SpectralMean     float64 `json:"spectral_mean"`        // Average spectral power
-	SpectralVariance float64 `json:"spectral_variance"`    // Spectral variance
-	SpectralCentroid float64 `json:"spectral_centroid_hz"` // Hz, where energy is concentrated (voice range: 300-4000 Hz)
-	SpectralSpread   float64 `json:"spectral_spread_hz"`   // Hz, bandwidth/fullness indicator
-	SpectralSkewness float64 `json:"spectral_skewness"`    // Spectral asymmetry (positive=bright, negative=dark)
-	SpectralKurtosis float64 `json:"spectral_kurtosis"`    // Peakiness (high = peaked harmonics like speech)
-	SpectralEntropy  float64 `json:"spectral_entropy"`     // Spectral randomness (0-1); distinct from the astats Entropy field above
-	SpectralFlatness float64 `json:"spectral_flatness"`    // 0-1, noise-like vs tonal (higher = more noise-like)
-	SpectralCrest    float64 `json:"spectral_crest"`       // Spectral peak-to-RMS (transient indicator)
-	SpectralFlux     float64 `json:"spectral_flux"`        // Frame-to-frame spectral change
-	SpectralSlope    float64 `json:"spectral_slope"`       // Spectral tilt (negative=more bass)
-	SpectralDecrease float64 `json:"spectral_decrease"`    // Average spectral decrease
-	SpectralRolloff  float64 `json:"spectral_rolloff_hz"`  // Hz, HF energy dropoff point
+	// room-tone region, mirroring RegionSample's Spectral embed. The custom
+	// NoiseProfile.MarshalJSON flattens this to the spectral_* tags (json:"-" keeps
+	// the default marshal from emitting the SpectralMetrics own tags). The astats
+	// Entropy field above stays DISTINCT from Spectral.Entropy (different axis).
+	Spectral SpectralMetrics `json:"-"`
 
 	// Room-tone band noise: per-band RMS (dBFS) over the elected room-tone region,
 	// one value per afftdn fixed band (see afftdnBandCentresHz). Feeds the measured
@@ -324,8 +315,7 @@ type OutputMeasurements struct {
 // The noise floor and silence threshold are computed from interval data after the full pass,
 // avoiding the need for a separate pre-scan phase.
 func AnalyseAudio(ctx stdcontext.Context, filename string, config *BaseFilterConfig, progressCallback ProgressCallback) (*AudioMeasurements, error) {
-	analysisContext := &ProcessingFilterContext{Pass: PassAnalysis}
-	collection, err := collectAnalysisFrames(ctx, filename, config, analysisContext, progressCallback)
+	collection, err := collectAnalysisFrames(ctx, filename, config, PassAnalysis, progressCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -441,29 +431,81 @@ func assignAstatsMeasurements(measurements *AudioMeasurements, acc *metadataAccu
 	measurements.Dynamics.NumberOfSamples = acc.astatsNumberOfSamples
 }
 
+// Noise-floor fallback estimator anchors (dB). These tune ONLY the fallback
+// estimators that run when astats provides no usable trough; the normal path
+// overwrites Noise.Floor with the VAD percentile floor.
+const (
+	// noiseFloorRMSEstimateOffsetDB drops below the overall RMS level to guess a
+	// floor when only an RMS level (no trough) is available.
+	noiseFloorRMSEstimateOffsetDB = 15.0
+	// noiseFloorThreshOffsetLoudDB / Mid / QuietDB sit below the ebur128 input
+	// threshold to guess a floor; a louder capture sits further above its floor.
+	noiseFloorThreshOffsetLoudDB  = 18.0
+	noiseFloorThreshOffsetMidDB   = 12.0
+	noiseFloorThreshOffsetQuietDB = 8.0
+	// noiseFloorClampMinDB / MaxDB bound the estimated floor.
+	noiseFloorClampMinDB = -90.0
+	noiseFloorClampMaxDB = -30.0
+)
+
+// Reduction-headroom fallback tiers (dB), used when no measured RMS/floor pair
+// is available.
+const (
+	reductionHeadroomLoudDB  = 40.0
+	reductionHeadroomMidDB   = 25.0
+	reductionHeadroomQuietDB = 15.0
+)
+
+// loudnessTier classifies a capture by its integrated input loudness against the
+// shared -20/-30 LUFS ladder, so the noise-floor and reduction-headroom fallback
+// estimators read one ordering instead of two copies.
+type loudnessTier int
+
+const (
+	loudnessTierLoud  loudnessTier = iota // InputI > -20 LUFS
+	loudnessTierMid                       // -30 < InputI <= -20 LUFS
+	loudnessTierQuiet                     // InputI <= -30 LUFS
+)
+
+const (
+	loudnessTierLoudThresholdLUFS = -20.0
+	loudnessTierMidThresholdLUFS  = -30.0
+)
+
+func classifyLoudnessTier(inputI float64) loudnessTier {
+	switch {
+	case inputI > loudnessTierLoudThresholdLUFS:
+		return loudnessTierLoud
+	case inputI > loudnessTierMidThresholdLUFS:
+		return loudnessTierMid
+	default:
+		return loudnessTierQuiet
+	}
+}
+
 func assignInputNoiseFloor(measurements *AudioMeasurements, acc *metadataAccumulators) {
 	switch {
 	case acc.astatsRMSTrough != 0 && !math.IsInf(acc.astatsRMSTrough, -1):
 		measurements.Noise.Floor = acc.astatsRMSTrough
 		measurements.Noise.FloorSource = "astats"
 	case acc.astatsRMSLevel != 0 && !math.IsInf(acc.astatsRMSLevel, -1):
-		measurements.Noise.Floor = acc.astatsRMSLevel - 15.0
+		measurements.Noise.Floor = acc.astatsRMSLevel - noiseFloorRMSEstimateOffsetDB
 		measurements.Noise.FloorSource = "rms_estimate"
 	default:
 		var noiseFloorOffset float64
-		switch {
-		case measurements.Loudness.InputI > -20:
-			noiseFloorOffset = 18.0
-		case measurements.Loudness.InputI > -30:
-			noiseFloorOffset = 12.0
+		switch classifyLoudnessTier(measurements.Loudness.InputI) {
+		case loudnessTierLoud:
+			noiseFloorOffset = noiseFloorThreshOffsetLoudDB
+		case loudnessTierMid:
+			noiseFloorOffset = noiseFloorThreshOffsetMidDB
 		default:
-			noiseFloorOffset = 8.0
+			noiseFloorOffset = noiseFloorThreshOffsetQuietDB
 		}
 		measurements.Noise.Floor = measurements.Loudness.InputThresh - noiseFloorOffset
 		measurements.Noise.FloorSource = "ebur128_estimate"
 	}
 
-	measurements.Noise.Floor = max(-90.0, min(-30.0, measurements.Noise.Floor))
+	measurements.Noise.Floor = max(noiseFloorClampMinDB, min(noiseFloorClampMaxDB, measurements.Noise.Floor))
 }
 
 func assignInputMeasurementSuggestions(measurements *AudioMeasurements) {
@@ -473,13 +515,13 @@ func assignInputMeasurementSuggestions(measurements *AudioMeasurements) {
 		return
 	}
 
-	switch {
-	case measurements.Loudness.InputI > -20:
-		measurements.Noise.ReductionHeadroom = 40.0
-	case measurements.Loudness.InputI > -30:
-		measurements.Noise.ReductionHeadroom = 25.0
+	switch classifyLoudnessTier(measurements.Loudness.InputI) {
+	case loudnessTierLoud:
+		measurements.Noise.ReductionHeadroom = reductionHeadroomLoudDB
+	case loudnessTierMid:
+		measurements.Noise.ReductionHeadroom = reductionHeadroomMidDB
 	default:
-		measurements.Noise.ReductionHeadroom = 15.0
+		measurements.Noise.ReductionHeadroom = reductionHeadroomQuietDB
 	}
 }
 
@@ -491,7 +533,7 @@ type analysisFrameCollection struct {
 	totalDuration    float64 // total audio length, seconds (from input metadata)
 }
 
-func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *BaseFilterConfig, context *ProcessingFilterContext, progressCallback ProgressCallback) (*analysisFrameCollection, error) {
+func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *BaseFilterConfig, pass PassNumber, progressCallback ProgressCallback) (*analysisFrameCollection, error) {
 	reader, metadata, err := audio.OpenAudioFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open audio file: %w", err)
@@ -506,7 +548,7 @@ func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *Base
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := createAnalysisFilterGraph(
 		reader.GetDecoderContext(),
 		config,
-		context,
+		pass,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create filter graph: %w", err)
@@ -565,7 +607,7 @@ func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *Base
 					progress = BandPhaseProgressStart
 				}
 				progressCallback(ProgressUpdate{
-					Pass:     context.Pass,
+					Pass:     pass,
 					PassName: "Analysing",
 					Progress: progress,
 					Level:    currentLevel,
@@ -611,15 +653,8 @@ func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *Base
 func createAnalysisFilterGraph(
 	decCtx *ffmpeg.AVCodecContext,
 	config *BaseFilterConfig,
-	context *ProcessingFilterContext,
+	_ PassNumber,
 ) (*ffmpeg.AVFilterGraph, *ffmpeg.AVFilterContext, *ffmpeg.AVFilterContext, error) {
-	if context == nil {
-		context = &ProcessingFilterContext{Pass: PassAnalysis}
-	}
-	if context.Pass == 0 {
-		context.Pass = PassAnalysis
-	}
-
 	analysisConfig := deriveEffectiveFilterConfig(config)
 	analysisConfig.FilterOrder = cloneFilterOrder(Pass1FilterOrder)
 

--- a/internal/processor/analyser.go
+++ b/internal/processor/analyser.go
@@ -546,7 +546,7 @@ func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *Base
 	estimatedTotalFrames := (totalDuration * sampleRate) / samplesPerFrame
 
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := createAnalysisFilterGraph(
-		reader.GetDecoderContext(),
+		reader.DecoderContext(),
 		config,
 		pass,
 	)
@@ -571,7 +571,7 @@ func collectAnalysisFrames(ctx stdcontext.Context, filename string, config *Base
 	var intervalStartTime time.Duration
 
 	var inputSamplesProcessed int64
-	inputSampleRate := float64(reader.GetDecoderContext().SampleRate())
+	inputSampleRate := float64(reader.DecoderContext().SampleRate())
 
 	if err := runFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
 		OnReadError: func(err error) error {

--- a/internal/processor/analyser.go
+++ b/internal/processor/analyser.go
@@ -54,10 +54,22 @@ type NoiseProfile struct {
 	Entropy            float64       `json:"entropy"`                      // Signal randomness (1.0 = white noise, lower = tonal noise like hum)
 	ExtractionWarning  string        `json:"extraction_warning,omitempty"` // Warning message if extraction had issues
 
-	// Spectral characteristics for contamination detection (added during candidate evaluation)
-	SpectralCentroid float64 `json:"spectral_centroid_hz,omitempty"` // Hz, where energy is concentrated (voice range: 300-4000 Hz)
-	SpectralFlatness float64 `json:"spectral_flatness,omitempty"`    // 0-1, noise-like vs tonal (higher = more noise-like)
-	SpectralKurtosis float64 `json:"spectral_kurtosis,omitempty"`    // Peakiness (high = peaked harmonics like speech)
+	// Spectral characteristics for contamination detection (added during candidate
+	// evaluation). The full 13-metric aspectralstats set averaged over the elected
+	// room-tone region, mirroring SpectralMetrics field order.
+	SpectralMean     float64 `json:"spectral_mean"`        // Average spectral power
+	SpectralVariance float64 `json:"spectral_variance"`    // Spectral variance
+	SpectralCentroid float64 `json:"spectral_centroid_hz"` // Hz, where energy is concentrated (voice range: 300-4000 Hz)
+	SpectralSpread   float64 `json:"spectral_spread_hz"`   // Hz, bandwidth/fullness indicator
+	SpectralSkewness float64 `json:"spectral_skewness"`    // Spectral asymmetry (positive=bright, negative=dark)
+	SpectralKurtosis float64 `json:"spectral_kurtosis"`    // Peakiness (high = peaked harmonics like speech)
+	SpectralEntropy  float64 `json:"spectral_entropy"`     // Spectral randomness (0-1); distinct from the astats Entropy field above
+	SpectralFlatness float64 `json:"spectral_flatness"`    // 0-1, noise-like vs tonal (higher = more noise-like)
+	SpectralCrest    float64 `json:"spectral_crest"`       // Spectral peak-to-RMS (transient indicator)
+	SpectralFlux     float64 `json:"spectral_flux"`        // Frame-to-frame spectral change
+	SpectralSlope    float64 `json:"spectral_slope"`       // Spectral tilt (negative=more bass)
+	SpectralDecrease float64 `json:"spectral_decrease"`    // Average spectral decrease
+	SpectralRolloff  float64 `json:"spectral_rolloff_hz"`  // Hz, HF energy dropoff point
 
 	// Room-tone band noise: per-band RMS (dBFS) over the elected room-tone region,
 	// one value per afftdn fixed band (see afftdnBandCentresHz). Feeds the measured

--- a/internal/processor/analyser.go
+++ b/internal/processor/analyser.go
@@ -37,7 +37,7 @@ type RoomToneRegion struct {
 //     gate threshold and de-esser/quality references.
 //   - CrestFactor/PeakLevel → peak-reference input to the legacy speech gate
 //     threshold path (calculateSpeechGateThresholdLegacy via adaptive_speech_gate.go),
-//     reached only when noise-to-speech separation is too small for the aggression maths.
+//     reached only when no SpeechProfile is elected.
 //
 // Entropy and the spectral fields are measured here for the report and
 // contamination detection; the current adaptive gate keys its release/range on
@@ -48,7 +48,7 @@ type RoomToneRegion struct {
 type NoiseProfile struct {
 	Start              time.Duration `json:"start"`                        // Start time of room tone region used (time.Duration ns)
 	Duration           time.Duration `json:"duration"`                     // Duration of extracted sample (time.Duration ns)
-	MeasuredNoiseFloor float64       `json:"measured_floor_dbfs"`          // dBFS, RMS level of room tone (average noise)
+	MeasuredNoiseFloor float64       `json:"measured_floor_dbfs"`          // Elected noise floor; seeded as astats RMS, overwritten by detectVoiceActivity with the momentary-LUFS percentile floor
 	PeakLevel          float64       `json:"peak_level_dbfs"`              // dBFS, peak level in room tone (transient noise indicator)
 	CrestFactor        float64       `json:"crest_factor_db"`              // Peak - RMS in dB (high = impulsive noise, low = steady noise)
 	Entropy            float64       `json:"entropy"`                      // Signal randomness (1.0 = white noise, lower = tonal noise like hum)

--- a/internal/processor/analyser_bands.go
+++ b/internal/processor/analyser_bands.go
@@ -62,7 +62,7 @@ func measureSpeechBandRMS(ctx context.Context, reader *audio.Reader, start, dura
 	// span is unchanged (see regionSeekPreRoll).
 	seekReaderBeforeRegion(reader, start, log)
 
-	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.GetDecoderContext(), filterSpec)
+	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.DecoderContext(), filterSpec)
 	if err != nil {
 		return 0, false, fmt.Errorf("failed to create band analysis filter graph: %w", err)
 	}

--- a/internal/processor/analyser_bands.go
+++ b/internal/processor/analyser_bands.go
@@ -38,7 +38,9 @@ const speechBandAnalysisFilterFormat = "aformat=channel_layouts=mono,atrim=start
 // band-limiting the downmixed signal before astats. Returns the RMS in dBFS and
 // ok=false when no RMS metadata was captured (e.g. region shorter than astats
 // warmup).
-func measureSpeechBandRMS(ctx context.Context, reader *audio.Reader, start, duration time.Duration, lowHz, highHz float64) (float64, bool, error) {
+//
+// log sinks the non-fatal region-seek warning.
+func measureSpeechBandRMS(ctx context.Context, reader *audio.Reader, start, duration time.Duration, lowHz, highHz float64, log debugLogger) (float64, bool, error) {
 	if start < 0 {
 		return 0, false, fmt.Errorf("invalid region: negative start time")
 	}
@@ -53,6 +55,12 @@ func measureSpeechBandRMS(ctx context.Context, reader *audio.Reader, start, dura
 		lowHz,
 		highHz,
 	)
+
+	// Skip the pre-region span: seek the demuxer near the region before decoding
+	// rather than decoding from frame 0 and letting atrim discard everything
+	// ahead of start. The atrim window stays region-absolute, so the measured
+	// span is unchanged (see regionSeekPreRoll).
+	seekReaderBeforeRegion(reader, start, log)
 
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.GetDecoderContext(), filterSpec)
 	if err != nil {
@@ -130,7 +138,7 @@ func measureSpeechBands(ctx context.Context, filename string, measurements *Audi
 		defer reader.Close()
 
 		band := speechBandPlan[i]
-		rms, ok, err := measureSpeechBandRMS(ctx, reader, region.Start, region.Duration, band.lowHz, band.highHz)
+		rms, ok, err := measureSpeechBandRMS(ctx, reader, region.Start, region.Duration, band.lowHz, band.highHz, log)
 		if err != nil {
 			log.Logf("Warning: speech band %d RMS measurement failed: %v", i, err)
 			return

--- a/internal/processor/analyser_candidates_shared.go
+++ b/internal/processor/analyser_candidates_shared.go
@@ -7,29 +7,41 @@ import (
 	"time"
 )
 
+// refineRegion is the neutral {Start, End, Duration} region value passed through
+// refineToSubregion. It is domain-agnostic on purpose: SpeechRegion and
+// RoomToneRegion share this shape but carry domain-specific JSON tags and meaning,
+// so the shared refinement helper takes and returns this plain value and each
+// caller converts to its own region type. (Distinct from spectrogram.go's
+// regionBounds, which holds float seconds for a spectrogram window.)
+type refineRegion struct {
+	Start    time.Duration
+	End      time.Duration
+	Duration time.Duration
+}
+
 // refineToSubregion implements the shared sliding-window refinement logic used by both
 // room tone and speech sub-region selection. It finds the best-scoring contiguous window
 // within the given time range, where "best" is determined by the provided scoring function
 // and comparison: isBetter(candidate, current) returns true when candidate should replace current.
 //
-// Returns the refined start, end, and duration. If refinement is not possible (insufficient
+// Returns the refined region bounds. If refinement is not possible (insufficient
 // intervals, already within target), returns the original bounds unchanged and ok=false.
 func refineToSubregion(
-	start, end, duration time.Duration,
+	region refineRegion,
 	intervals []IntervalSample,
 	windowDuration, windowMinimum time.Duration,
 	score func([]IntervalSample) float64,
 	isBetter func(candidate, current float64) bool,
-) (refinedStart, refinedEnd, refinedDuration time.Duration, ok bool) {
+) (refined refineRegion, ok bool) {
 	// No refinement needed if already at or below target duration
-	if duration <= windowDuration {
-		return start, end, duration, false
+	if region.Duration <= windowDuration {
+		return region, false
 	}
 
 	// Extract intervals within the candidate's time range
-	candidateIntervals := getIntervalsInRange(intervals, start, end)
+	candidateIntervals := getIntervalsInRange(intervals, region.Start, region.End)
 	if candidateIntervals == nil {
-		return start, end, duration, false
+		return region, false
 	}
 
 	// Calculate window size in intervals
@@ -38,7 +50,7 @@ func refineToSubregion(
 
 	// Need at least minimum window worth of intervals
 	if len(candidateIntervals) < minimumIntervals {
-		return start, end, duration, false
+		return region, false
 	}
 
 	// If we have fewer intervals than target window, use what we have
@@ -59,11 +71,14 @@ func refineToSubregion(
 	}
 
 	// Calculate refined region bounds from the best window position
-	refinedStart = candidateIntervals[bestStartIdx].Timestamp
-	refinedDuration = time.Duration(windowIntervals) * goldenIntervalSize
-	refinedEnd = refinedStart + refinedDuration
+	refinedStart := candidateIntervals[bestStartIdx].Timestamp
+	refinedDuration := time.Duration(windowIntervals) * goldenIntervalSize
 
-	return refinedStart, refinedEnd, refinedDuration, true
+	return refineRegion{
+		Start:    refinedStart,
+		End:      refinedStart + refinedDuration,
+		Duration: refinedDuration,
+	}, true
 }
 
 // getIntervalsInRange returns intervals that fall within the given time range.

--- a/internal/processor/analyser_candidates_shared.go
+++ b/internal/processor/analyser_candidates_shared.go
@@ -259,11 +259,9 @@ func scoreSpeechIntervalWindow(intervals []IntervalSample) float64 {
 	}
 
 	// Rolloff score: prefer regions with rolloff in typical voiced speech range.
-	// Uses shared helper function for consistency with scoreSpeechCandidate.
 	rolloffScore := calculateRolloffScore(avgRolloff)
 
 	// Flux score: prefer regions with low spectral flux (stable voicing).
-	// Uses shared helper function for consistency with scoreSpeechCandidate.
 	fluxScore := calculateFluxScore(avgFlux)
 
 	// Weighted combination optimised for measurement stability (weights sum to 1.0;

--- a/internal/processor/analyser_candidates_speech.go
+++ b/internal/processor/analyser_candidates_speech.go
@@ -186,8 +186,8 @@ func refineToGoldenSpeechSubregion(candidate *SpeechRegion, intervals []Interval
 		return nil
 	}
 
-	start, end, dur, ok := refineToSubregion(
-		candidate.Start, candidate.End, candidate.Duration,
+	refined, ok := refineToSubregion(
+		refineRegion{Start: candidate.Start, End: candidate.End, Duration: candidate.Duration},
 		intervals,
 		goldenSpeechWindowDuration, goldenSpeechWindowMinimum,
 		scoreSpeechIntervalWindow,
@@ -197,7 +197,7 @@ func refineToGoldenSpeechSubregion(candidate *SpeechRegion, intervals []Interval
 		return candidate
 	}
 
-	return &SpeechRegion{Start: start, End: end, Duration: dur}
+	return &SpeechRegion{Start: refined.Start, End: refined.End, Duration: refined.Duration}
 }
 
 // findBestSpeechRegionResult contains the selected region and all evaluated candidates.

--- a/internal/processor/analyser_candidates_speech.go
+++ b/internal/processor/analyser_candidates_speech.go
@@ -342,9 +342,9 @@ const (
 // SNR penalty into the score by taking the noise floor as a parameter, so the
 // election helper no longer carries scoring maths (god-function mitigation).
 //
-// Design note (proposal Risk 5/6; VAD-RESEARCH.md:920-927): the old composite
-// clustered candidates at 0.58-0.65 and never ranked them, so the SNR axis here
-// MUST spread across the candidates within a file. The SNR term is
+// Design note: the old composite clustered candidates at 0.58-0.65 and never
+// ranked them, so the SNR axis here MUST spread across the candidates within a
+// file. The SNR term is
 // relative-within-file: it depends on RMSLevel - noiseFloorDB, so a constant floor
 // offset shifts every candidate equally and does not change their ranking. The SNR
 // saturation point (snrSaturationMargin) is a placeholder set by the Phase 3

--- a/internal/processor/analyser_metrics.go
+++ b/internal/processor/analyser_metrics.go
@@ -132,22 +132,27 @@ func (s *IntervalSample) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// intervalSpectralJSONKeys is the single source of truth for the flat spectral_*
+// JSON keys on an interval sample. The intervalSampleJSON marshal/unmarshal tags
+// must match this list, and hasSpectralKeys probes exactly these keys.
+var intervalSpectralJSONKeys = []string{
+	"spectral_mean",
+	"spectral_variance",
+	"spectral_centroid",
+	"spectral_spread",
+	"spectral_skewness",
+	"spectral_kurtosis",
+	"spectral_entropy",
+	"spectral_flatness",
+	"spectral_crest",
+	"spectral_flux",
+	"spectral_slope",
+	"spectral_decrease",
+	"spectral_rolloff",
+}
+
 func hasSpectralKeys(raw map[string]json.RawMessage) bool {
-	for _, key := range []string{
-		"spectral_mean",
-		"spectral_variance",
-		"spectral_centroid",
-		"spectral_spread",
-		"spectral_skewness",
-		"spectral_kurtosis",
-		"spectral_entropy",
-		"spectral_flatness",
-		"spectral_crest",
-		"spectral_flux",
-		"spectral_slope",
-		"spectral_decrease",
-		"spectral_rolloff",
-	} {
+	for _, key := range intervalSpectralJSONKeys {
 		if _, ok := raw[key]; ok {
 			return true
 		}

--- a/internal/processor/analyser_noise_bands.go
+++ b/internal/processor/analyser_noise_bands.go
@@ -86,7 +86,7 @@ func measureNoiseBands(ctx context.Context, filename string, measurements *Audio
 		defer reader.Close()
 
 		lowHz, highHz := afftdnBandEdgesHz(i)
-		rms, ok, err := measureSpeechBandRMS(ctx, reader, profile.Start, profile.Duration, lowHz, highHz)
+		rms, ok, err := measureSpeechBandRMS(ctx, reader, profile.Start, profile.Duration, lowHz, highHz, log)
 		if err != nil {
 			log.Logf("Warning: noise band %d RMS measurement failed: %v", i, err)
 			return

--- a/internal/processor/analyser_noise_seed.go
+++ b/internal/processor/analyser_noise_seed.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"cmp"
-	"math"
 	"slices"
 	"time"
 )
@@ -203,7 +202,7 @@ func estimateNoiseFloorAndThreshold(intervals []IntervalSample, medians silenceM
 	seen := false
 	for i := 0; i < candidateCount; i++ {
 		level := scored[i].level
-		if math.IsInf(level, 0) || math.IsNaN(level) || level <= vadLevelFloorDB {
+		if isFlooredLevel(level) {
 			continue
 		}
 		if !seen || level > maxRoomToneLevel {

--- a/internal/processor/analyser_noise_seed.go
+++ b/internal/processor/analyser_noise_seed.go
@@ -11,9 +11,8 @@ import (
 //
 // These run in buildInputMeasurements BEFORE the voice-activity detector: they
 // produce the measured pre-scan floor (Noise.FloorPrescan) that anchors the
-// detector's split clamp. They were moved here from the room-tone candidate
-// files when the scored room-tone election was deleted; the unified detector
-// keeps only this seed path plus the shared golden-window bounds.
+// detector's split clamp. The unified detector keeps only this seed path plus
+// the shared golden-window bounds; it has no scored room-tone election.
 
 // Golden sub-region refinement bounds, shared by the room-tone region picker
 // (pickLowClusterRegion) and the shared sliding-window refinement
@@ -75,8 +74,8 @@ const (
 // The amplitude cue reads the momentary-LUFS axis (interval.MomentaryLUFS), the
 // same axis the VAD split, floor, and noise margin operate on, so the seed and the
 // detector share one scale. It feeds the pre-scan noise-floor estimator
-// (estimateNoiseFloorAndThreshold); the richer spectral metrics are no longer
-// used now the scored room-tone election is gone.
+// (estimateNoiseFloorAndThreshold); only the amplitude and flux cues are used,
+// the richer spectral metrics are not, since there is no scored room-tone election.
 func roomToneScore(interval IntervalSample, levelP50, fluxP50 float64) float64 {
 	// Amplitude component: quieter = more likely room tone
 	// Score 1.0 if at or below median, decreasing above

--- a/internal/processor/analyser_output.go
+++ b/internal/processor/analyser_output.go
@@ -112,7 +112,7 @@ func measureOutputRegionFromReader(ctx context.Context, reader *audio.Reader, st
 	// span is unchanged (see regionSeekPreRoll).
 	seekReaderBeforeRegion(reader, start, log)
 
-	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.GetDecoderContext(), filterSpec)
+	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.DecoderContext(), filterSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create analysis filter graph: %w", err)
 	}

--- a/internal/processor/analyser_output.go
+++ b/internal/processor/analyser_output.go
@@ -71,6 +71,23 @@ type regionMeasurements struct {
 	FramesProcessed int64
 }
 
+// toRegionSample maps the measured region metrics to a bare RegionSample
+// (amplitude/spectral/loudness only). FramesProcessed is a measurement-internal
+// counter and is not carried onto the sample. Both output region wrappers share
+// this so the eight-field copy lives in one place.
+func (r *regionMeasurements) toRegionSample() *RegionSample {
+	return &RegionSample{
+		RMSLevel:      r.RMSLevel,
+		PeakLevel:     r.PeakLevel,
+		CrestFactor:   r.CrestFactor,
+		Spectral:      r.Spectral,
+		MomentaryLUFS: r.MomentaryLUFS,
+		ShortTermLUFS: r.ShortTermLUFS,
+		TruePeak:      r.TruePeak,
+		SamplePeak:    r.SamplePeak,
+	}
+}
+
 // measureOutputRegionFromReader measures amplitude, spectral, and loudness
 // metrics for a time region in an already-opened audio file. This is the
 // shared implementation behind measureOutputRoomToneRegionFromReader and
@@ -224,16 +241,7 @@ func measureOutputRoomToneRegionFromReader(ctx context.Context, reader *audio.Re
 
 	log.Logf("=== measureOutputRoomToneRegion SUMMARY ===")
 
-	return &RegionSample{
-		RMSLevel:      result.RMSLevel,
-		PeakLevel:     result.PeakLevel,
-		CrestFactor:   result.CrestFactor,
-		Spectral:      result.Spectral,
-		MomentaryLUFS: result.MomentaryLUFS,
-		ShortTermLUFS: result.ShortTermLUFS,
-		TruePeak:      result.TruePeak,
-		SamplePeak:    result.SamplePeak,
-	}, nil
+	return result.toRegionSample(), nil
 }
 
 // extractRegionPair builds optional RoomToneRegion and SpeechRegion pointers
@@ -319,14 +327,5 @@ func measureOutputSpeechRegionFromReader(ctx context.Context, reader *audio.Read
 
 	log.Logf("=== measureOutputSpeechRegion SUMMARY ===")
 
-	return &RegionSample{
-		RMSLevel:      result.RMSLevel,
-		PeakLevel:     result.PeakLevel,
-		CrestFactor:   result.CrestFactor,
-		Spectral:      result.Spectral,
-		MomentaryLUFS: result.MomentaryLUFS,
-		ShortTermLUFS: result.ShortTermLUFS,
-		TruePeak:      result.TruePeak,
-		SamplePeak:    result.SamplePeak,
-	}, nil
+	return result.toRegionSample(), nil
 }

--- a/internal/processor/analyser_output_test.go
+++ b/internal/processor/analyser_output_test.go
@@ -128,6 +128,50 @@ func TestRegionSeekPreRollCoversLoudnessWindows(t *testing.T) {
 	}
 }
 
+// TestToRegionSample asserts the eight-field copy maps each regionMeasurements
+// field to its RegionSample counterpart and drops the measurement-internal
+// FramesProcessed counter. Pure-function test: no audio, no demuxer.
+func TestToRegionSample(t *testing.T) {
+	rm := &regionMeasurements{
+		RMSLevel:        -18.5,
+		PeakLevel:       -2.0,
+		CrestFactor:     16.5,
+		Spectral:        SpectralMetrics{Centroid: 1234.5, Rolloff: 6789.0, Found: true},
+		MomentaryLUFS:   -16.2,
+		ShortTermLUFS:   -15.8,
+		TruePeak:        -1.1,
+		SamplePeak:      -1.3,
+		FramesProcessed: 4242,
+	}
+
+	got := rm.toRegionSample()
+
+	if got.RMSLevel != rm.RMSLevel {
+		t.Errorf("RMSLevel = %v, want %v", got.RMSLevel, rm.RMSLevel)
+	}
+	if got.PeakLevel != rm.PeakLevel {
+		t.Errorf("PeakLevel = %v, want %v", got.PeakLevel, rm.PeakLevel)
+	}
+	if got.CrestFactor != rm.CrestFactor {
+		t.Errorf("CrestFactor = %v, want %v", got.CrestFactor, rm.CrestFactor)
+	}
+	if got.Spectral != rm.Spectral {
+		t.Errorf("Spectral = %+v, want %+v", got.Spectral, rm.Spectral)
+	}
+	if got.MomentaryLUFS != rm.MomentaryLUFS {
+		t.Errorf("MomentaryLUFS = %v, want %v", got.MomentaryLUFS, rm.MomentaryLUFS)
+	}
+	if got.ShortTermLUFS != rm.ShortTermLUFS {
+		t.Errorf("ShortTermLUFS = %v, want %v", got.ShortTermLUFS, rm.ShortTermLUFS)
+	}
+	if got.TruePeak != rm.TruePeak {
+		t.Errorf("TruePeak = %v, want %v", got.TruePeak, rm.TruePeak)
+	}
+	if got.SamplePeak != rm.SamplePeak {
+		t.Errorf("SamplePeak = %v, want %v", got.SamplePeak, rm.SamplePeak)
+	}
+}
+
 func TestExtractRegionPair(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/processor/analyser_test.go
+++ b/internal/processor/analyser_test.go
@@ -1259,7 +1259,7 @@ func TestRunFilterGraph(t *testing.T) {
 
 	// Create a passthrough filter graph (anull = audio null filter, passes through unchanged)
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(
-		reader.GetDecoderContext(),
+		reader.DecoderContext(),
 		"anull",
 	)
 	if err != nil {
@@ -1315,7 +1315,7 @@ func TestRunFilterGraphLenientErrors(t *testing.T) {
 	defer reader.Close()
 
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(
-		reader.GetDecoderContext(),
+		reader.DecoderContext(),
 		"anull",
 	)
 	if err != nil {

--- a/internal/processor/analyser_vad.go
+++ b/internal/processor/analyser_vad.go
@@ -62,6 +62,17 @@ const (
 // window near -120 dBFS; this margin sits just above that measurement floor.
 const vadLevelFloorDB = -115.0
 
+// isFlooredLevel reports whether a per-interval level is floored: at or below
+// vadLevelFloorDB (digital silence / unmeasurable) or non-finite (+Inf, -Inf,
+// NaN). The histogram, the level set, the gate statistics, and the noise-floor
+// seed all exclude these so digital silence does not invent a spurious low mode
+// or seed a phantom floor. flooredFraction deliberately uses a NaN-only test
+// (it counts floored intervals against the measurable denominator), so it is
+// kept separate; do not route it through this predicate.
+func isFlooredLevel(level float64) bool {
+	return math.IsInf(level, 0) || math.IsNaN(level) || level <= vadLevelFloorDB
+}
+
 // intervalLevel returns the per-interval level on the selected axis.
 func intervalLevel(s IntervalSample, axis levelAxis) float64 {
 	switch axis {
@@ -104,7 +115,7 @@ func buildLevelHistogram(intervals []IntervalSample, axis levelAxis, binWidthDB 
 	maxLevel := math.Inf(-1)
 	for _, iv := range intervals {
 		level := intervalLevel(iv, axis)
-		if math.IsInf(level, 0) || math.IsNaN(level) || level <= vadLevelFloorDB {
+		if isFlooredLevel(level) {
 			continue
 		}
 		levels = append(levels, level)
@@ -144,7 +155,7 @@ func vadLevels(intervals []IntervalSample, axis levelAxis) []float64 {
 	levels := make([]float64, 0, len(intervals))
 	for _, iv := range intervals {
 		level := intervalLevel(iv, axis)
-		if math.IsInf(level, 0) || math.IsNaN(level) || level <= vadLevelFloorDB {
+		if isFlooredLevel(level) {
 			continue
 		}
 		levels = append(levels, level)
@@ -210,7 +221,7 @@ func deriveGateStatistics(intervals []IntervalSample, split float64, axis levelA
 	var voiced, noise []float64
 	for i := range intervals {
 		level := intervalLevel(intervals[i], axis)
-		if math.IsInf(level, 0) || math.IsNaN(level) || level <= vadLevelFloorDB {
+		if isFlooredLevel(level) {
 			continue
 		}
 		if level < split {
@@ -557,21 +568,12 @@ func extractNoiseProfileFromIntervals(region *RoomToneRegion, intervals []Interv
 		return nil
 	}
 
-	var rmsSum, peakMax float64
-	var spectralSum SpectralMetrics
-	peakMax = -120.0
-
-	for _, interval := range regionIntervals {
-		rmsSum += interval.RMSLevel
-		if interval.PeakLevel > peakMax {
-			peakMax = interval.PeakLevel
-		}
-		spectralSum.add(interval.Spectral)
-	}
+	acc := accumulateIntervalMetrics(regionIntervals)
+	peakMax := acc.peakMax
 
 	n := float64(len(regionIntervals))
-	avgRMS := rmsSum / n
-	avgSpectral := spectralSum.average(n)
+	avgRMS := acc.rmsSum / n
+	avgSpectral := acc.spectralSum.average(n)
 
 	profile := &NoiseProfile{
 		Start:    region.Start,
@@ -583,21 +585,12 @@ func extractNoiseProfileFromIntervals(region *RoomToneRegion, intervals []Interv
 		PeakLevel:          peakMax,
 		CrestFactor:        peakMax - avgRMS,
 		// Entropy (astats signal-randomness field) is fed from the spectral
-		// entropy average, unchanged from the prior entropySum/n behaviour.
-		Entropy:          avgSpectral.Entropy,
-		SpectralMean:     avgSpectral.Mean,
-		SpectralVariance: avgSpectral.Variance,
-		SpectralCentroid: avgSpectral.Centroid,
-		SpectralSpread:   avgSpectral.Spread,
-		SpectralSkewness: avgSpectral.Skewness,
-		SpectralKurtosis: avgSpectral.Kurtosis,
-		SpectralEntropy:  avgSpectral.Entropy,
-		SpectralFlatness: avgSpectral.Flatness,
-		SpectralCrest:    avgSpectral.Crest,
-		SpectralFlux:     avgSpectral.Flux,
-		SpectralSlope:    avgSpectral.Slope,
-		SpectralDecrease: avgSpectral.Decrease,
-		SpectralRolloff:  avgSpectral.Rolloff,
+		// entropy average, unchanged from the prior entropySum/n behaviour. It
+		// stays DISTINCT from the embedded Spectral.Entropy (different axis).
+		Entropy: avgSpectral.Entropy,
+		// The full 13-metric room-tone spectral average, copied as one embedded
+		// value (mirrors RegionSample's Spectral embed).
+		Spectral: avgSpectral,
 	}
 
 	if region.Duration < idealDurationMin {
@@ -678,15 +671,15 @@ func pickLowClusterRegion(intervals []IntervalSample, split float64, axis levelA
 	// Golden refinement: trim a long quiet run to its cleanest (lowest-RMS) inner
 	// window, biasing the noise sample inward. Reuses the shared sliding-window
 	// refinement with the room-tone window bounds.
-	start, end, dur, ok := refineToSubregion(
-		best.Start, best.End, best.Duration,
+	refined, ok := refineToSubregion(
+		refineRegion{Start: best.Start, End: best.End, Duration: best.Duration},
 		intervals,
 		goldenWindowDuration, goldenWindowMinimum,
 		scoreIntervalWindow,
 		func(candidate, current float64) bool { return candidate < current },
 	)
 	if ok {
-		return &RoomToneRegion{Start: start, End: end, Duration: dur}
+		return &RoomToneRegion{Start: refined.Start, End: refined.End, Duration: refined.Duration}
 	}
 	return best
 }

--- a/internal/processor/analyser_vad.go
+++ b/internal/processor/analyser_vad.go
@@ -11,8 +11,8 @@ import (
 // the one owner of the interval duration: collectAnalysisFrames reads it to
 // close each interval window, and the voice-activity detector reads it to
 // convert its duration-expressed bounds into interval counts. The value is a
-// measured choice; the hop-separation sweep (Phase 6.1) may revise it. Keeping
-// it a single named value means that revision is a one-line change.
+// measured choice a future hop-separation sweep may revise. Keeping it a single
+// named value means that revision is a one-line change.
 const analysisIntervalHop = 250 * time.Millisecond
 
 // Voice-activity detector run-formation bounds, expressed as durations rather
@@ -43,8 +43,8 @@ func intervalsForDuration(d, hop time.Duration) int {
 }
 
 // levelAxis names the per-interval amplitude signal the detector splits on. It
-// is the single named choice the validation gate (Phase 6.2) may flip, so the
-// fallback is a one-line change.
+// is the single named choice a future validation gate may flip, so the fallback
+// is a one-line change.
 type levelAxis int
 
 const (

--- a/internal/processor/analyser_vad.go
+++ b/internal/processor/analyser_vad.go
@@ -558,7 +558,7 @@ func extractNoiseProfileFromIntervals(region *RoomToneRegion, intervals []Interv
 	}
 
 	var rmsSum, peakMax float64
-	var entropySum, centroidSum, flatnessSum, kurtosisSum float64
+	var spectralSum SpectralMetrics
 	peakMax = -120.0
 
 	for _, interval := range regionIntervals {
@@ -566,14 +566,12 @@ func extractNoiseProfileFromIntervals(region *RoomToneRegion, intervals []Interv
 		if interval.PeakLevel > peakMax {
 			peakMax = interval.PeakLevel
 		}
-		entropySum += interval.Spectral.Entropy
-		centroidSum += interval.Spectral.Centroid
-		flatnessSum += interval.Spectral.Flatness
-		kurtosisSum += interval.Spectral.Kurtosis
+		spectralSum.add(interval.Spectral)
 	}
 
 	n := float64(len(regionIntervals))
 	avgRMS := rmsSum / n
+	avgSpectral := spectralSum.average(n)
 
 	profile := &NoiseProfile{
 		Start:    region.Start,
@@ -584,10 +582,22 @@ func extractNoiseProfileFromIntervals(region *RoomToneRegion, intervals []Interv
 		MeasuredNoiseFloor: avgRMS,
 		PeakLevel:          peakMax,
 		CrestFactor:        peakMax - avgRMS,
-		Entropy:            entropySum / n,
-		SpectralCentroid:   centroidSum / n,
-		SpectralFlatness:   flatnessSum / n,
-		SpectralKurtosis:   kurtosisSum / n,
+		// Entropy (astats signal-randomness field) is fed from the spectral
+		// entropy average, unchanged from the prior entropySum/n behaviour.
+		Entropy:          avgSpectral.Entropy,
+		SpectralMean:     avgSpectral.Mean,
+		SpectralVariance: avgSpectral.Variance,
+		SpectralCentroid: avgSpectral.Centroid,
+		SpectralSpread:   avgSpectral.Spread,
+		SpectralSkewness: avgSpectral.Skewness,
+		SpectralKurtosis: avgSpectral.Kurtosis,
+		SpectralEntropy:  avgSpectral.Entropy,
+		SpectralFlatness: avgSpectral.Flatness,
+		SpectralCrest:    avgSpectral.Crest,
+		SpectralFlux:     avgSpectral.Flux,
+		SpectralSlope:    avgSpectral.Slope,
+		SpectralDecrease: avgSpectral.Decrease,
+		SpectralRolloff:  avgSpectral.Rolloff,
 	}
 
 	if region.Duration < idealDurationMin {

--- a/internal/processor/analyser_vad.go
+++ b/internal/processor/analyser_vad.go
@@ -546,8 +546,7 @@ const (
 
 // extractNoiseProfileFromIntervals creates a NoiseProfile using pre-collected interval data.
 // This avoids re-reading the audio file - all measurements come from Pass 1's interval samples.
-// Returns nil if no intervals fall within the region. Moved here from the room-tone file so the
-// detector keeps the exact NoiseProfile field shape and the short/long extraction warnings.
+// Returns nil if no intervals fall within the region.
 func extractNoiseProfileFromIntervals(region *RoomToneRegion, intervals []IntervalSample) *NoiseProfile {
 	if region == nil {
 		return nil
@@ -577,8 +576,11 @@ func extractNoiseProfileFromIntervals(region *RoomToneRegion, intervals []Interv
 	avgRMS := rmsSum / n
 
 	profile := &NoiseProfile{
-		Start:              region.Start,
-		Duration:           region.Duration,
+		Start:    region.Start,
+		Duration: region.Duration,
+		// avgRMS is the local astats-RMS value, not the final one. The caller
+		// detectVoiceActivity overwrites MeasuredNoiseFloor with the percentile
+		// floor on the momentary-LUFS axis.
 		MeasuredNoiseFloor: avgRMS,
 		PeakLevel:          peakMax,
 		CrestFactor:        peakMax - avgRMS,

--- a/internal/processor/analyser_vad_test.go
+++ b/internal/processor/analyser_vad_test.go
@@ -828,7 +828,7 @@ func TestPickLowClusterRegion(t *testing.T) {
 		t.Errorf("MeasuredNoiseFloor = %.2f, want percentile floor %.2f", profile.MeasuredNoiseFloor, floor)
 	}
 	// Spectral fields come from the picked region (centroid set by vadInterval).
-	if profile.SpectralCentroid == 0 {
+	if profile.Spectral.Centroid == 0 {
 		t.Error("NoiseProfile spectral centroid is zero; want region spectral fields")
 	}
 }
@@ -882,19 +882,19 @@ func TestExtractNoiseProfileSpectralFields(t *testing.T) {
 		got  float64
 		want float64
 	}{
-		{"SpectralMean", profile.SpectralMean, 2.0},
-		{"SpectralVariance", profile.SpectralVariance, 3.0},
-		{"SpectralCentroid", profile.SpectralCentroid, 1500},
-		{"SpectralSpread", profile.SpectralSpread, 400},
-		{"SpectralSkewness", profile.SpectralSkewness, 1.0},
-		{"SpectralKurtosis", profile.SpectralKurtosis, 3.0},
-		{"SpectralEntropy", profile.SpectralEntropy, 0.5},
-		{"SpectralFlatness", profile.SpectralFlatness, 0.4},
-		{"SpectralCrest", profile.SpectralCrest, 8.0},
-		{"SpectralFlux", profile.SpectralFlux, 0.04},
-		{"SpectralSlope", profile.SpectralSlope, -0.3},
-		{"SpectralDecrease", profile.SpectralDecrease, 0.12},
-		{"SpectralRolloff", profile.SpectralRolloff, 7000},
+		{"SpectralMean", profile.Spectral.Mean, 2.0},
+		{"SpectralVariance", profile.Spectral.Variance, 3.0},
+		{"SpectralCentroid", profile.Spectral.Centroid, 1500},
+		{"SpectralSpread", profile.Spectral.Spread, 400},
+		{"SpectralSkewness", profile.Spectral.Skewness, 1.0},
+		{"SpectralKurtosis", profile.Spectral.Kurtosis, 3.0},
+		{"SpectralEntropy", profile.Spectral.Entropy, 0.5},
+		{"SpectralFlatness", profile.Spectral.Flatness, 0.4},
+		{"SpectralCrest", profile.Spectral.Crest, 8.0},
+		{"SpectralFlux", profile.Spectral.Flux, 0.04},
+		{"SpectralSlope", profile.Spectral.Slope, -0.3},
+		{"SpectralDecrease", profile.Spectral.Decrease, 0.12},
+		{"SpectralRolloff", profile.Spectral.Rolloff, 7000},
 	}
 	for _, c := range checks {
 		if math.Abs(c.got-c.want) > tol {
@@ -1194,5 +1194,28 @@ func TestDetectVoiceActivity_NoProfileLeavesVoicedPercentileZero(t *testing.T) {
 	}
 	if m.Regions.VoicedLowPercentile != 0 {
 		t.Errorf("VoicedLowPercentile = %.3f, want 0 (no profile, empty voiced set)", m.Regions.VoicedLowPercentile)
+	}
+}
+
+func TestIsFlooredLevel(t *testing.T) {
+	cases := []struct {
+		name  string
+		level float64
+		want  bool
+	}{
+		{"normal value above floor", -40.0, false},
+		{"value at floor", vadLevelFloorDB, true},
+		{"value below floor", vadLevelFloorDB - 1, true},
+		{"positive infinity", math.Inf(1), true},
+		{"negative infinity", math.Inf(-1), true},
+		{"NaN", math.NaN(), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isFlooredLevel(tc.level); got != tc.want {
+				t.Errorf("isFlooredLevel(%v) = %v, want %v", tc.level, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/processor/analyser_vad_test.go
+++ b/internal/processor/analyser_vad_test.go
@@ -833,6 +833,76 @@ func TestPickLowClusterRegion(t *testing.T) {
 	}
 }
 
+// TestExtractNoiseProfileSpectralFields confirms extractNoiseProfileFromIntervals
+// averages and preserves all 13 contamination-detection spectral fields from the
+// region's interval samples. These fields have no adaptive consumer yet but are
+// the measurement spine the report exposes, so they must survive extraction
+// unchanged. The astats Entropy field tracks the spectral-entropy mean (unchanged
+// behaviour).
+func TestExtractNoiseProfileSpectralFields(t *testing.T) {
+	hop := analysisIntervalHop
+	// Two intervals with distinct spectral values; the profile must carry their
+	// arithmetic mean for each field (no rounding, no drop). Values are chosen so
+	// each per-field mean is a clean number.
+	iv := []IntervalSample{
+		{
+			Timestamp: 0, RMSLevel: -60, PeakLevel: -50,
+			Spectral: SpectralMetrics{
+				Mean: 1.0, Variance: 2.0, Centroid: 1400, Spread: 300,
+				Skewness: 0.5, Kurtosis: 2.0, Entropy: 0.4, Flatness: 0.3,
+				Crest: 6.0, Flux: 0.02, Slope: -0.4, Decrease: 0.10,
+				Rolloff: 6000, Found: true,
+			},
+		},
+		{
+			Timestamp: hop, RMSLevel: -58, PeakLevel: -48,
+			Spectral: SpectralMetrics{
+				Mean: 3.0, Variance: 4.0, Centroid: 1600, Spread: 500,
+				Skewness: 1.5, Kurtosis: 4.0, Entropy: 0.6, Flatness: 0.5,
+				Crest: 10.0, Flux: 0.06, Slope: -0.2, Decrease: 0.14,
+				Rolloff: 8000, Found: true,
+			},
+		},
+	}
+	region := &RoomToneRegion{Start: 0, Duration: 2 * hop}
+
+	profile := extractNoiseProfileFromIntervals(region, iv)
+	if profile == nil {
+		t.Fatal("extractNoiseProfileFromIntervals returned nil")
+	}
+
+	const tol = 0.001
+	// astats Entropy field carries the spectral-entropy mean (unchanged behaviour).
+	if math.Abs(profile.Entropy-0.5) > tol {
+		t.Errorf("Entropy = %.4f, want mean 0.5", profile.Entropy)
+	}
+
+	checks := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"SpectralMean", profile.SpectralMean, 2.0},
+		{"SpectralVariance", profile.SpectralVariance, 3.0},
+		{"SpectralCentroid", profile.SpectralCentroid, 1500},
+		{"SpectralSpread", profile.SpectralSpread, 400},
+		{"SpectralSkewness", profile.SpectralSkewness, 1.0},
+		{"SpectralKurtosis", profile.SpectralKurtosis, 3.0},
+		{"SpectralEntropy", profile.SpectralEntropy, 0.5},
+		{"SpectralFlatness", profile.SpectralFlatness, 0.4},
+		{"SpectralCrest", profile.SpectralCrest, 8.0},
+		{"SpectralFlux", profile.SpectralFlux, 0.04},
+		{"SpectralSlope", profile.SpectralSlope, -0.3},
+		{"SpectralDecrease", profile.SpectralDecrease, 0.12},
+		{"SpectralRolloff", profile.SpectralRolloff, 7000},
+	}
+	for _, c := range checks {
+		if math.Abs(c.got-c.want) > tol {
+			t.Errorf("%s = %.4f, want mean %.4f", c.name, c.got, c.want)
+		}
+	}
+}
+
 func TestDeriveGateStatistics(t *testing.T) {
 	const split = -30.0
 

--- a/internal/processor/encoder.go
+++ b/internal/processor/encoder.go
@@ -29,35 +29,50 @@ func createOutputEncoder(outputPath string, bufferSinkCtx *ffmpeg.AVFilterContex
 		return nil, fmt.Errorf("failed to allocate output context: %w", err)
 	}
 
+	// Rollback: on any error path success stays false, so the defer frees every
+	// resource acquired so far in the reverse order of acquisition - AVIOClose
+	// (pb), then AVCodecFreeContext (encCtx), then AVFormatFreeContext (fmtCtx).
+	// Each free is nil-guarded so an unallocated resource is skipped. The success
+	// return sets success = true, handing ownership to the returned *Encoder.
+	var encCtx *ffmpeg.AVCodecContext
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		if fmtCtx != nil && fmtCtx.Pb() != nil {
+			ffmpeg.AVIOClose(fmtCtx.Pb())
+		}
+		if encCtx != nil {
+			ffmpeg.AVCodecFreeContext(&encCtx)
+		}
+		if fmtCtx != nil {
+			ffmpeg.AVFormatFreeContext(fmtCtx)
+		}
+	}()
+
 	codec := ffmpeg.AVCodecFindEncoder(ffmpeg.AVCodecIdFlac)
 	if codec == nil {
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("FLAC encoder not found for output: %s", outputPath)
 	}
 
 	stream := ffmpeg.AVFormatNewStream(fmtCtx, nil)
 	if stream == nil {
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to create stream for output: %s", outputPath)
 	}
 
-	encCtx := ffmpeg.AVCodecAllocContext3(codec)
+	encCtx = ffmpeg.AVCodecAllocContext3(codec)
 	if encCtx == nil {
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to allocate encoder context for output: %s", outputPath)
 	}
 
 	// Get audio parameters from filter output (we only need sample rate, format is set to S16 via aformat filter)
 	if _, err := ffmpeg.AVBuffersinkGetFormat(bufferSinkCtx); err != nil { // Verify filter output is configured
-		ffmpeg.AVCodecFreeContext(&encCtx)
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to get sample format: %w", err)
 	}
 
 	sampleRate, err := ffmpeg.AVBuffersinkGetSampleRate(bufferSinkCtx)
 	if err != nil {
-		ffmpeg.AVCodecFreeContext(&encCtx)
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to get sample rate: %w", err)
 	}
 
@@ -69,8 +84,6 @@ func createOutputEncoder(outputPath string, bufferSinkCtx *ffmpeg.AVFilterContex
 
 	channels, err := ffmpeg.AVBuffersinkGetChannels(bufferSinkCtx)
 	if err != nil {
-		ffmpeg.AVCodecFreeContext(&encCtx)
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to get channels: %w", err)
 	}
 
@@ -79,8 +92,6 @@ func createOutputEncoder(outputPath string, bufferSinkCtx *ffmpeg.AVFilterContex
 	// Set compression level for FLAC
 	if codec.Id() == ffmpeg.AVCodecIdFlac {
 		if _, err := ffmpeg.AVOptSetInt(encCtx.RawPtr(), ffmpeg.GlobalCStr("compression_level"), 5, 0); err != nil {
-			ffmpeg.AVCodecFreeContext(&encCtx)
-			ffmpeg.AVFormatFreeContext(fmtCtx)
 			return nil, fmt.Errorf("failed to set FLAC compression level: %w", err)
 		}
 		// FLAC encoder requires fixed frame size - must match asetnsamples filter (4096)
@@ -95,14 +106,10 @@ func createOutputEncoder(outputPath string, bufferSinkCtx *ffmpeg.AVFilterContex
 	encCtx.SetTimeBase(timeBase)
 
 	if _, err := ffmpeg.AVCodecOpen2(encCtx, codec, nil); err != nil {
-		ffmpeg.AVCodecFreeContext(&encCtx)
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to open encoder: %w", err)
 	}
 
 	if _, err := ffmpeg.AVCodecParametersFromContext(stream.Codecpar(), encCtx); err != nil {
-		ffmpeg.AVCodecFreeContext(&encCtx)
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to copy encoder parameters: %w", err)
 	}
 
@@ -111,32 +118,21 @@ func createOutputEncoder(outputPath string, bufferSinkCtx *ffmpeg.AVFilterContex
 	if fmtCtx.Oformat().Flags()&ffmpeg.AVFmtNofile == 0 {
 		var pb *ffmpeg.AVIOContext
 		if _, err := ffmpeg.AVIOOpen(&pb, outputPathC, ffmpeg.AVIOFlagWrite); err != nil {
-			ffmpeg.AVCodecFreeContext(&encCtx)
-			ffmpeg.AVFormatFreeContext(fmtCtx)
 			return nil, fmt.Errorf("failed to open output file: %w", err)
 		}
 		fmtCtx.SetPb(pb)
 	}
 
 	if _, err := ffmpeg.AVFormatWriteHeader(fmtCtx, nil); err != nil {
-		if fmtCtx.Pb() != nil {
-			ffmpeg.AVIOClose(fmtCtx.Pb())
-		}
-		ffmpeg.AVCodecFreeContext(&encCtx)
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to write header: %w", err)
 	}
 
 	packet := ffmpeg.AVPacketAlloc()
 	if packet == nil {
-		if fmtCtx.Pb() != nil {
-			ffmpeg.AVIOClose(fmtCtx.Pb())
-		}
-		ffmpeg.AVCodecFreeContext(&encCtx)
-		ffmpeg.AVFormatFreeContext(fmtCtx)
 		return nil, fmt.Errorf("failed to allocate packet for output: %s", outputPath)
 	}
 
+	success = true
 	return &Encoder{
 		fmtCtx: fmtCtx,
 		encCtx: encCtx,

--- a/internal/processor/encoder.go
+++ b/internal/processor/encoder.go
@@ -198,7 +198,6 @@ func (e *Encoder) receivePackets() error {
 // Close closes the encoder and output file
 // Safe to call multiple times - subsequent calls are no-ops.
 func (e *Encoder) Close() error {
-	// Guard against double-close
 	if e.fmtCtx == nil {
 		return nil
 	}
@@ -220,7 +219,7 @@ func (e *Encoder) Close() error {
 	}
 
 	ffmpeg.AVFormatFreeContext(e.fmtCtx)
-	e.fmtCtx = nil // Mark as closed
+	e.fmtCtx = nil // nil fmtCtx marks the encoder closed, so a second Close is a no-op
 
 	return nil
 }
@@ -230,8 +229,8 @@ func (e *Encoder) Close() error {
 // package must not import internal/ui, so the value is mirrored here.
 const meterLevelFloorDB = -70.0
 
-// calculateFrameLevel calculates the RMS (Root Mean Square) level of an audio frame in dB
-// This provides accurate audio level measurement for VU meter display
+// calculateFrameLevel returns the RMS (Root Mean Square) level of an audio frame
+// in dB, clamped to the VU-meter display range [meterLevelFloorDB, 0].
 func calculateFrameLevel(frame *ffmpeg.AVFrame) float64 {
 	sumSquares, sampleCount, _, ok := frameSumSquaresAndPeak(frame)
 	if !ok {
@@ -241,13 +240,11 @@ func calculateFrameLevel(frame *ffmpeg.AVFrame) float64 {
 		return meterLevelFloorDB // Silence threshold
 	}
 
-	// Calculate RMS (Root Mean Square)
 	rms := math.Sqrt(sumSquares / float64(sampleCount))
 
-	// Convert to dB: 20 * log10(rms)
-	// Add small epsilon to avoid log(0)
+	// Floor near-silence before the log so 20*log10(rms) never sees rms<=0.
 	if rms < 0.00001 { // Equivalent to -100 dB
-		return meterLevelFloorDB // Floor for silence
+		return meterLevelFloorDB
 	}
 
 	levelDB := 20.0 * math.Log10(rms)

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -175,7 +175,7 @@ func runFullbenchFilterSpecCore(tb testing.TB, inputPath, outputPath, filterSpec
 		DurationSecs: metadata.Duration,
 	}
 
-	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.GetDecoderContext(), filterSpec)
+	filterGraph, bufferSrcCtx, bufferSinkCtx, err := setupFilterGraph(reader.DecoderContext(), filterSpec)
 	if err != nil {
 		tb.Fatalf("failed to create fullbench filter graph: %v", err)
 	}

--- a/internal/processor/filter_ablation_benchmark_test.go
+++ b/internal/processor/filter_ablation_benchmark_test.go
@@ -403,7 +403,7 @@ func buildFullbenchPass4ResampleFilter(config *EffectiveFilterConfig) string {
 func buildFullbenchProductionPass4SpecWithoutAdeclick(config *EffectiveFilterConfig, measurement *LoudnormMeasurement) string {
 	pass4Config := *config
 	pass4Config.Adeclick.Enabled = false
-	return buildLoudnormFilterSpec(&pass4Config, measurement, measurement.TargetOffset, 0, 0, false, 48000, "")
+	return buildLoudnormFilterSpec(&pass4Config, measurement, measurement.TargetOffset, limiterPlan{}, 48000, "")
 }
 
 func extractFullbenchFilterClause(spec, prefix string) string {
@@ -559,7 +559,7 @@ func TestFullbenchLoudnormClauseMatchesProduction(t *testing.T) {
 	productionConfig := *config
 	productionConfig.Adeclick.Enabled = false
 	productionClause := extractFullbenchFilterClause(
-		buildLoudnormFilterSpec(&productionConfig, measurement, measurement.TargetOffset, 0, 0, false, 48000, ""),
+		buildLoudnormFilterSpec(&productionConfig, measurement, measurement.TargetOffset, limiterPlan{}, 48000, ""),
 		"loudnorm=",
 	)
 	benchmarkClause := buildFullbenchLoudnormClause(config, measurement)

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -81,13 +81,17 @@ const (
 	NormToleranceLU = 0.5
 )
 
-// NoiseReduction production defaults.
+// NoiseReduction production defaults (anlmdn parameters; matrix spike defaults at
+// .bench/anlmdn-matrix-spike):
+//   - s: strength (0.00001 = minimum, kept constant)
+//   - p: patch size in seconds (6ms = 0.006s, context window for similarity)
+//   - r: research radius in seconds (2.0ms = 0.0020s, r_min)
+//   - m: smoothing factor (3 = m_strict)
 //
-// The matrix spike at .bench/anlmdn-matrix-spike validated `r_min` (r=0.0020)
-// at native source rate against the previous 32 kHz cap path with r=0.0045,
-// confirming a ~35 % Pass 2 speedup at metric-equivalent quality. `m_strict`
-// (m=3) was a free quality lever - matched cleanup at zero speed cost on both
-// fixtures.
+// The matrix spike validated `r_min` (r=0.0020) at native source rate against the
+// previous 32 kHz cap path with r=0.0045, confirming a ~35 % Pass 2 speedup at
+// metric-equivalent quality. `m_strict` (m=3) was a free quality lever - matched
+// cleanup at zero speed cost on both fixtures.
 const (
 	noiseReductionProductionStrength    = 0.00001
 	noiseReductionProductionPatchSec    = 0.0060
@@ -177,18 +181,18 @@ type NoiseReductionConfig struct {
 	// must be capped at ~12 to avoid warble.
 	AfftdnEnabled        bool    `json:"afftdn_enabled"`
 	AfftdnNoiseReduction float64 `json:"afftdn_noise_reduction_db"`
-	AfftdnNoiseType      string  `json:"afftdn_noise_type"`
-	AfftdnTrackNoise     bool    `json:"afftdn_track_noise"`
+	// AfftdnNoiseType selects afftdn's noise model: "w" (white, the default) or
+	// "custom" (a measured spectral shape). On the custom path AfftdnBandNoise
+	// carries the per-band relative shape; nf still carries the absolute level and
+	// nr the depth, so all three stack.
+	AfftdnNoiseType  string `json:"afftdn_noise_type"`
+	AfftdnTrackNoise bool   `json:"afftdn_track_noise"`
 	// AfftdnNoiseFloor is the static measured noise floor (dB) fed to afftdn's nf
 	// parameter. The zero value means unset, so nf= is omitted and afftdn uses its
 	// own default; a real floor is always negative. tuneNoiseReduction sets it from
 	// the measured Noise.Floor (clamped to afftdn's [-80, -20] range) and turns
 	// track_noise off so afftdn holds the static measured floor.
 	AfftdnNoiseFloor float64 `json:"afftdn_noise_floor_db"`
-	// AfftdnNoiseType selects afftdn's noise model: "w" (white, the default) or
-	// "custom" (a measured spectral shape). On the custom path AfftdnBandNoise
-	// carries the per-band relative shape; nf still carries the absolute level and
-	// nr the depth, so all three stack.
 	// AfftdnBandNoise is the afftdn custom-profile band shape: up to 15 dB values,
 	// "|"-separated, one per fixed band, relative to the band mean (white = all
 	// zeros). Emitted as bn= only when AfftdnNoiseType is "custom" and the string is
@@ -781,11 +785,7 @@ func (cfg *EffectiveFilterConfig) buildBandlimitLowPassFilter() string {
 // Runs at the source sample rate; downstream filters (gate, levelling compressor,
 // de-esser, analysis) operate at the same rate.
 //
-// anlmdn parameters (matrix spike defaults at .bench/anlmdn-matrix-spike):
-// - s: strength (0.00001 = minimum, kept constant)
-// - p: patch size in seconds (6ms = 0.006s, context window for similarity)
-// - r: research radius in seconds (2.0ms = 0.0020s, r_min)
-// - m: smoothing factor (3 = m_strict)
+// anlmdn s/p/r/m values and their rationale: see the noise-reduction constant block.
 //
 // afftdn replaced the former compand residual-suppression stage. Sweeps on the
 // noisiest corpus stem showed anlmdn → afftdn matches

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -316,11 +316,6 @@ type AdaptiveDiagnostics struct {
 	AfftdnNoiseType string `json:"afftdn_noise_type"`
 }
 
-// ProcessingFilterContext holds pass execution state outside caller-owned defaults.
-type ProcessingFilterContext struct {
-	Pass PassNumber
-}
-
 // filterBuilderFunc is a function that builds a filter spec from effective config.
 // Returns the FFmpeg filter specification string, or empty string if disabled.
 type filterBuilderFunc func(*EffectiveFilterConfig) string
@@ -619,6 +614,18 @@ func (cfg *EffectiveFilterConfig) buildDownmixFilter() string {
 	return "aformat=channel_layouts=mono"
 }
 
+// Shared analysis-filter segments. Pass 2 (buildAnalysisFilter) and the Pass-4
+// chain (buildNormalisationFilters) both measure the signal with the same
+// astats and aspectralstats settings; these constants are the single source so
+// the two passes cannot drift. The ebur128 stage differs by one option (Pass 2
+// appends target=<TargetI>, Pass 4 leaves the default), so it shares only the
+// common prefix below. The metric catalogue is documented on buildAnalysisFilter.
+const (
+	astatsAnalysisSpec         = "astats=metadata=1:measure_perchannel=all"
+	aspectralstatsAnalysisSpec = "aspectralstats=win_size=2048:win_func=hann:measure=all"
+	ebur128AnalysisSpecPrefix  = "ebur128=metadata=1:peak=sample+true:dualmono=true"
+)
+
 // buildAnalysisFilter builds the audio analysis filter chain.
 // Combines astats, aspectralstats, and ebur128 for comprehensive measurement.
 // Used in both Pass 1 (input analysis) and Pass 2 (output analysis).
@@ -675,9 +682,10 @@ func (cfg *EffectiveFilterConfig) buildAnalysisFilter() string {
 	// measurement for Pass 3 is done separately via measureWithLoudnorm() which
 	// reads the file without encoding output.
 	return fmt.Sprintf(
-		"astats=metadata=1:measure_perchannel=all,"+
-			"aspectralstats=win_size=2048:win_func=hann:measure=all,"+
-			"ebur128=metadata=1:peak=sample+true:dualmono=true:target=%.0f",
+		"%s,%s,%s:target=%.0f",
+		astatsAnalysisSpec,
+		aspectralstatsAnalysisSpec,
+		ebur128AnalysisSpecPrefix,
 		cfg.Loudnorm.TargetI)
 }
 

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -299,7 +299,7 @@ type AdaptiveDiagnostics struct {
 	// SpeechGateNarrowGap is set when the voiced-anchored threshold cannot clear
 	// the loud noise (voiced p10 minus the speech margin sits below noise p95 plus
 	// the noise margin). The threshold stays on the speech side; this signal tells
-	// the depth step (Phase 4 task 4.3) to back off rather than over-gate.
+	// the depth step to back off rather than over-gate.
 	SpeechGateNarrowGap bool `json:"narrow_gap"`
 
 	// AfftdnEnabled records whether the afftdn FFT denoise tail stays in the chain.
@@ -629,8 +629,8 @@ func (cfg *EffectiveFilterConfig) buildDownmixFilter() string {
 // measure the original signal format, then ebur128 does its own internal upsampling
 // for accurate true peak detection without affecting other measurements.
 //
-// NOTE: loudnorm is NOT included here because it has no "measure only" mode -
-// it always processes/normalizes audio. Loudnorm measurement for Pass 3 is done
+// NOTE: loudnorm is NOT included here because it has no "measure only" mode.
+// It always processes/normalises audio. Loudnorm measurement for Pass 3 is done
 // separately via measureWithLoudnorm() which reads the processed file without
 // encoding output.
 func (cfg *EffectiveFilterConfig) buildAnalysisFilter() string {
@@ -671,9 +671,9 @@ func (cfg *EffectiveFilterConfig) buildAnalysisFilter() string {
 	// Note: astats measure_perchannel=all requests all available per-channel statistics
 	//
 	// IMPORTANT: loudnorm is NOT included here, even for Pass 2, because loudnorm
-	// doesn't have a "measure only" mode - it always processes/normalizes audio.
-	// Loudnorm measurement for Pass 3 is done separately via measureWithLoudnorm()
-	// which reads the file without encoding output.
+	// has no "measure only" mode. It always processes/normalises audio. Loudnorm
+	// measurement for Pass 3 is done separately via measureWithLoudnorm() which
+	// reads the file without encoding output.
 	return fmt.Sprintf(
 		"astats=metadata=1:measure_perchannel=all,"+
 			"aspectralstats=win_size=2048:win_func=hann:measure=all,"+

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -1464,6 +1464,69 @@ func TestBuildAnalysisFilter(t *testing.T) {
 	})
 }
 
+// findFilterElement returns the comma-separated element of an FFmpeg filter
+// chain whose name matches prefix (e.g. "astats="), or "" if absent.
+func findFilterElement(spec, prefix string) string {
+	for element := range strings.SplitSeq(spec, ",") {
+		if strings.HasPrefix(element, prefix) {
+			return element
+		}
+	}
+	return ""
+}
+
+// TestAnalysisSegmentSharedAcrossPasses locks the Pass-2 (buildAnalysisFilter)
+// and Pass-4 (buildLoudnormFilterSpec) analysis segments together so they cannot
+// drift. The astats and aspectralstats specs must be byte-identical; the ebur128
+// stages must share a byte-identical prefix (Pass 2 alone appends target=).
+func TestAnalysisSegmentSharedAcrossPasses(t *testing.T) {
+	pass2Config := newTestConfig()
+	pass2Config.Analysis.Enabled = true
+	pass2Config.Loudnorm.TargetI = -16.0
+	pass2Spec := pass2Config.buildAnalysisFilter()
+
+	pass4Config := defaultNormalisationTestConfig()
+	measurement := &LoudnormMeasurement{
+		InputI:       -24.0,
+		InputTP:      -5.0,
+		InputLRA:     6.0,
+		InputThresh:  -34.0,
+		TargetOffset: -0.5,
+	}
+	pass4Spec := buildLoudnormFilterSpec(pass4Config, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 48000, "")
+
+	pass2Astats := findFilterElement(pass2Spec, "astats=")
+	pass4Astats := findFilterElement(pass4Spec, "astats=")
+	if pass2Astats == "" || pass4Astats == "" {
+		t.Fatalf("astats segment missing\npass2: %q\npass4: %q", pass2Spec, pass4Spec)
+	}
+	if pass2Astats != pass4Astats {
+		t.Errorf("astats segment drift\npass2: %q\npass4: %q", pass2Astats, pass4Astats)
+	}
+
+	pass2Spectral := findFilterElement(pass2Spec, "aspectralstats=")
+	pass4Spectral := findFilterElement(pass4Spec, "aspectralstats=")
+	if pass2Spectral == "" || pass4Spectral == "" {
+		t.Fatalf("aspectralstats segment missing\npass2: %q\npass4: %q", pass2Spec, pass4Spec)
+	}
+	if pass2Spectral != pass4Spectral {
+		t.Errorf("aspectralstats segment drift\npass2: %q\npass4: %q", pass2Spectral, pass4Spectral)
+	}
+
+	pass2Ebur128 := findFilterElement(pass2Spec, "ebur128=")
+	pass4Ebur128 := findFilterElement(pass4Spec, "ebur128=")
+	if pass2Ebur128 == "" || pass4Ebur128 == "" {
+		t.Fatalf("ebur128 segment missing\npass2: %q\npass4: %q", pass2Spec, pass4Spec)
+	}
+	// Pass 4 emits the shared prefix verbatim; Pass 2 appends target=<TargetI>.
+	if pass4Ebur128 != ebur128AnalysisSpecPrefix {
+		t.Errorf("Pass-4 ebur128 = %q, want shared prefix %q", pass4Ebur128, ebur128AnalysisSpecPrefix)
+	}
+	if !strings.HasPrefix(pass2Ebur128, ebur128AnalysisSpecPrefix) {
+		t.Errorf("Pass-2 ebur128 %q does not start with shared prefix %q", pass2Ebur128, ebur128AnalysisSpecPrefix)
+	}
+}
+
 func TestBuildResampleFilter(t *testing.T) {
 	t.Run("enabled returns aformat+asetnsamples with default params", func(t *testing.T) {
 		config := newTestConfig()

--- a/internal/processor/frame_processor_integration_test.go
+++ b/internal/processor/frame_processor_integration_test.go
@@ -59,7 +59,7 @@ func openTestFilterGraph(t *testing.T) (
 		t.Fatalf("failed to open test audio %s: %v", inputPath, err)
 	}
 
-	graph, srcCtx, sinkCtx, err := setupFilterGraph(r.GetDecoderContext(), "anull")
+	graph, srcCtx, sinkCtx, err := setupFilterGraph(r.DecoderContext(), "anull")
 	if err != nil {
 		r.Close()
 		t.Fatalf("failed to create filter graph: %v", err)

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -1151,6 +1151,22 @@ func finalizeLoudnormOutputMeasurements(
 	return finalMeasurements, regionMeasurementTime
 }
 
+// loudnormTPTargets resolves the two Pass-4 true-peak targets from a file's
+// loudnorm measurement: the TP= value loudnorm emits for itself and the
+// sample-peak ceiling the downstream brickwall enforces.
+//
+// emittedTP is the per-file internal TP (loudnormInternalTargetTP) clamped to
+// FFmpeg's accepted [-9, 0] range. brickwallCeilingDBTP is loudnorm.TargetTP less
+// the inter-sample allowance (brickwallTruePeakHeadroomDB) so realised oversampled
+// true peak lands ≤ loudnorm.TargetTP. The two are distinct by design: loudnorm
+// targets its own internal TP while the brickwall owns delivered ceiling.
+func loudnormTPTargets(loudnorm LoudnormConfig, measurement *LoudnormMeasurement) (emittedTP, brickwallCeilingDBTP float64) {
+	internalTP := loudnormInternalTargetTP(loudnorm, measurement.InputTP, measurement.InputI)
+	emittedTP = max(loudnormTPMinDB, min(internalTP, loudnormTPMaxDB))
+	brickwallCeilingDBTP = loudnorm.TargetTP - brickwallTruePeakHeadroomDB
+	return emittedTP, brickwallCeilingDBTP
+}
+
 // buildLoudnormFilterSpec constructs the filter chain for Pass 4 loudnorm application.
 //
 // Chain order: [volume+alimiter] → loudnorm → aresample → [adeclick] → brickwall → astats → aspectralstats → ebur128 → resample
@@ -1176,22 +1192,6 @@ func finalizeLoudnormOutputMeasurements(
 // makes the gain cap binding: when the cap lowers effectiveTargetI on a high-crest
 // stem, the matching offset pins the realised scalar gain to the capped I=, holding
 // the final true peak at targetTP. On a safe stem it equals the planned makeup.
-// loudnormTPTargets resolves the two Pass-4 true-peak targets from a file's
-// loudnorm measurement: the TP= value loudnorm emits for itself and the
-// sample-peak ceiling the downstream brickwall enforces.
-//
-// emittedTP is the per-file internal TP (loudnormInternalTargetTP) clamped to
-// FFmpeg's accepted [-9, 0] range. brickwallCeilingDBTP is loudnorm.TargetTP less
-// the inter-sample allowance (brickwallTruePeakHeadroomDB) so realised oversampled
-// true peak lands ≤ loudnorm.TargetTP. The two are distinct by design: loudnorm
-// targets its own internal TP while the brickwall owns delivered ceiling.
-func loudnormTPTargets(loudnorm LoudnormConfig, measurement *LoudnormMeasurement) (emittedTP, brickwallCeilingDBTP float64) {
-	internalTP := loudnormInternalTargetTP(loudnorm, measurement.InputTP, measurement.InputI)
-	emittedTP = max(loudnormTPMinDB, min(internalTP, loudnormTPMaxDB))
-	brickwallCeilingDBTP = loudnorm.TargetTP - brickwallTruePeakHeadroomDB
-	return emittedTP, brickwallCeilingDBTP
-}
-
 func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, offset float64, preGainDB float64, ceiling float64, needsLimiting bool, sourceSampleRate int, statsPath string) string {
 	var filters []string
 	loudnorm := config.Loudnorm

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -555,7 +555,7 @@ func loudnormInternalTargetTP(loudnorm LoudnormConfig, measuredTP, measuredI flo
 }
 
 // calculateLinearModeTarget calculates the target I and offset that ensure loudnorm
-// stays in linear mode (never falls back to dynamic normalization).
+// stays in linear mode (never falls back to dynamic normalisation).
 //
 // For linear mode, loudnorm requires: measured_TP + (target_I - measured_I) <= target_TP
 // Rearranging: target_I <= target_TP - measured_TP + measured_I
@@ -621,7 +621,7 @@ type NormalisationResult struct {
 	InputTP           float64        `json:"input_dbtp"`            // Pre-normalisation true peak (from Pass 2 loudnorm measurement)
 	OutputLUFS        float64        `json:"output_lufs"`           // Post-normalisation loudness (measured)
 	OutputTP          float64        `json:"output_dbtp"`           // Post-normalisation true peak (measured)
-	GainApplied       float64        `json:"gain_applied_db"`       // Gain adjustment applied (dB) - loudnorm's target_offset
+	GainApplied       float64        `json:"gain_applied_db"`       // Gain adjustment applied (dB): the capped linear makeup (effectiveTargetI - measured_I)
 	WithinTarget      bool           `json:"within_target"`         // True if final output is within tolerance of target
 	Skipped           bool           `json:"skipped"`               // True if normalisation was skipped (already within tolerance)
 	LoudnormStats     *LoudnormStats `json:"loudnorm_measured"`     // Diagnostic output from loudnorm second pass (nil if capture failed)
@@ -657,20 +657,21 @@ func loudnormFellBackToDynamic(stats *LoudnormStats, inputPath string, log debug
 	return true
 }
 
-// ApplyNormalisation performs Pass 3: EBU R128 dynamic loudness normalisation.
-// Uses FFmpeg's loudnorm filter in two-pass mode.
+// ApplyNormalisation performs Pass 3/4: EBU R128 loudness normalisation via
+// FFmpeg's loudnorm filter in two-pass mode, driven into linear mode.
 //
 // Workflow:
-// 1. Pass 3a: Run loudnorm measurement pass on Pass 2 output (measureWithLoudnorm)
-// 2. Pass 3b: Apply loudnorm with linear=true using those measurements
+// 1. Pass 3: Run loudnorm measurement pass on Pass 2 output (measureWithLoudnorm)
+// 2. Pass 4: Apply loudnorm with linear=true using those measurements
 //
-// This uses loudnorm's own target_offset from the measurement pass, not one we
-// calculate ourselves from ebur128 measurements (per ffmpeg-loudnorm-helper).
+// The applied offset is the capped linear makeup we derive (effectiveTargetI -
+// measured_I), not loudnorm's own first-pass target_offset, so the gain cap binds
+// on high-crest stems.
 //
-// Unlike simple linear gain, loudnorm:
-// - Applies adaptive gain (more to quiet sections, less to loud sections)
-// - Includes 100ms lookahead true peak limiter (upsamples to 192kHz internally)
-// - Prevents noise floor from being elevated into audibility
+// In linear mode loudnorm:
+// - Applies one consistent scalar gain (no adaptive per-section EQ)
+// - Includes a 100ms lookahead true peak limiter (upsamples to 192kHz internally)
+// - Keeps the noise floor from being elevated into audibility
 // - Preserves natural dynamics while hitting target loudness
 //
 // Parameters:

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -301,7 +301,7 @@ func measureWithLoudnorm(ctx context.Context, inputPath string, config *Effectiv
 
 	// Create filter graph
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := deps.setupFilterGraph(
-		reader.GetDecoderContext(),
+		reader.DecoderContext(),
 		filterSpec,
 	)
 	if err != nil {
@@ -1026,7 +1026,7 @@ func prepareLoudnormApplication(ctx context.Context, request loudnormApplication
 		statsPath,
 	)
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := deps.setupFilterGraph(
-		reader.GetDecoderContext(),
+		reader.DecoderContext(),
 		filterSpec,
 	)
 	if err != nil {

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -106,6 +106,68 @@ type LoudnormStats struct {
 	TargetOffset      string `json:"target_offset"`
 }
 
+// LoudnormValue is one loudnorm measurement parsed to a typed float, with OK
+// false when the source string failed to parse. The report formats Value when OK
+// and emits the placeholder otherwise, so a missing or unparseable measurement
+// never fabricates a number.
+type LoudnormValue struct {
+	Value float64
+	OK    bool
+}
+
+// LoudnormMeasured holds the loudnorm stats parsed once to typed floats, plus the
+// precomputed target deviation (OutputI - EffectiveTargetI). The report consumes
+// these typed values and formats them like every other section; it no longer
+// re-parses LoudnormStats strings. This is a report-facing convenience built at
+// record assembly; it is NOT serialised (the JSON record keeps the FFmpeg
+// string-keyed LoudnormStats as its parse target, see normalisationRecord).
+type LoudnormMeasured struct {
+	InputI          LoudnormValue
+	InputTP         LoudnormValue
+	InputLRA        LoudnormValue
+	InputThresh     LoudnormValue
+	OutputI         LoudnormValue
+	OutputTP        LoudnormValue
+	OutputLRA       LoudnormValue
+	OutputThresh    LoudnormValue
+	TargetDeviation LoudnormValue
+}
+
+// parseLoudnormValue parses one loudnorm stats string to a typed float, trimming
+// surrounding whitespace first. OK is false on a parse failure, matching the
+// renderer's former graceful behaviour (placeholder, never a fabricated value).
+func parseLoudnormValue(value string) LoudnormValue {
+	f, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return LoudnormValue{}
+	}
+	return LoudnormValue{Value: f, OK: true}
+}
+
+// parseLoudnormMeasured parses the loudnorm stats to typed floats once and
+// precomputes the target deviation (OutputI - effectiveTargetI). Returns nil for
+// nil stats so the report omits the loudnorm rows. The deviation OK follows the
+// OutputI parse, mirroring the renderer's former targetDeviationCell guard.
+func parseLoudnormMeasured(stats *LoudnormStats, effectiveTargetI float64) *LoudnormMeasured {
+	if stats == nil {
+		return nil
+	}
+	m := &LoudnormMeasured{
+		InputI:       parseLoudnormValue(stats.InputI),
+		InputTP:      parseLoudnormValue(stats.InputTP),
+		InputLRA:     parseLoudnormValue(stats.InputLRA),
+		InputThresh:  parseLoudnormValue(stats.InputThresh),
+		OutputI:      parseLoudnormValue(stats.OutputI),
+		OutputTP:     parseLoudnormValue(stats.OutputTP),
+		OutputLRA:    parseLoudnormValue(stats.OutputLRA),
+		OutputThresh: parseLoudnormValue(stats.OutputThresh),
+	}
+	if m.OutputI.OK {
+		m.TargetDeviation = LoudnormValue{Value: m.OutputI.Value - effectiveTargetI, OK: true}
+	}
+	return m
+}
+
 // parseLoudnormStatsFile reads loudnorm's JSON stats from a file and parses it
 // into LoudnormStats. A missing or empty file, or one without a JSON object,
 // returns an error in the same failure class as the av_log "no JSON found" path.
@@ -617,18 +679,23 @@ type LimiterDiagnostics struct {
 
 // NormalisationResult contains the outcome of the normalisation pass.
 type NormalisationResult struct {
-	InputLUFS         float64        `json:"input_lufs"`            // Pre-normalisation loudness (from Pass 2 loudnorm measurement)
-	InputTP           float64        `json:"input_dbtp"`            // Pre-normalisation true peak (from Pass 2 loudnorm measurement)
-	OutputLUFS        float64        `json:"output_lufs"`           // Post-normalisation loudness (measured)
-	OutputTP          float64        `json:"output_dbtp"`           // Post-normalisation true peak (measured)
-	GainApplied       float64        `json:"gain_applied_db"`       // Gain adjustment applied (dB): the capped linear makeup (effectiveTargetI - measured_I)
-	WithinTarget      bool           `json:"within_target"`         // True if final output is within tolerance of target
-	Skipped           bool           `json:"skipped"`               // True if normalisation was skipped (already within tolerance)
-	LoudnormStats     *LoudnormStats `json:"loudnorm_measured"`     // Diagnostic output from loudnorm second pass (nil if capture failed)
-	RequestedTargetI  float64        `json:"requested_target_lufs"` // The target I that was requested (from config)
-	EffectiveTargetI  float64        `json:"effective_target_lufs"` // The target I actually used (may be lower to ensure linear mode)
-	LinearModeForced  bool           `json:"linear_mode_forced"`    // True if target was adjusted to force linear mode
-	ActualNormDynamic bool           `json:"actual_norm_dynamic"`   // True if loudnorm's reported normalization_type was "dynamic" (detective)
+	InputLUFS     float64        `json:"input_lufs"`        // Pre-normalisation loudness (from Pass 2 loudnorm measurement)
+	InputTP       float64        `json:"input_dbtp"`        // Pre-normalisation true peak (from Pass 2 loudnorm measurement)
+	OutputLUFS    float64        `json:"output_lufs"`       // Post-normalisation loudness (measured)
+	OutputTP      float64        `json:"output_dbtp"`       // Post-normalisation true peak (measured)
+	GainApplied   float64        `json:"gain_applied_db"`   // Gain adjustment applied (dB): the capped linear makeup (effectiveTargetI - measured_I)
+	WithinTarget  bool           `json:"within_target"`     // True if final output is within tolerance of target
+	Skipped       bool           `json:"skipped"`           // True if normalisation was skipped (already within tolerance)
+	LoudnormStats *LoudnormStats `json:"loudnorm_measured"` // Diagnostic output from loudnorm second pass (nil if capture failed)
+	// LoudnormParsed holds the loudnorm stats parsed once to typed floats plus the
+	// precomputed target deviation, built at result assembly for the report. It is
+	// NOT serialised (json:"-"): the JSON record keeps the string-keyed
+	// LoudnormStats above as its parse target, so the schema is unchanged.
+	LoudnormParsed    *LoudnormMeasured `json:"-"`
+	RequestedTargetI  float64           `json:"requested_target_lufs"` // The target I that was requested (from config)
+	EffectiveTargetI  float64           `json:"effective_target_lufs"` // The target I actually used (may be lower to ensure linear mode)
+	LinearModeForced  bool              `json:"linear_mode_forced"`    // True if target was adjusted to force linear mode
+	ActualNormDynamic bool              `json:"actual_norm_dynamic"`   // True if loudnorm's reported normalization_type was "dynamic" (detective)
 
 	// Limiter diagnostics (Pass 4 pre-limiting). The six limiter values live in
 	// the embedded LimiterDiagnostics (flattened into this JSON object); the Pass 3
@@ -754,6 +821,7 @@ func buildNormalisationResult(
 		WithinTarget:          withinTarget,
 		Skipped:               false,
 		LoudnormStats:         application.loudnormStats,
+		LoudnormParsed:        parseLoudnormMeasured(application.loudnormStats, effectiveTargetI),
 		RequestedTargetI:      requestedTargetI,
 		EffectiveTargetI:      effectiveTargetI,
 		LinearModeForced:      !linearPossible,
@@ -953,9 +1021,7 @@ func prepareLoudnormApplication(ctx context.Context, request loudnormApplication
 		request.config,
 		request.measurement,
 		request.offset,
-		request.limiter.preGainDB,
-		request.limiter.ceilingDB,
-		request.limiter.needed,
+		request.limiter,
 		metadata.SampleRate,
 		statsPath,
 	)
@@ -991,14 +1057,26 @@ func executeAndPublishLoudnormApplication(
 ) (*loudnormApplicationExecutionResult, error) {
 	result := &loudnormApplicationExecutionResult{}
 
+	// failPublish captures the in-graph loudnorm stats and removes the temp file on
+	// any publish-failure path, returning result + the wrapped error. encoderClosed
+	// is set by the caller first when the encoder is already closed, so failPublish
+	// closes it only when still open.
+	encoderClosed := false
+	failPublish := func(encoder loudnormOutputEncoder, err error) (*loudnormApplicationExecutionResult, error) {
+		result.loudnormStats = captureGraphStats()
+		if encoder != nil && !encoderClosed {
+			encoderClosed = true
+			_ = encoder.Close()
+		}
+		removeTemp()
+		return result, err
+	}
+
 	// Create output encoder (same format as input)
 	encoder, err := deps.createEncoder(prep.tempPath, prep.bufferSinkCtx)
 	if err != nil {
-		result.loudnormStats = captureGraphStats()
-		removeTemp()
-		return result, fmt.Errorf("failed to create encoder: %w", err)
+		return failPublish(nil, fmt.Errorf("failed to create encoder: %w", err))
 	}
-	encoderClosed := false
 	defer func() {
 		if !encoderClosed {
 			_ = encoder.Close()
@@ -1008,35 +1086,23 @@ func executeAndPublishLoudnormApplication(
 	loopErr := deps.runFilterGraph(ctx, prep.reader, prep.bufferSrcCtx, prep.bufferSinkCtx,
 		newLoudnormApplicationFrameLoop(prep, request.progress, encoder, &result.acc))
 	if loopErr != nil {
-		result.loudnormStats = captureGraphStats()
-		encoderClosed = true
-		_ = encoder.Close()
-		removeTemp()
-		return result, loopErr
+		return failPublish(encoder, loopErr)
 	}
 
 	// Flush encoder
 	if err := encoder.Flush(); err != nil {
-		result.loudnormStats = captureGraphStats()
-		encoderClosed = true
-		_ = encoder.Close()
-		removeTemp()
-		return result, fmt.Errorf("failed to flush encoder: %w", err)
+		return failPublish(encoder, fmt.Errorf("failed to flush encoder: %w", err))
 	}
 
 	// Close encoder before rename
 	encoderClosed = true
 	if err := encoder.Close(); err != nil {
-		result.loudnormStats = captureGraphStats()
-		removeTemp()
-		return result, fmt.Errorf("failed to close encoder: %w", err)
+		return failPublish(nil, fmt.Errorf("failed to close encoder: %w", err))
 	}
 
 	// Atomic rename: temp file → original file (in-place update)
 	if err := deps.rename(prep.tempPath, request.inputPath); err != nil {
-		result.loudnormStats = captureGraphStats()
-		removeTemp()
-		return result, fmt.Errorf("failed to rename output: %w", err)
+		return failPublish(nil, fmt.Errorf("failed to rename output: %w", err))
 	}
 
 	return result, nil
@@ -1172,10 +1238,11 @@ func loudnormTPTargets(loudnorm LoudnormConfig, measurement *LoudnormMeasurement
 //
 // Chain order: [volume+alimiter] → loudnorm → aresample → [adeclick] → brickwall → astats → aspectralstats → ebur128 → resample
 //
-// The caller pre-computes preGainDB, ceiling, and needsLimiting from Pass 2 measurements.
-// This function builds the prefix via buildPreLimiterPrefix() and passes measurement.InputI
-// and measurement.InputTP directly to loudnorm as measured_I and measured_TP - no manual
-// adjustment is needed because Pass 3 already measured through the same prefix chain.
+// The caller pre-computes the limiterPlan (preGainDB, ceiling, needed) from Pass 2
+// measurements. This function builds the prefix via buildPreLimiterPrefix() and passes
+// measurement.InputI and measurement.InputTP directly to loudnorm as measured_I and
+// measured_TP - no manual adjustment is needed because Pass 3 already measured through
+// the same prefix chain.
 //
 // The loudnorm filter in second pass mode:
 // - Uses measurements from measureWithLoudnorm() (LoudnormMeasurement)
@@ -1193,13 +1260,13 @@ func loudnormTPTargets(loudnorm LoudnormConfig, measurement *LoudnormMeasurement
 // makes the gain cap binding: when the cap lowers effectiveTargetI on a high-crest
 // stem, the matching offset pins the realised scalar gain to the capped I=, holding
 // the final true peak at targetTP. On a safe stem it equals the planned makeup.
-func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, offset float64, preGainDB float64, ceiling float64, needsLimiting bool, sourceSampleRate int, statsPath string) string {
+func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *LoudnormMeasurement, offset float64, limiter limiterPlan, sourceSampleRate int, statsPath string) string {
 	var filters []string
 	loudnorm := config.Loudnorm
 	emittedTP, brickwallCeilingDBTP := loudnormTPTargets(loudnorm, measurement)
 
 	// 1. Build pre-limiter prefix (volume + alimiter) from pre-computed values
-	prefix := buildPreLimiterPrefix(preGainDB, ceiling, needsLimiting)
+	prefix := buildPreLimiterPrefix(limiter.preGainDB, limiter.ceilingDB, limiter.needed)
 	if prefix != "" {
 		filters = append(filters, prefix)
 	}
@@ -1280,21 +1347,15 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 	// oversampled true peak lands ≤ loudnorm.TargetTP.
 	filters = append(filters, buildBrickwallLimiter(brickwallCeilingDBTP))
 
-	// 5. astats for amplitude measurements (same as Pass 2)
-	// Provides noise floor, dynamic range, RMS level, peak level, etc.
-	// measure_perchannel=all requests all available per-channel statistics
-	filters = append(filters, "astats=metadata=1:measure_perchannel=all")
-
-	// 6. aspectralstats for spectral analysis (same as Pass 2)
-	// Provides centroid, spread, skewness, kurtosis, entropy, flatness, crest, rolloff, etc.
-	// win_size=2048 and win_func=hann match Pass 2 settings for comparable measurements
-	filters = append(filters, "aspectralstats=win_size=2048:win_func=hann:measure=all")
-
-	// 7. ebur128 for loudness validation (metadata only, no audio modification)
-	// dualmono=true ensures accurate mono loudness measurement
-	// Note: ebur128 forces its output format to f64/double (always); its 192kHz
-	// true-peak oversampling is internal-only and the output rate equals the input rate
-	filters = append(filters, "ebur128=metadata=1:peak=sample+true:dualmono=true")
+	// 5-7. astats, aspectralstats, ebur128 for amplitude, spectral, and loudness
+	// measurement. The astats and aspectralstats specs are shared with Pass 2
+	// (filters.go constants) so the two passes cannot drift; the metric catalogue
+	// is documented on buildAnalysisFilter. Pass 4 omits ebur128's target= option
+	// (the brickwall already owns delivered loudness), so it uses the shared prefix
+	// without the target suffix Pass 2 appends.
+	filters = append(filters, astatsAnalysisSpec)
+	filters = append(filters, aspectralstatsAnalysisSpec)
+	filters = append(filters, ebur128AnalysisSpecPrefix)
 
 	// 8. Resample back to output format (44.1kHz/s16/mono)
 	// Required for the f64->s16 conversion ebur128 forces (output format f64, not a

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -28,65 +28,33 @@ func normaliseDuration(m *AudioMeasurements) float64 {
 // Limiter ceiling constants used by calculateLimiterCeiling and pre-gain deficit
 // calculation.
 const (
-	// minLimiterCeilingDB is the practical minimum for FFmpeg's alimiter.
-	// limit=0.0625 = 20*log10(0.0625) ≈ -24.08 dBTP; we use -24.0 with a small buffer.
-	// This is the alimiter engine floor, not a tuning constant.
+	// minLimiterCeilingDB is the practical minimum for FFmpeg's alimiter ceiling
+	// (dBTP). Engine floor, not a tuning constant.
+	// See docs/Normalisation-Tuning.md for the corpus derivation.
 	minLimiterCeilingDB = -24.0 // dBTP
 
-	// brickwallTruePeakHeadroomDB is the inter-sample (sample-peak vs true-peak)
-	// allowance subtracted from loudnorm's TargetTP to set the brickwall's
-	// sample-peak ceiling. The brickwall alimiter limits SAMPLE peak, but the spec
-	// targets oversampled TRUE peak; the gap between them (the inter-sample excess)
-	// pushes realised true peak above the sample ceiling.
-	//
-	// Corpus-derived (testdata/validation-0.5.x-vs-0.6.x/out-combined,
-	// _combined-metrics.csv): across the combined post-Phase-2 run the
-	// inter-sample excess (final true_peak dBTP − sample_peak dBFS) peaked at
-	// 0.817 dB on LMP-76 popey, driven up by the Phase-2 loudness-cap relaxation
-	// (the former static loudnorm TP relax) from the 0.60 dB the earlier 0.7 value
-	// was sized for. The excess is positive on every file, realised true peak sits above
-	// the sample ceiling on all of them. 0.9 dB covers the p100 of 0.817 with a
-	// ~0.08 dB safety allowance, so the sample-peak brickwall keeps oversampled
-	// true peak ≤ the loudnorm TargetTP on the whole corpus.
+	// brickwallTruePeakHeadroomDB is the inter-sample allowance (dB) subtracted
+	// from loudnorm's TargetTP to set the brickwall's sample-peak ceiling.
+	// See docs/Normalisation-Tuning.md for the corpus derivation.
 	brickwallTruePeakHeadroomDB = 0.9 // dB
 
-	// measurementCushionDB is the fixed measurement-disagreement cushion added to
-	// loudnorm's INTERNAL true-peak target (loudnormInternalTargetTP). It guards
-	// the per-file projected post-gain peak against loudnorm's OWN internal
-	// oversampled true-peak estimate disagreeing with our Pass-3 measured TP: Go
-	// computes projectedPeak from measured_TP/measured_I; FFmpeg's loudnorm
-	// computes its own output-peak estimate at a different point. If loudnorm's
-	// estimate exceeds our projection by more than the cushion, loudnorm can trip
-	// to DYNAMIC mode, the failure the Pass-4 leveling limiter exists to prevent.
-	//
-	// Corpus-measured (testdata/validation-0.5.x-vs-0.6.x/out-final/*.json):
-	// delta = loudnorm_output_tp − projectedPeak is ≤ 0.05 dB across all 48 files,
-	// one-sided positive (loudnorm estimates its peak ≈0.04 dB HOTTER on every
-	// file). 0.2 clears the measured 0.05 bias ~4×, leaving headroom for
-	// off-corpus material (other producers' audio) where the Go/FFmpeg estimator
-	// gap could be larger.
-	//
-	// This is the ONLY static margin left in loudnorm's internal targeting. The
-	// variable, corpus-dependent loudness shortfall the former 0.5 relax constant
-	// covered is now derived per file from each file's Pass-3 measured_I/measured_TP
-	// (see loudnormInternalTargetTP), so no corpus-tuned number remains. It applies
-	// ONLY to loudnorm's internal targeting; the brickwall ceiling stays at
-	// TargetTP − brickwallTruePeakHeadroomDB, unchanged.
+	// measurementCushionDB is the fixed measurement-disagreement cushion (dB) added
+	// to loudnorm's internal true-peak target (loudnormInternalTargetTP). It is the
+	// only static margin left in loudnorm's internal targeting.
+	// See docs/Normalisation-Tuning.md for the corpus derivation.
 	measurementCushionDB = 0.2 // dB
 
-	// linearSafetyMargin keeps loudnorm safely inside linear-mode bounds in the
-	// calculateLinearModeTarget guard. It accounts for floating-point precision
-	// differences between Go and FFmpeg, rounding in filter parameter passing, and
-	// measurement variance. loudnormInternalTargetTP folds it into the per-file
-	// internal TP so the linear-mode cap is inert by construction.
+	// linearSafetyMargin keeps loudnorm inside linear-mode bounds (dB) in the
+	// calculateLinearModeTarget guard. loudnormInternalTargetTP folds the same value
+	// into the per-file internal TP so the cap is inert by construction.
+	// See docs/Normalisation-Tuning.md for the corpus derivation.
 	linearSafetyMargin = 0.1 // dB
 
-	// loudnormTPMaxDB / loudnormTPMinDB bound the value emitted into loudnorm's
-	// TP= option. FFmpeg's af_loudnorm rejects a TP outside [-9.0, 0.0] dBTP
-	// (AVERROR(ERANGE) at graph build, see set_options in af_loudnorm.c). The
-	// per-file loudnormInternalTargetTP is unbounded by construction, so the
-	// emitted TP= is clamped to this range; the linear-mode guard keeps the
-	// unclamped value (see the clamp site in the loudnorm filter string).
+	// loudnormTPMaxDB / loudnormTPMinDB bound the value emitted into loudnorm's TP=
+	// option (dBTP). FFmpeg's af_loudnorm rejects a TP outside [-9.0, 0.0]; the
+	// per-file loudnormInternalTargetTP is clamped to this range, the linear-mode
+	// guard keeps the unclamped value.
+	// See docs/Normalisation-Tuning.md for the engine constraint.
 	loudnormTPMaxDB = 0.0  // dBTP
 	loudnormTPMinDB = -9.0 // dBTP
 )

--- a/internal/processor/normalise_guard_test.go
+++ b/internal/processor/normalise_guard_test.go
@@ -45,7 +45,7 @@ func TestMetadataModeGuard(t *testing.T) {
 			TargetOffset: -0.5,
 		}
 
-		spec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
+		spec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 48000, "")
 		assertBothFlags(t, "buildLoudnormFilterSpec()", spec)
 	})
 

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -1559,7 +1559,7 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 				ceiling = reDerivedCeiling
 			}
 
-			filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, preGainDB, ceiling, needsLimiting, 48000, "")
+			filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{preGainDB: preGainDB, ceilingDB: ceiling, needed: needsLimiting}, 48000, "")
 
 			// (a)/(b): Check volume filter presence
 			hasVolume := strings.Contains(filterSpec, "volume=")
@@ -1639,7 +1639,7 @@ func TestBuildLoudnormFilterSpec_DoesNotMutateConfig(t *testing.T) {
 		TargetOffset: -0.5,
 	}
 
-	filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
+	filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 48000, "")
 
 	if config.Resample.Enabled {
 		t.Error("buildLoudnormFilterSpec mutated config.Resample.Enabled")
@@ -1663,7 +1663,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 	t.Run("uses Pass 4 adeclick helper", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 48000, "")
 
 		const want = "adeclick=t=1.7:w=55:o=50:m=s"
 		if !strings.Contains(filterSpec, want) {
@@ -1675,7 +1675,7 @@ func TestBuildLoudnormFilterSpec_Adeclick(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 		config.Adeclick.Enabled = false
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 48000, "")
 
 		if strings.Contains(filterSpec, "adeclick=") {
 			t.Errorf("buildLoudnormFilterSpec() emitted disabled adeclick\nfilterSpec: %s", filterSpec)
@@ -1699,7 +1699,7 @@ func TestBuildLoudnormFilterSpecSourceRateResample(t *testing.T) {
 	t.Run("derives resample rate and orders it between loudnorm and adeclick", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 96000, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 96000, "")
 
 		const wantResample = "aresample=96000"
 		if !strings.Contains(filterSpec, wantResample) {
@@ -1725,7 +1725,7 @@ func TestBuildLoudnormFilterSpecSourceRateResample(t *testing.T) {
 	t.Run("omits resample when source rate is zero", func(t *testing.T) {
 		config := defaultNormalisationTestConfig()
 
-		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, 0, -1.0, false, 0, "")
+		filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 0, "")
 
 		if strings.Contains(filterSpec, "aresample=") {
 			t.Fatalf("buildLoudnormFilterSpec() emitted aresample for zero source rate\nfilterSpec: %s", filterSpec)
@@ -1747,7 +1747,7 @@ func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 
 	base := defaultNormalisationTestConfig()
 	assertNoStaleEffectiveConfigFields(t)
-	controlSpec := buildLoudnormFilterSpec(base, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
+	controlSpec := buildLoudnormFilterSpec(base, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 48000, "")
 
 	withUnrelatedFilterFields := *base
 	withUnrelatedFilterFields.FilterOrder = []FilterID{FilterAnalysis}
@@ -1755,7 +1755,7 @@ func TestBuildLoudnormFilterSpecIgnoresNonNormalisationFields(t *testing.T) {
 	withUnrelatedFilterFields.SpeechGate.Ratio = 4.0
 	withUnrelatedFilterFields.LevellingCompressor.Threshold = -30.0
 
-	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, measurement.TargetOffset, 0, -1.0, false, 48000, "")
+	gotSpec := buildLoudnormFilterSpec(&withUnrelatedFilterFields, measurement, measurement.TargetOffset, limiterPlan{ceilingDB: -1.0}, 48000, "")
 	if gotSpec != controlSpec {
 		t.Fatalf("buildLoudnormFilterSpec() changed when unrelated filter fields changed\ncontrol: %s\ngot:     %s", controlSpec, gotSpec)
 	}
@@ -1968,7 +1968,7 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 				bCeiling = bReDerived
 			}
 
-			filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, preGainDB, bCeiling, bNeeded, 48000, "")
+			filterSpec := buildLoudnormFilterSpec(config, measurement, measurement.TargetOffset, limiterPlan{preGainDB: preGainDB, ceilingDB: bCeiling, needed: bNeeded}, 48000, "")
 			if !bClamped {
 				t.Error("expected pre-computation to report clamped")
 			}
@@ -2208,9 +2208,7 @@ func TestLoudnormPrefixAndFilterSpecParityRepresentativeCases(t *testing.T) {
 				config,
 				&tt.measurement,
 				tt.measurement.TargetOffset,
-				limiter.preGainDB,
-				limiter.ceilingDB,
-				limiter.needed,
+				limiter,
 				48000,
 				"",
 			)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -282,7 +282,7 @@ func processWithFilters(ctx context.Context, inputPath, outputPath string, confi
 	// NOTE: loudnorm is NOT in the Pass 2 filter chain because it always processes audio
 	// (no measure-only mode). Loudnorm measurement is done separately in Pass 3.
 	filterGraph, bufferSrcCtx, bufferSinkCtx, err := CreateProcessingFilterGraph(
-		reader.GetDecoderContext(),
+		reader.DecoderContext(),
 		config,
 	)
 	if err != nil {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -188,7 +188,6 @@ func ProcessAudio(ctx context.Context, inputPath string, config *BaseFilterConfi
 		OutputPath:           outputPath,
 		InputLUFS:            measurements.Loudness.InputI,
 		OutputLUFS:           0.0, // Will be set to final value below
-		NoiseFloor:           measurements.Noise.Floor,
 		Measurements:         measurements,
 		Config:               effectiveConfig, // Include per-file config for logging adaptive parameters
 		Diagnostics:          diagnostics,
@@ -238,7 +237,6 @@ type ProcessingResult struct {
 	OutputPath   string
 	InputLUFS    float64
 	OutputLUFS   float64 // Final output loudness (after normalisation if applied)
-	NoiseFloor   float64
 	Measurements *AudioMeasurements
 	Config       *EffectiveFilterConfig // Contains adaptive parameters used
 	Diagnostics  *AdaptiveDiagnostics

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -706,7 +706,6 @@ func TestProcessAudio(t *testing.T) {
 	// Log results
 	t.Logf("Input LUFS: %.2f", result.InputLUFS)
 	t.Logf("Output LUFS: %.2f", result.OutputLUFS)
-	t.Logf("Noise Floor: %.2f", result.NoiseFloor)
 	t.Logf("Output: %s", result.OutputPath)
 }
 

--- a/internal/processor/quality.go
+++ b/internal/processor/quality.go
@@ -192,6 +192,29 @@ func InputRoomToneFloorDB(m *AudioMeasurements) (float64, bool) {
 	return floor, true
 }
 
+// OutputTP resolves the final-output true peak (dBTP) for the done-box
+// before->after row. It reads NormResult.OutputTP, ebur128's measured peak on
+// the final Pass 4 output, the same value the pool read inline. The bool is
+// false when NormResult is nil (normalisation disabled or skipped), so the UI
+// gates the row rather than showing a bogus 0.
+func OutputTP(result *ProcessingResult) (float64, bool) {
+	if result == nil || result.NormResult == nil {
+		return 0, false
+	}
+	return result.NormResult.OutputTP, true
+}
+
+// OutputLRA resolves the final-output loudness range (LU) for the done-box
+// before->after row, read from the final-stage FinalMeasurements measured by
+// ebur128, the same value the pool read inline. The bool is false when
+// NormResult or its FinalMeasurements is nil, so the UI gates the row.
+func OutputLRA(result *ProcessingResult) (float64, bool) {
+	if result == nil || result.NormResult == nil || result.NormResult.FinalMeasurements == nil {
+		return 0, false
+	}
+	return result.NormResult.FinalMeasurements.Loudness.OutputLRA, true
+}
+
 // inputRoomToneRMS resolves the elected input room-tone RMS floor (dBFS) from a
 // ProcessingResult, delegating to InputRoomToneFloorDB so the quality scorer's
 // input-floor fallback shares the one display resolver.

--- a/internal/processor/quality.go
+++ b/internal/processor/quality.go
@@ -137,21 +137,9 @@ func outputTruePeak(result *ProcessingResult) float64 {
 	return qualityTPHot
 }
 
-// FinalNoiseFloor resolves the output room-tone RMS floor (dBFS) for display, the
-// same quantity the quality scorer rewards. Prefers the Pass 4 final room-tone
-// sample; falls back to the input floor when no final sample exists so the done
-// box always shows a real measured floor. The bool is false when neither is
-// available.
-func FinalNoiseFloor(result *ProcessingResult) (float64, bool) {
-	if floor, ok := finalRoomToneRMS(result); ok {
-		return floor, true
-	}
-	return inputRoomToneRMS(result)
-}
-
 // OutputNoiseFloor resolves the genuine Pass 4 output room-tone RMS floor (dBFS),
-// the after half of the done-box before->after pair. Unlike FinalNoiseFloor it
-// does NOT fall back to the input floor: the bool is false when no Pass 4
+// the after half of the done-box before->after pair. It does NOT fall back to
+// the input floor: the bool is false when no Pass 4
 // room-tone sample exists, so the done box can show the input figure alone
 // rather than a misleading input->input arrow.
 func OutputNoiseFloor(result *ProcessingResult) (float64, bool) {
@@ -163,7 +151,7 @@ func OutputNoiseFloor(result *ProcessingResult) (float64, bool) {
 
 // InputNoiseFloor resolves the input room-tone RMS floor (dBFS) for display,
 // the before half of the done-box before->after pair whose after half is
-// FinalNoiseFloor. Both ends are RegionSample.RMSLevel on the same astats RMS
+// OutputNoiseFloor. Both ends are RegionSample.RMSLevel on the same astats RMS
 // dBFS axis, so the pair is honestly comparable. It delegates to
 // InputRoomToneFloorDB, which reads only the elected room-tone RegionSample
 // (ElectedRoomToneSample, measured by the same interval accumulation that

--- a/internal/processor/quality_test.go
+++ b/internal/processor/quality_test.go
@@ -205,3 +205,67 @@ func TestOutputNoiseFloorAbsentNoFallback(t *testing.T) {
 		t.Error("OutputNoiseFloor with no Pass 4 sample: ok = true, want false (no input fallback)")
 	}
 }
+
+// TestOutputTP covers the three nil-guard layers: nil NormResult yields ok =
+// false; a populated NormResult returns its top-level OutputTP regardless of
+// FinalMeasurements (TP is a NormResult field, the value the pool read inline).
+func TestOutputTP(t *testing.T) {
+	if _, ok := OutputTP(nil); ok {
+		t.Error("OutputTP(nil): ok = true, want false")
+	}
+
+	noNorm := &ProcessingResult{}
+	if _, ok := OutputTP(noNorm); ok {
+		t.Error("OutputTP with nil NormResult: ok = true, want false")
+	}
+
+	// Nil FinalMeasurements still yields the TP: it is a top-level NormResult
+	// field, so the value is available without FinalMeasurements.
+	nilFinal := &ProcessingResult{NormResult: &NormalisationResult{OutputTP: -1.5}}
+	tp, ok := OutputTP(nilFinal)
+	if !ok {
+		t.Fatal("OutputTP with nil FinalMeasurements: ok = false, want true")
+	}
+	if tp != -1.5 {
+		t.Errorf("OutputTP = %.1f, want -1.5", tp)
+	}
+
+	full := resultWith(-16.0, -2.0, -64.0, -82.0)
+	if tp, ok := OutputTP(full); !ok || tp != -2.0 {
+		t.Errorf("OutputTP populated = %.1f, ok = %v; want -2.0, true", tp, ok)
+	}
+}
+
+// TestOutputLRA covers the three nil-guard layers: nil NormResult and nil
+// FinalMeasurements both yield ok = false; a fully populated result returns
+// FinalMeasurements.Loudness.OutputLRA, the value the pool read inline.
+func TestOutputLRA(t *testing.T) {
+	if _, ok := OutputLRA(nil); ok {
+		t.Error("OutputLRA(nil): ok = true, want false")
+	}
+
+	noNorm := &ProcessingResult{}
+	if _, ok := OutputLRA(noNorm); ok {
+		t.Error("OutputLRA with nil NormResult: ok = true, want false")
+	}
+
+	nilFinal := &ProcessingResult{NormResult: &NormalisationResult{}}
+	if _, ok := OutputLRA(nilFinal); ok {
+		t.Error("OutputLRA with nil FinalMeasurements: ok = true, want false")
+	}
+
+	full := &ProcessingResult{
+		NormResult: &NormalisationResult{
+			FinalMeasurements: &OutputMeasurements{
+				Loudness: OutputLoudnessMetrics{OutputLRA: 7.5},
+			},
+		},
+	}
+	lra, ok := OutputLRA(full)
+	if !ok {
+		t.Fatal("OutputLRA populated: ok = false, want true")
+	}
+	if lra != 7.5 {
+		t.Errorf("OutputLRA = %.1f, want 7.5", lra)
+	}
+}

--- a/internal/processor/recording.go
+++ b/internal/processor/recording.go
@@ -1,7 +1,5 @@
 package processor
 
-import "math"
-
 // ComputeRecordingScore grades the INPUT capture quality from Pass-1
 // measurements, the counterpart to ComputeQualityScore (which grades the
 // OUTPUT against spec). The output score saturates near 5 stars because the
@@ -82,7 +80,7 @@ func linearScore(v, full, zero float64) float64 {
 		return 0.0
 	}
 	t := (v - zero) / (full - zero)
-	return math.Max(0.0, math.Min(1.0, t))
+	return min(1.0, max(0.0, t))
 }
 
 // ComputeRecordingScore derives the source-capture quality rating from Pass-1
@@ -125,7 +123,7 @@ func recordingCleanliness(m *AudioMeasurements) float64 {
 // recordingLevel blends the loudness deficit (quiet captures penalised, loud
 // ones not) and the loudness range (sprawl penalised).
 func recordingLevel(m *AudioMeasurements) float64 {
-	deficit := math.Max(0, recordingLevelTarget-m.Loudness.InputI)
+	deficit := max(0, recordingLevelTarget-m.Loudness.InputI)
 	deficitScore := linearScore(deficit, recordingDeficitFull, recordingDeficitZero)
 	lraScore := linearScore(m.Loudness.InputLRA, recordingLRAFull, recordingLRAZero)
 	return recordingDeficitWeight*deficitScore + recordingLRAWeight*lraScore

--- a/internal/processor/recording.go
+++ b/internal/processor/recording.go
@@ -131,8 +131,10 @@ func recordingLevel(m *AudioMeasurements) float64 {
 	return recordingDeficitWeight*deficitScore + recordingLRAWeight*lraScore
 }
 
-// floorOrZero returns the elected room-tone noise floor (dBFS), or 0 when no
-// NoiseProfile was elected. A 0 dBFS floor scores as maximally dirty, keeping
+// floorOrZero returns the elected room-tone noise floor on the K-weighted
+// momentary-LUFS axis (overwritten by detectVoiceActivity), or 0 when no
+// NoiseProfile was elected. Compare it only against momentary-LUFS values,
+// never an astats-RMS dBFS level. A 0 floor scores as maximally dirty, keeping
 // the fallback honest.
 func (np *NoiseProfile) floorOrZero() float64 {
 	if np == nil {

--- a/internal/processor/runrecord.go
+++ b/internal/processor/runrecord.go
@@ -34,17 +34,17 @@ type RunRecord struct {
 	// (see normalisationRecord); the source struct is untouched.
 	Normalisation *normalisationRecord `json:"normalisation,omitempty"`
 
-	// IntervalSummary holds the per-250ms RMS distribution and gap summary (task
-	// 3.1). The full per-interval series lives in the .intervals.jsonl sidecar; the
-	// summary stays inline. nil + omitempty drops it when no intervals exist.
+	// IntervalSummary holds the per-250ms RMS distribution and gap summary. The
+	// full per-interval series lives in the .intervals.jsonl sidecar; the summary
+	// stays inline. nil + omitempty drops it when no intervals exist.
 	IntervalSummary *IntervalSummary `json:"interval_summary,omitempty"`
 
 	// Spectrograms is the deterministic before/after (processing) or input
 	// (analysis-only) spectrogram image list, attached synchronously by the
-	// --diagnostics write site (T4) via deriveSpectrogramImages before the
-	// background PNG renders run. The renderer links these relative paths; the paths
-	// are known before the files land. Empty + omitempty drops it when the flag is
-	// off or no region beyond whole-file is elected.
+	// --diagnostics write site via deriveSpectrogramImages before the background
+	// PNG renders run. The renderer links these relative paths; the paths are known
+	// before the files land. Empty + omitempty drops it when the flag is off or no
+	// region beyond whole-file is elected.
 	Spectrograms []SpectrogramImage `json:"spectrograms,omitempty"`
 }
 
@@ -111,8 +111,8 @@ type FiltersBlock struct {
 
 // IntervalSummary is the §8.1 `interval_summary` block: the RMS distribution and
 // largest-gap summary derived from the full per-250ms IntervalSamples series. The
-// full series itself lands in the .intervals.jsonl sidecar (§8.5 call 2); only
-// this summary is inline. newIntervalSummary owns the maths.
+// full series itself lands in the .intervals.jsonl sidecar; only this summary is
+// inline. newIntervalSummary owns the maths.
 type IntervalSummary struct {
 	Count int `json:"count"`
 
@@ -142,7 +142,7 @@ type RMSDistribution struct {
 // score), and the per-stage before/after samples. Assembly-side type only - it
 // points into the live ProcessingResult data BY REFERENCE (§9.2), never copying
 // values. The full candidate arrays and interval series are NOT inline; they live
-// in the .candidates.jsonl / .intervals.jsonl sidecars (§8.5 call 2, §9.3).
+// in the .candidates.jsonl / .intervals.jsonl sidecars.
 type RegionsBlock struct {
 	RoomTone       RoomToneRegionRecord `json:"room_tone"`
 	Speech         SpeechRegionRecord   `json:"speech"`
@@ -199,7 +199,7 @@ func (s SpeechRegionRecord) ElectedProfile() *SpeechCandidateMetrics {
 	return s.Elected.Profile()
 }
 
-// CandidatesSummary is the inline stand-in for a full candidate array (§9.3): the
+// CandidatesSummary is the inline stand-in for a full candidate array: the
 // number evaluated and the elected candidate's score. The elected candidate's
 // full metrics already live in regions.<kind>.elected; the full scored array is
 // streamed to the .candidates.jsonl sidecar. ElectedScore is a pointer so an
@@ -231,7 +231,7 @@ func NewRunRecord(result *ProcessingResult) *RunRecord {
 		rec.Loudness.Stages.Filtered = &fm.Loudness
 		rec.Dynamics.Stages.Filtered = &fm.Dynamics
 		rec.Spectral.Stages.Filtered = &fm.Spectral
-		// Pass 2 before/after region samples (task 1.2), referenced not copied.
+		// Pass 2 before/after region samples, referenced not copied.
 		if rec.Regions != nil {
 			rec.Regions.RoomTone.Samples.Filtered = fm.RoomToneSample
 			rec.Regions.Speech.Samples.Filtered = fm.SpeechSample
@@ -243,7 +243,7 @@ func NewRunRecord(result *ProcessingResult) *RunRecord {
 			rec.Loudness.Stages.Final = &fm.Loudness
 			rec.Dynamics.Stages.Final = &fm.Dynamics
 			rec.Spectral.Stages.Final = &fm.Spectral
-			// Pass 4 before/after region samples (task 1.2), referenced not copied.
+			// Pass 4 before/after region samples, referenced not copied.
 			if rec.Regions != nil {
 				rec.Regions.RoomTone.Samples.Final = fm.RoomToneSample
 				rec.Regions.Speech.Samples.Final = fm.SpeechSample

--- a/internal/processor/runrecord.go
+++ b/internal/processor/runrecord.go
@@ -249,6 +249,14 @@ func NewRunRecord(result *ProcessingResult) *RunRecord {
 				rec.Regions.Speech.Samples.Final = fm.SpeechSample
 			}
 		}
+		// Parse loudnorm stats to typed floats once for the report, precomputing the
+		// target deviation. buildNormalisationResult sets this on the production path;
+		// fill it here when absent (e.g. a result assembled directly) so the report
+		// formats typed numbers and never re-parses the strings. The typed values are
+		// json:"-", so this does not touch the run-record JSON schema.
+		if result.NormResult.LoudnormParsed == nil {
+			result.NormResult.LoudnormParsed = parseLoudnormMeasured(result.NormResult.LoudnormStats, result.NormResult.EffectiveTargetI)
+		}
 		rec.Normalisation = &normalisationRecord{recordWrapper[NormalisationResult]{src: result.NormResult}}
 	}
 

--- a/internal/processor/runrecord_sidecar_test.go
+++ b/internal/processor/runrecord_sidecar_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// TestRunRecord_IntervalSummaryInlineSeriesAbsent asserts task 3.1's split: the
+// TestRunRecord_IntervalSummaryInlineSeriesAbsent asserts the interval split: the
 // inline record carries interval_summary (count + RMS distribution + largest gap)
 // and never the full interval_samples series.
 func TestRunRecord_IntervalSummaryInlineSeriesAbsent(t *testing.T) {
@@ -46,7 +46,7 @@ func TestRunRecord_IntervalSummaryInlineSeriesAbsent(t *testing.T) {
 }
 
 // TestNewIntervalSummary_MatchesReportMaths asserts the percentile/gap selection
-// reproduces the .log diagnostic's integer-index maths exactly.
+// uses the integer-index maths the inline summary reports verbatim.
 func TestNewIntervalSummary_MatchesReportMaths(t *testing.T) {
 	// 11 distinct RMS values above the -120 silence floor.
 	vals := []float64{-70, -68, -66, -64, -62, -40, -38, -36, -34, -32, -30}
@@ -77,8 +77,8 @@ func TestNewIntervalSummary_MatchesReportMaths(t *testing.T) {
 	}
 }
 
-// TestNewIntervalSummary_BelowThresholdDropsDistribution mirrors the .log: fewer
-// than 10 non-silence intervals prints count only, no distribution/gap.
+// TestNewIntervalSummary_BelowThresholdDropsDistribution asserts the threshold
+// rule: fewer than 10 non-silence intervals yields count only, no distribution/gap.
 func TestNewIntervalSummary_BelowThresholdDropsDistribution(t *testing.T) {
 	samples := syntheticIntervals(5)
 	s := newIntervalSummary(samples)

--- a/internal/processor/runrecord_tags_test.go
+++ b/internal/processor/runrecord_tags_test.go
@@ -426,7 +426,8 @@ func TestAdaptiveDiagnosticsJSON_HasCanonicalKeys(t *testing.T) {
 
 // TestNormalisationResultJSON_HasCanonicalKeys asserts the §8.4 keys for the
 // `normalisation` block, that LoudnormStats nests under loudnorm_measured, and
-// that FinalMeasurements is excluded (assembled into stages at RunRecord 2.4).
+// that FinalMeasurements is excluded (assembled into the loudness/dynamics/spectral
+// stages instead).
 func TestNormalisationResultJSON_HasCanonicalKeys(t *testing.T) {
 	res := NormalisationResult{
 		InputLUFS: -18, InputTP: -2, OutputLUFS: -16, OutputTP: -2,

--- a/internal/processor/runrecord_tags_test.go
+++ b/internal/processor/runrecord_tags_test.go
@@ -67,11 +67,13 @@ func populatedAudioMeasurements() *AudioMeasurements {
 		NoiseProfile: &NoiseProfile{
 			Start: 2 * time.Second, Duration: 10 * time.Second,
 			MeasuredNoiseFloor: -60, PeakLevel: -50, CrestFactor: 10, Entropy: 0.5,
-			SpectralMean: 1.2, SpectralVariance: 2.4, SpectralCentroid: 1500,
-			SpectralSpread: 350, SpectralSkewness: 0.8, SpectralKurtosis: 3,
-			SpectralEntropy: 0.55, SpectralFlatness: 0.4, SpectralCrest: 7.5,
-			SpectralFlux: 0.03, SpectralSlope: -0.25, SpectralDecrease: 0.11,
-			SpectralRolloff: 6500,
+			Spectral: SpectralMetrics{
+				Mean: 1.2, Variance: 2.4, Centroid: 1500,
+				Spread: 350, Skewness: 0.8, Kurtosis: 3,
+				Entropy: 0.55, Flatness: 0.4, Crest: 7.5,
+				Flux: 0.03, Slope: -0.25, Decrease: 0.11,
+				Rolloff: 6500,
+			},
 		},
 	}
 	m.Regions.SpeechProfile = &m.Regions.SpeechCandidates[0]
@@ -223,10 +225,10 @@ func TestRunRecordNoiseProfileSpectralFieldsZeroValued(t *testing.T) {
 	m := populatedAudioMeasurements()
 	// Zero out a representative spread: variance, skewness, flux, and decrease.
 	// Each would have dropped under the old `,omitempty` tags.
-	m.Regions.NoiseProfile.SpectralVariance = 0
-	m.Regions.NoiseProfile.SpectralSkewness = 0
-	m.Regions.NoiseProfile.SpectralFlux = 0
-	m.Regions.NoiseProfile.SpectralDecrease = 0
+	m.Regions.NoiseProfile.Spectral.Variance = 0
+	m.Regions.NoiseProfile.Spectral.Skewness = 0
+	m.Regions.NoiseProfile.Spectral.Flux = 0
+	m.Regions.NoiseProfile.Spectral.Decrease = 0
 
 	rec := NewAnalysisRunRecord("/tmp/episode.flac", m)
 	tree, raw := marshalRecordTree(t, rec)

--- a/internal/processor/runrecord_tags_test.go
+++ b/internal/processor/runrecord_tags_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"time"
 )
@@ -66,7 +67,11 @@ func populatedAudioMeasurements() *AudioMeasurements {
 		NoiseProfile: &NoiseProfile{
 			Start: 2 * time.Second, Duration: 10 * time.Second,
 			MeasuredNoiseFloor: -60, PeakLevel: -50, CrestFactor: 10, Entropy: 0.5,
-			SpectralCentroid: 1500, SpectralFlatness: 0.4, SpectralKurtosis: 3,
+			SpectralMean: 1.2, SpectralVariance: 2.4, SpectralCentroid: 1500,
+			SpectralSpread: 350, SpectralSkewness: 0.8, SpectralKurtosis: 3,
+			SpectralEntropy: 0.55, SpectralFlatness: 0.4, SpectralCrest: 7.5,
+			SpectralFlux: 0.03, SpectralSlope: -0.25, SpectralDecrease: 0.11,
+			SpectralRolloff: 6500,
 		},
 	}
 	m.Regions.SpeechProfile = &m.Regions.SpeechCandidates[0]
@@ -112,8 +117,11 @@ func TestAudioMeasurementsJSON_HasCanonicalKeys(t *testing.T) {
 		"voiced_low_percentile_dbfs", "noise_high_percentile_dbfs", "gate_separation_db",
 		// region-sample / candidate fields
 		"crest_factor_db", "speech_band_body_rms_dbfs", "speech_band_sib_rms_dbfs",
-		// noise profile fields
+		// noise profile fields (full 13-metric spectral set)
 		"measured_floor_dbfs", "spectral_centroid_hz",
+		"spectral_mean", "spectral_variance", "spectral_spread_hz",
+		"spectral_skewness", "spectral_entropy", "spectral_crest",
+		"spectral_flux", "spectral_slope", "spectral_decrease", "spectral_rolloff_hz",
 	}
 	for _, key := range wantPresent {
 		if !keys[key] {
@@ -129,17 +137,140 @@ func TestAudioMeasurementsJSON_HasCanonicalKeys(t *testing.T) {
 		"floor", "floor_prescan", "floor_astats", "reduction_headroom",
 		"room_tone_detect_level", "min_level", "max_level", "zero_crossings",
 		// legacy flat spectral keys (the old un-suffixed SpectralMetrics marshal).
-		// Note: NoiseProfile keeps its own distinct contamination fields
-		// spectral_flatness / spectral_kurtosis / spectral_centroid_hz (§1.7), so
-		// those are deliberately NOT asserted absent.
+		// Note: NoiseProfile keeps its own distinct contamination fields covering
+		// the full 13-metric set (spectral_mean / spectral_flatness /
+		// spectral_kurtosis / spectral_centroid_hz / spectral_flux / ...), so those
+		// suffixed keys are deliberately NOT asserted absent. The bare
+		// spectral_spread / spectral_rolloff (no _hz) stay asserted absent because
+		// NoiseProfile emits the _hz-suffixed forms.
 		"spectral_centroid", "spectral_spread", "spectral_rolloff",
-		"spectral_mean", "spectral_flux",
 		// removed silence/suggestion plumbing
 		"suggested_gate_threshold", "measured_noise_floor",
 	}
 	for _, key := range wantAbsent {
 		if keys[key] {
 			t.Errorf("legacy key %q must not appear in the record", key)
+		}
+	}
+}
+
+// TestRunRecordNoiseProfileSpectralFields confirms the RunRecord noise-profile
+// node carries all 13 contamination-detection spectral fields (entropy plus the
+// full spectral set) with the values measured on the NoiseProfile. No consumer
+// reads them yet, but they are the measurement spine the JSON artefact must
+// expose, so they must reach regions.room_tone.elected unchanged rather than
+// being dropped on the way to the record.
+func TestRunRecordNoiseProfileSpectralFields(t *testing.T) {
+	rec := NewAnalysisRunRecord("/tmp/episode.flac", populatedAudioMeasurements())
+	tree, raw := marshalRecordTree(t, rec)
+
+	regions, ok := tree["regions"].(map[string]any)
+	if !ok {
+		t.Fatal("missing regions block")
+	}
+	roomTone, ok := regions["room_tone"].(map[string]any)
+	if !ok {
+		t.Fatal("missing regions.room_tone block")
+	}
+	elected, ok := roomTone["elected"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing regions.room_tone.elected noise profile\n%s", raw)
+	}
+
+	// Values come from populatedAudioMeasurements' NoiseProfile fixture.
+	cases := []struct {
+		key  string
+		want float64
+	}{
+		{"entropy", 0.5},
+		{"spectral_mean", 1.2},
+		{"spectral_variance", 2.4},
+		{"spectral_centroid_hz", 1500},
+		{"spectral_spread_hz", 350},
+		{"spectral_skewness", 0.8},
+		{"spectral_kurtosis", 3},
+		{"spectral_entropy", 0.55},
+		{"spectral_flatness", 0.4},
+		{"spectral_crest", 7.5},
+		{"spectral_flux", 0.03},
+		{"spectral_slope", -0.25},
+		{"spectral_decrease", 0.11},
+		{"spectral_rolloff_hz", 6500},
+	}
+	for _, c := range cases {
+		got, present := elected[c.key]
+		if !present {
+			t.Errorf("regions.room_tone.elected missing %q", c.key)
+			continue
+		}
+		num, isNum := got.(float64)
+		if !isNum {
+			t.Errorf("%q = %v (%T), want number", c.key, got, got)
+			continue
+		}
+		if math.Abs(num-c.want) > 0.001 {
+			t.Errorf("%q = %v, want %v", c.key, num, c.want)
+		}
+	}
+}
+
+// TestRunRecordNoiseProfileSpectralFieldsZeroValued confirms the 13 spectral
+// fields keep a stable key set when a metric averages to exactly 0.0. With
+// `,omitempty` removed from their tags, a zero-valued spectral field must still
+// serialise into regions.room_tone.elected rather than dropping out, so the key
+// set is identical file-to-file regardless of measured values.
+func TestRunRecordNoiseProfileSpectralFieldsZeroValued(t *testing.T) {
+	m := populatedAudioMeasurements()
+	// Zero out a representative spread: variance, skewness, flux, and decrease.
+	// Each would have dropped under the old `,omitempty` tags.
+	m.Regions.NoiseProfile.SpectralVariance = 0
+	m.Regions.NoiseProfile.SpectralSkewness = 0
+	m.Regions.NoiseProfile.SpectralFlux = 0
+	m.Regions.NoiseProfile.SpectralDecrease = 0
+
+	rec := NewAnalysisRunRecord("/tmp/episode.flac", m)
+	tree, raw := marshalRecordTree(t, rec)
+
+	regions, ok := tree["regions"].(map[string]any)
+	if !ok {
+		t.Fatal("missing regions block")
+	}
+	roomTone, ok := regions["room_tone"].(map[string]any)
+	if !ok {
+		t.Fatal("missing regions.room_tone block")
+	}
+	elected, ok := roomTone["elected"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing regions.room_tone.elected noise profile\n%s", raw)
+	}
+
+	// All 13 spectral keys must be present even when the value is 0.0.
+	spectralKeys := []string{
+		"spectral_mean", "spectral_variance", "spectral_centroid_hz",
+		"spectral_spread_hz", "spectral_skewness", "spectral_kurtosis",
+		"spectral_entropy", "spectral_flatness", "spectral_crest",
+		"spectral_flux", "spectral_slope", "spectral_decrease", "spectral_rolloff_hz",
+	}
+	for _, key := range spectralKeys {
+		if _, present := elected[key]; !present {
+			t.Errorf("regions.room_tone.elected missing %q when value is zero\n%s", key, raw)
+		}
+	}
+
+	// The zeroed fields must serialise as a numeric 0, not drop or null.
+	for _, key := range []string{"spectral_variance", "spectral_skewness", "spectral_flux", "spectral_decrease"} {
+		got, present := elected[key]
+		if !present {
+			t.Errorf("zero-valued %q dropped from record", key)
+			continue
+		}
+		num, isNum := got.(float64)
+		if !isNum {
+			t.Errorf("%q = %v (%T), want numeric 0", key, got, got)
+			continue
+		}
+		if num != 0 {
+			t.Errorf("%q = %v, want 0", key, num)
 		}
 	}
 }

--- a/internal/processor/runrecord_test.go
+++ b/internal/processor/runrecord_test.go
@@ -184,7 +184,7 @@ func TestRunRecord_NonFiniteFloatSerialisesAsNull(t *testing.T) {
 // full (processing) record: room_tone and speech each carry elected, candidates,
 // and samples; the elected profiles are present; the speech input sample wires
 // from SpeechProfile.RegionSample; and filtered/final samples wire from the
-// output measurements (task 2.7).
+// output measurements.
 func TestRunRecord_RegionsNestedShape(t *testing.T) {
 	result := populatedProcessingResult()
 	// Wire output region samples on both filtered and final stages so the
@@ -282,8 +282,8 @@ func TestRunRecord_RegionsNestedShape(t *testing.T) {
 		}
 	}
 
-	// Room-tone input sample is now populated from the elected candidate's
-	// RegionSample captured at election (FIX 1).
+	// Room-tone input sample is populated from the elected candidate's RegionSample
+	// captured at election.
 	rtSamples := rt["samples"].(map[string]any)
 	rtInput, ok := rtSamples["input"].(map[string]any)
 	if !ok {
@@ -303,7 +303,7 @@ func TestRunRecord_RegionsNestedShape(t *testing.T) {
 
 // TestRunRecord_RegionsAnalysisOnlyDropsSamples asserts the before/after samples
 // drop in an analysis-only record (no FilteredMeasurements / NormResult): the
-// nested elected/candidates stay, but filtered/final samples are omitted (task 2.7).
+// nested elected/candidates stay, but filtered/final samples are omitted.
 func TestRunRecord_RegionsAnalysisOnlyDropsSamples(t *testing.T) {
 	rec := NewAnalysisRunRecord("/tmp/episode.flac", populatedAudioMeasurements())
 	tree, _ := marshalRecordTree(t, rec)
@@ -335,8 +335,8 @@ func TestRunRecord_RegionsAnalysisOnlyDropsSamples(t *testing.T) {
 	}
 }
 
-// TestRunRecord_RegionDurationsAreSeconds asserts FIX 2(a): region time bounds
-// emit as _s float seconds, not raw nanoseconds, and the ns keys are absent.
+// TestRunRecord_RegionDurationsAreSeconds asserts region time bounds emit as _s
+// float seconds, not raw nanoseconds, and the ns keys are absent.
 func TestRunRecord_RegionDurationsAreSeconds(t *testing.T) {
 	rec := NewRunRecord(populatedProcessingResult())
 	tree, _ := marshalRecordTree(t, rec)
@@ -381,8 +381,8 @@ func TestRunRecord_RegionDurationsAreSeconds(t *testing.T) {
 	}
 }
 
-// TestRunRecord_LoudnormMeasuredNumeric asserts FIX 2(b): normalisation.loudnorm_measured
-// is the §8.4 numeric sub-block, not FFmpeg's raw string keys, with normalization_type
+// TestRunRecord_LoudnormMeasuredNumeric asserts normalisation.loudnorm_measured is
+// the §8.4 numeric sub-block, not FFmpeg's raw string keys, with normalization_type
 // kept as a categorical string.
 func TestRunRecord_LoudnormMeasuredNumeric(t *testing.T) {
 	rec := NewRunRecord(populatedProcessingResult())

--- a/internal/processor/runrecord_units.go
+++ b/internal/processor/runrecord_units.go
@@ -24,6 +24,18 @@ func sanitisedSourceMap(source any) map[string]any {
 		return nil
 	}
 	v := reflect.ValueOf(source)
+	// Honour a custom json.Marshaler on the source (e.g. NoiseProfile flattens its
+	// embedded Spectral to spectral_* keys) by routing through sanitiseValue, which
+	// marshals via the type then re-sanitises the decoded tree. Falls through to the
+	// reflection walk for plain structs (no marshaler). Either way a struct source
+	// yields a map; non-struct or non-object sources yield nil so the caller drops
+	// the field.
+	if _, ok := marshalerOf(v); ok {
+		if m, isMap := sanitiseValue(v).(map[string]any); isMap {
+			return m
+		}
+		return nil
+	}
 	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		if v.IsNil() {
 			return nil
@@ -128,6 +140,82 @@ func (p *noiseProfileRecord) Profile() *NoiseProfile {
 		return nil
 	}
 	return p.source()
+}
+
+// noiseProfileJSON is the flat JSON contract for NoiseProfile: the embedded
+// SpectralMetrics is unpacked into the historical spectral_* tags (distinct from
+// SpectralMetrics's own mean/centroid_hz/entropy tags) so the schema is unchanged
+// after the embed. Field order and tags mirror the former flat struct exactly.
+type noiseProfileJSON struct {
+	Start              time.Duration `json:"start"`
+	Duration           time.Duration `json:"duration"`
+	MeasuredNoiseFloor float64       `json:"measured_floor_dbfs"`
+	PeakLevel          float64       `json:"peak_level_dbfs"`
+	CrestFactor        float64       `json:"crest_factor_db"`
+	Entropy            float64       `json:"entropy"`
+	ExtractionWarning  string        `json:"extraction_warning,omitempty"`
+
+	SpectralMean     float64 `json:"spectral_mean"`
+	SpectralVariance float64 `json:"spectral_variance"`
+	SpectralCentroid float64 `json:"spectral_centroid_hz"`
+	SpectralSpread   float64 `json:"spectral_spread_hz"`
+	SpectralSkewness float64 `json:"spectral_skewness"`
+	SpectralKurtosis float64 `json:"spectral_kurtosis"`
+	SpectralEntropy  float64 `json:"spectral_entropy"`
+	SpectralFlatness float64 `json:"spectral_flatness"`
+	SpectralCrest    float64 `json:"spectral_crest"`
+	SpectralFlux     float64 `json:"spectral_flux"`
+	SpectralSlope    float64 `json:"spectral_slope"`
+	SpectralDecrease float64 `json:"spectral_decrease"`
+	SpectralRolloff  float64 `json:"spectral_rolloff_hz"`
+
+	BandNoise     []float64 `json:"band_noise_dbfs,omitempty"`
+	BandsMeasured bool      `json:"band_noise_measured,omitempty"`
+
+	OriginalStart    time.Duration `json:"original_start,omitempty"`
+	OriginalDuration time.Duration `json:"original_duration,omitempty"`
+	WasRefined       bool          `json:"was_refined,omitempty"`
+}
+
+// MarshalJSON preserves the flat spectral_* JSON contract while the Go model
+// carries the room-tone spectral data as an embedded SpectralMetrics value. The
+// embedded value flattens into the historical spectral_* tags rather than
+// SpectralMetrics's own mean/centroid_hz/entropy tags, so the run-record JSON and
+// the default-marshalled noise_profile key stay byte-identical. Non-finite float
+// fields serialise to null via the shared sanitiseValue sweep, mirroring
+// IntervalSample.MarshalJSON.
+func (p NoiseProfile) MarshalJSON() ([]byte, error) {
+	flat := noiseProfileJSON{
+		Start:              p.Start,
+		Duration:           p.Duration,
+		MeasuredNoiseFloor: p.MeasuredNoiseFloor,
+		PeakLevel:          p.PeakLevel,
+		CrestFactor:        p.CrestFactor,
+		Entropy:            p.Entropy,
+		ExtractionWarning:  p.ExtractionWarning,
+
+		SpectralMean:     p.Spectral.Mean,
+		SpectralVariance: p.Spectral.Variance,
+		SpectralCentroid: p.Spectral.Centroid,
+		SpectralSpread:   p.Spectral.Spread,
+		SpectralSkewness: p.Spectral.Skewness,
+		SpectralKurtosis: p.Spectral.Kurtosis,
+		SpectralEntropy:  p.Spectral.Entropy,
+		SpectralFlatness: p.Spectral.Flatness,
+		SpectralCrest:    p.Spectral.Crest,
+		SpectralFlux:     p.Spectral.Flux,
+		SpectralSlope:    p.Spectral.Slope,
+		SpectralDecrease: p.Spectral.Decrease,
+		SpectralRolloff:  p.Spectral.Rolloff,
+
+		BandNoise:     p.BandNoise,
+		BandsMeasured: p.BandsMeasured,
+
+		OriginalStart:    p.OriginalStart,
+		OriginalDuration: p.OriginalDuration,
+		WasRefined:       p.WasRefined,
+	}
+	return json.Marshal(sanitiseValue(reflect.ValueOf(flat)))
 }
 
 // speechProfileRecord wraps the elected speech candidate for the record. Its

--- a/internal/processor/spectrogram.go
+++ b/internal/processor/spectrogram.go
@@ -112,7 +112,7 @@ func generateSpectrogram(ctx context.Context, inputPath string, bounds *regionBo
 		seekReaderBeforeRegion(reader, time.Duration(bounds.Start*float64(time.Second)), log)
 	}
 
-	graph, srcCtx, sinkCtx, err := setupSpectrumGraph(reader.GetDecoderContext(), spectrogramFilterSpec(bounds))
+	graph, srcCtx, sinkCtx, err := setupSpectrumGraph(reader.DecoderContext(), spectrogramFilterSpec(bounds))
 	if err != nil {
 		return err
 	}

--- a/internal/processor/spectrogram.go
+++ b/internal/processor/spectrogram.go
@@ -167,26 +167,39 @@ func spectrogramBounds(kind string, rec *RunRecord) (*regionBounds, error) {
 	case SpectrogramKindWhole:
 		return nil, nil //nolint:nilnil // whole-file: nil bounds is the success signal
 	case SpectrogramKindRoomTone:
-		if rec == nil || rec.Regions == nil {
-			return nil, fmt.Errorf("room-tone spectrogram requested but no regions on record")
-		}
-		p := rec.Regions.RoomTone.ElectedProfile()
-		if p == nil {
-			return nil, fmt.Errorf("room-tone spectrogram requested but no elected profile")
-		}
-		return &regionBounds{Start: p.Start.Seconds(), Duration: p.Duration.Seconds()}, nil
+		return boundsForProfile(rec, "room-tone", func() *regionBounds {
+			p := rec.Regions.RoomTone.ElectedProfile()
+			if p == nil {
+				return nil
+			}
+			return &regionBounds{Start: p.Start.Seconds(), Duration: p.Duration.Seconds()}
+		})
 	case SpectrogramKindSpeech:
-		if rec == nil || rec.Regions == nil {
-			return nil, fmt.Errorf("speech spectrogram requested but no regions on record")
-		}
-		p := rec.Regions.Speech.ElectedProfile()
-		if p == nil {
-			return nil, fmt.Errorf("speech spectrogram requested but no elected profile")
-		}
-		return &regionBounds{Start: p.Region.Start.Seconds(), Duration: p.Region.Duration.Seconds()}, nil
+		return boundsForProfile(rec, "speech", func() *regionBounds {
+			p := rec.Regions.Speech.ElectedProfile()
+			if p == nil {
+				return nil
+			}
+			return &regionBounds{Start: p.Region.Start.Seconds(), Duration: p.Region.Duration.Seconds()}
+		})
 	default:
 		return nil, fmt.Errorf("unknown spectrogram kind %q", kind)
 	}
+}
+
+// boundsForProfile holds the shared region-spectrogram guards: it checks the
+// record carries regions, then calls extract to fetch the elected profile's
+// bounds, treating a nil result as the no-elected-profile error. label names the
+// kind in both error messages.
+func boundsForProfile(rec *RunRecord, label string, extract func() *regionBounds) (*regionBounds, error) {
+	if rec == nil || rec.Regions == nil {
+		return nil, fmt.Errorf("%s spectrogram requested but no regions on record", label)
+	}
+	bounds := extract()
+	if bounds == nil {
+		return nil, fmt.Errorf("%s spectrogram requested but no elected profile", label)
+	}
+	return bounds, nil
 }
 
 // setupSpectrumGraph builds the mixed-media graph: an abuffer audio source

--- a/internal/processor/spectrogram.go
+++ b/internal/processor/spectrogram.go
@@ -1,10 +1,10 @@
 // Package processor: spectrogram generation (Stage 3, AUDIO-MEASUREMENTS.md §7.2).
 //
 // This file holds the frozen showspectrumpic parameter string and the
-// audio-decode → showspectrumpic → PNG generation function (T1.2). The honesty
-// contract is ONE frozen parameter string, applied identically to both sides of
-// every before/after pair: s, gain, and the start/stop frequency range are
-// LITERAL, never computed per file or per duration.
+// audio-decode → showspectrumpic → PNG generation function. The honesty contract
+// is ONE frozen parameter string, applied identically to both sides of every
+// before/after pair: s, gain, and the start/stop frequency range are LITERAL,
+// never computed per file or per duration.
 package processor
 
 import (
@@ -21,9 +21,8 @@ import (
 
 // frozenSpectrogramSpec is the single, frozen showspectrumpic parameter string for
 // every spectrogram image. It is applied identically to both sides of every
-// before/after pair, the honest-comparison contract (decision #8, proposal
-// §"Honest comparison, the locked showspectrumpic parameters"). The example it is
-// derived from is docs/Spectral-Metrics-Reference.md:168.
+// before/after pair, the honest-comparison contract. It is derived from the
+// showspectrumpic example in docs/Spectral-Metrics-Reference.md.
 //
 // Why each term is load-bearing:
 //   - s=1024x512   fixed pixel dimensions across before/after (the §7.2 hard
@@ -35,19 +34,20 @@ import (
 //   - gain=1       no per-image auto-gain that would silently re-reference the scale.
 //   - color=intensity  same palette both sides.
 //
-// legend=1 is RESOLVED (T1.4): the legend renders a FIXED 0 → -117 dBFS colour-to-dB
-// scale, NOT a per-image auto-scaled one. A real before/after pair (raw input vs its
-// -LUFS-NN-processed output) produced byte-identical legend strips (same SHA-256), so
-// the dB key matches across the pair, gain=1 pins the magnitude reference and legend
-// reads off it. legend=1 is kept; no magnitude-pinning term was needed.
+// legend=1 renders a FIXED 0 → -117 dBFS colour-to-dB scale, NOT a per-image
+// auto-scaled one: a real before/after pair (raw input vs its -LUFS-NN-processed
+// output) produces byte-identical legend strips, so the dB key matches across the
+// pair. gain=1 pins the magnitude reference and the legend reads off it; no
+// separate magnitude-pinning term is needed.
 //
 // One definition, never mutated or derived per call.
 const frozenSpectrogramSpec = "s=1024x512:scale=log:fscale=log:start=20:stop=20000:gain=1:color=intensity:legend=1"
 
 // regionBounds is an optional time window for a region spectrogram. Both fields
-// are in SECONDS, matching the atrim=start=%f:duration=%f precedent at
-// analyser_output.go:18 and the record's Elected profile _s float seconds. A nil
-// *regionBounds means the whole-file path (no atrim, full stream).
+// are in SECONDS, matching the atrim=start=%f:duration=%f precedent in
+// outputRegionAnalysisFilterFormat (analyser_output.go) and the record's Elected
+// profile _s float seconds. A nil *regionBounds means the whole-file path (no
+// atrim, full stream).
 type regionBounds struct {
 	Start    float64
 	Duration float64
@@ -55,7 +55,7 @@ type regionBounds struct {
 
 // spectrogramFilterSpec builds the showspectrumpic filter spec for a graph.
 // With nil bounds it is the bare frozen spec (whole file). With bounds, it
-// prepends an atrim window (T1.3), mirroring outputRegionAnalysisFilterFormat:
+// prepends an atrim window, mirroring outputRegionAnalysisFilterFormat:
 //
 //	atrim=start=%f:duration=%f,asetpts=PTS-STARTPTS,showspectrumpic=<frozen>
 //
@@ -74,18 +74,18 @@ func spectrogramFilterSpec(bounds *regionBounds) string {
 
 // generateSpectrogram renders one showspectrumpic PNG for inputPath to pngPath.
 // With nil bounds it renders the whole file; with bounds it renders that time
-// window (T1.3). It runs ONE audio-decode → mixed-media filter graph →
-// single-frame pull → PNG encode/mux per call.
+// window. It runs ONE audio-decode → mixed-media filter graph → single-frame pull
+// → PNG encode/mux per call.
 //
 // The audio-in/video-out graph is hand-wired through a single AVFilterGraphParsePtr
-// pass (the seam proven by the T0.1 smoke test): an abuffer audio source feeds the
-// spec into a hand-allocated video buffersink whose pix_fmts is pinned to rgb24
-// before init. showspectrumpic emits its single frame at EOF, so the loop drives
-// the decode, flushes with a nil frame, then pulls the one frame.
+// pass: an abuffer audio source feeds the spec into a hand-allocated video
+// buffersink whose pix_fmts is pinned to rgb24 before init. showspectrumpic emits
+// its single frame at EOF, so the loop drives the decode, flushes with a nil
+// frame, then pulls the one frame.
 //
 // ctx discipline: the decode/push loop checks ctx.Err(); on cancellation (or any
 // failure) the partial pngPath is removed best-effort so no residue survives. Any
-// failure returns a non-nil error so the caller (T4.1/T4.2) decides fatality.
+// failure returns a non-nil error so the caller decides fatality.
 func generateSpectrogram(ctx context.Context, inputPath string, bounds *regionBounds, pngPath string) (err error) {
 	// Remove any partial output on failure or cancellation (best-effort).
 	defer func() {
@@ -120,7 +120,7 @@ func generateSpectrogram(ctx context.Context, inputPath string, bounds *regionBo
 // goroutine, keeping the source/bounds/dest resolution INSIDE this package, which
 // owns the record, the kind/stage constants, and the elected-region bounds.
 //
-// Resolution (proposal §4, plan T4.1):
+// Resolution:
 //   - source: Stage before/input → inputPath; Stage after → outputPath.
 //   - bounds: Kind whole → nil (whole file); Kind roomtone/speech → the elected
 //     profile's Start/Duration as seconds. deriveSpectrogramImages already omits a

--- a/internal/processor/spectrogram.go
+++ b/internal/processor/spectrogram.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	ffmpeg "github.com/linuxmatters/ffmpeg-statigo"
 	"github.com/linuxmatters/ffmpeg-statigo/av"
@@ -99,6 +100,17 @@ func generateSpectrogram(ctx context.Context, inputPath string, bounds *regionBo
 		return fmt.Errorf("open audio file: %w", err)
 	}
 	defer reader.Close()
+
+	// For a region render, skip the pre-region span: seek the demuxer near the
+	// region before decoding rather than decoding from frame 0 and letting atrim
+	// discard everything ahead of start. The atrim window stays region-absolute,
+	// so the rendered PNG is unchanged (see regionSeekPreRoll). The whole-file
+	// path (bounds == nil) has no atrim and must decode from frame 0, so it stays
+	// seek-free. A nil debugLogger is a no-op sink for the non-fatal seek warning.
+	if bounds != nil {
+		var log debugLogger
+		seekReaderBeforeRegion(reader, time.Duration(bounds.Start*float64(time.Second)), log)
+	}
 
 	graph, srcCtx, sinkCtx, err := setupSpectrumGraph(reader.GetDecoderContext(), spectrogramFilterSpec(bounds))
 	if err != nil {

--- a/internal/processor/spectrogram_integration_test.go
+++ b/internal/processor/spectrogram_integration_test.go
@@ -93,8 +93,8 @@ func TestGenerateSpectrogramCancellation(t *testing.T) {
 	}
 }
 
-// TestGenerateSpectrogramDimensionParity (A3) renders a whole-file image and a
-// region image of the SAME input, decodes both, and asserts identical Dx()/Dy().
+// TestGenerateSpectrogramDimensionParity renders a whole-file image and a region
+// image of the SAME input, decodes both, and asserts identical Dx()/Dy().
 // The frozen s=1024x512 plus the fixed legend make dimensions content- and
 // duration-independent, so the before/after pair always matches pixel-for-pixel
 // in size.

--- a/internal/processor/spectrogram_paths.go
+++ b/internal/processor/spectrogram_paths.go
@@ -3,9 +3,8 @@ package processor
 import "path/filepath"
 
 // Spectrogram kind and stage constants. The path suffix convention is
-// `<stem-basename>.spectrogram-<kind>-<stage>.png` (proposal §1 "Naming"). These
-// are the single source of truth for the strings T3.2 (renderer) and T4
-// (generator) reuse - no scattered literals.
+// `<stem-basename>.spectrogram-<kind>-<stage>.png`. These are the single source of
+// truth for the strings the renderer and generator reuse - no scattered literals.
 const (
 	// SpectrogramKindWhole is the whole-file spectrogram, always rendered.
 	SpectrogramKindWhole = "whole"
@@ -50,10 +49,10 @@ func DeriveSpectrogramImages(rec *RunRecord, outputStem string, stages []string)
 
 // deriveSpectrogramImages returns the deterministic spectrogram image list for a
 // run. It is PURE: no I/O, no ffmpeg - only the record's elected-region presence
-// and the output stem drive the result. The renderer (T3.2) links these paths and
-// the generator (T4) fills them.
+// and the output stem drive the result. The renderer links these paths and the
+// generator fills them.
 //
-// Rules (proposal §1, plan T3.1):
+// Rules:
 //   - whole: always present.
 //   - roomtone: only when a room-tone profile is elected.
 //   - speech: only when a speech profile is elected.

--- a/internal/processor/spectrogram_paths_test.go
+++ b/internal/processor/spectrogram_paths_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// outputStem mirrors the processing stem derivation (pool.go:113):
+// outputStem mirrors the processing stem derivation in pool.go:
 // strings.TrimSuffix(OutputPath, filepath.Ext(OutputPath)). The derivation stores
 // filepath.Base of this, so a directory prefix must not leak into the Path.
 const testOutputStem = "/tmp/out/episode-LUFS-16-processed"

--- a/internal/processor/spectrogram_test.go
+++ b/internal/processor/spectrogram_test.go
@@ -78,7 +78,7 @@ func TestSpectrogramRegistryGate(t *testing.T) {
 //
 //   - nil bounds   → the bare frozen spec (whole file, no atrim, full stream).
 //   - bounds set   → atrim=start=%f:duration=%f,asetpts=PTS-STARTPTS, prepended,
-//     mirroring outputRegionAnalysisFilterFormat (analyser_output.go:18) with the
+//     mirroring outputRegionAnalysisFilterFormat (analyser_output.go) with the
 //     astats,… tail swapped for showspectrumpic=<frozen>.
 func TestSpectrogramFilterSpecBranches(t *testing.T) {
 	t.Run("nil_bounds_whole_file", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestSpectrogramFilterSpecBranches(t *testing.T) {
 	t.Run("bounds_prepend_atrim", func(t *testing.T) {
 		b := &regionBounds{Start: 12.5, Duration: 3.25}
 		got := spectrogramFilterSpec(b)
-		// Same %f seconds formatting as outputRegionAnalysisFilterFormat.
+		// Same %f seconds formatting as outputRegionAnalysisFilterFormat (analyser_output.go).
 		want := fmt.Sprintf(
 			"atrim=start=%f:duration=%f,asetpts=PTS-STARTPTS,showspectrumpic=%s",
 			b.Start, b.Duration, frozenSpectrogramSpec,
@@ -144,8 +144,8 @@ func TestSpectrogramFilterSpecDeterministic(t *testing.T) {
 // Pure-string, always runs. The render side of this contract (the frozen params
 // reaching ffmpeg unchanged) is exercised by the render tests below.
 func TestSpectrogramFrozenParamSingleDefinition(t *testing.T) {
-	// The constant carries the load-bearing terms (decision #8); assert the spec
-	// embeds it verbatim rather than re-deriving any term per call.
+	// The constant carries the load-bearing terms; assert the spec embeds it
+	// verbatim rather than re-deriving any term per call.
 	for _, c := range []*regionBounds{nil, {Start: 5, Duration: 3}} {
 		spec := spectrogramFilterSpec(c)
 		if !strings.Contains(spec, frozenSpectrogramSpec) {
@@ -161,7 +161,7 @@ func TestSpectrogramFrozenParamSingleDefinition(t *testing.T) {
 // ---------------------------------------------------------------------------
 // 2b. RenderSpectrogramImage source/bounds resolution (pure mapping, no ffmpeg,
 //     no testdata). The render itself is exercised by section 3; here the
-//     source-file and region-bounds resolution rules (T4.1) are pinned.
+//     source-file and region-bounds resolution rules are pinned.
 // ---------------------------------------------------------------------------
 
 // TestSpectrogramSourceResolution pins the stage→source-file mapping: before and

--- a/internal/report/definitions.go
+++ b/internal/report/definitions.go
@@ -138,14 +138,6 @@ var Definitions = map[string]Definition{
 		Unit:  "",
 		Gloss: "Fraction of sample pairs that change sign, zero_crossings/N.",
 	},
-	// Catalogued but not yet rendered: no report section emits this key. The
-	// data key is a live JSON struct tag in analyser.go; the gloss is kept ready
-	// for a future renderer.
-	"zero_crossings_count": {
-		Label: "Zero-crossings count",
-		Unit:  "count",
-		Gloss: "Number of sample pairs that change sign.",
-	},
 	"bit_depth": {
 		Label: "Bit depth",
 		Unit:  "bits",
@@ -156,41 +148,6 @@ var Definitions = map[string]Definition{
 		Unit:  "",
 		Gloss: "Magnitude-weighted spectral entropy, -sum(mag*ln(mag+eps))/ln(N); for astats stages, the sample-value distribution entropy.",
 	},
-	// Catalogued but not yet rendered: no report section emits the keys in this
-	// group. noise_floor_count and number_of_samples are live JSON struct tags
-	// in analyser.go; the astats *_difference keys are authored for forward use.
-	// Glosses are kept ready for a future renderer.
-	"noise_floor_count": {
-		Label: "Noise-floor count",
-		Unit:  "count",
-		Gloss: "Number of samples at or below the measured noise-floor level (astats).",
-	},
-	"number_of_samples": {
-		Label: "Number of samples",
-		Unit:  "count",
-		Gloss: "Count of samples in the measured stream (astats).",
-	},
-	"max_difference": {
-		Label: "Max difference",
-		Unit:  "",
-		Gloss: "Largest absolute difference between two consecutive samples (astats).",
-	},
-	"min_difference": {
-		Label: "Min difference",
-		Unit:  "",
-		Gloss: "Smallest absolute difference between two consecutive samples (astats).",
-	},
-	"mean_difference": {
-		Label: "Mean difference",
-		Unit:  "",
-		Gloss: "Mean absolute difference between consecutive samples (astats).",
-	},
-	"rms_difference": {
-		Label: "RMS difference",
-		Unit:  "",
-		Gloss: "RMS of the absolute differences between consecutive samples (astats).",
-	},
-
 	// -------------------------------------------------------------------------
 	// Spectral (aspectralstats, the 13 fields)
 	// -------------------------------------------------------------------------
@@ -416,9 +373,7 @@ var Definitions = map[string]Definition{
 // requiredKeys is the set of RunRecord field names the loudness, dynamics, and
 // spectral sections emit and that MUST have a definition. The renderers and the
 // completeness test assert every key here resolves in Definitions; a missing
-// entry fails the test. Authored (not in the reference doc) keys are the astats
-// *_difference, noise_floor_count, and number_of_samples fields, defined
-// minimally and factually above.
+// entry fails the test.
 var requiredKeys = []string{
 	// Loudness
 	"integrated_lufs",

--- a/internal/report/definitions.go
+++ b/internal/report/definitions.go
@@ -12,7 +12,7 @@ package report
 // Risk: definition drift. If a metric's computation, unit, or key changes in the
 // reference or the record schema, update the matching entry here. The
 // required-key test (definitions_test.go) fails when a renderer-needed key has no
-// definition, but it cannot detect a stale gloss, keep this file aligned with
+// definition, but it cannot detect a stale gloss. Keep this file aligned with
 // the reference by hand.
 //
 // Glosses are OBJECTIVE: what the metric is and, in brief, how it is computed. No

--- a/internal/report/format.go
+++ b/internal/report/format.go
@@ -11,12 +11,25 @@ import (
 // formatters in mdtable.go build on top of this rule.
 const placeholder = "-"
 
+// nonFiniteToken reports whether value is a non-finite float the formatters
+// render as the placeholder, returning the placeholder and true when so. infSign
+// selects which infinities count: 0 catches both directions, +1 catches only
+// +Inf (the dB/LUFS formatters treat -Inf as a measurable digital-silence floor,
+// not a placeholder). NaN always counts. Every float formatter guards through
+// this so the placeholder rule stays in one place.
+func nonFiniteToken(value float64, infSign int) (string, bool) {
+	if math.IsNaN(value) || math.IsInf(value, infSign) {
+		return placeholder, true
+	}
+	return "", false
+}
+
 // formatFloat renders a float64 leaf to a cell string. Non-finite values
 // (NaN, +Inf, -Inf) map to the stable placeholder; finite values format with
 // the given number of decimal places.
 func formatFloat(v float64, decimals int) string {
-	if math.IsNaN(v) || math.IsInf(v, 0) {
-		return placeholder
+	if token, ok := nonFiniteToken(v, 0); ok {
+		return token
 	}
 	return strconv.FormatFloat(v, 'f', decimals, 64)
 }

--- a/internal/report/mdtable.go
+++ b/internal/report/mdtable.go
@@ -93,8 +93,8 @@ func isDigitalSilence(value float64) bool {
 // notation for very small non-zero magnitudes (< 0.0001), the placeholder for
 // NaN/Inf, otherwise fixed decimals.
 func formatMetric(value float64, decimals int) string {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
-		return placeholder
+	if token, ok := nonFiniteToken(value, 0); ok {
+		return token
 	}
 	if value != 0 && math.Abs(value) < 0.0001 {
 		return fmt.Sprintf("%.2e", value)
@@ -105,8 +105,8 @@ func formatMetric(value float64, decimals int) string {
 // formatMetricDB formats a dB value, rendering "< -120" for digital silence
 // (-Inf or at/below the floor) and the placeholder for NaN/+Inf.
 func formatMetricDB(value float64, decimals int) string {
-	if math.IsNaN(value) || math.IsInf(value, 1) {
-		return placeholder
+	if token, ok := nonFiniteToken(value, 1); ok {
+		return token
 	}
 	if isDigitalSilence(value) {
 		return "< -120"
@@ -117,8 +117,8 @@ func formatMetricDB(value float64, decimals int) string {
 // formatMetricLUFS formats a LUFS value, rendering "< -70" below the ebur128
 // measurement floor and the placeholder for NaN/+Inf.
 func formatMetricLUFS(value float64, decimals int) string {
-	if math.IsNaN(value) || math.IsInf(value, 1) {
-		return placeholder
+	if token, ok := nonFiniteToken(value, 1); ok {
+		return token
 	}
 	if value < lufsMeasurementFloor {
 		return "< -70"
@@ -129,8 +129,8 @@ func formatMetricLUFS(value float64, decimals int) string {
 // formatMetricSigned formats a value with an explicit sign for positives (e.g.
 // "+2.5"), and the placeholder for NaN/Inf.
 func formatMetricSigned(value float64, decimals int) string {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
-		return placeholder
+	if token, ok := nonFiniteToken(value, 0); ok {
+		return token
 	}
 	return fmt.Sprintf("%+.*f", decimals, value)
 }

--- a/internal/report/mdtable_test.go
+++ b/internal/report/mdtable_test.go
@@ -80,7 +80,7 @@ func TestEscapeCellPassThrough(t *testing.T) {
 	}
 }
 
-// TestIsDigitalSilence pins the legacy threshold semantics (table.go:131): -Inf
+// TestIsDigitalSilence pins the isDigitalSilence threshold semantics: -Inf
 // or at/below -120 dBFS is digital silence.
 func TestIsDigitalSilence(t *testing.T) {
 	cases := []struct {
@@ -102,7 +102,7 @@ func TestIsDigitalSilence(t *testing.T) {
 }
 
 // TestFormatMetricDB pins the "< -120" digital-silence rendering and the
-// placeholder for NaN/+Inf (table.go:158).
+// placeholder for NaN/+Inf in formatMetricDB.
 func TestFormatMetricDB(t *testing.T) {
 	cases := []struct {
 		in   float64
@@ -123,7 +123,7 @@ func TestFormatMetricDB(t *testing.T) {
 	}
 }
 
-// TestFormatMetricLUFS pins the "< -70" measurement-floor rendering (table.go:174).
+// TestFormatMetricLUFS pins the "< -70" measurement-floor rendering in formatMetricLUFS.
 func TestFormatMetricLUFS(t *testing.T) {
 	cases := []struct {
 		in   float64
@@ -150,8 +150,8 @@ func TestFormatMetricSpectral(t *testing.T) {
 	}
 }
 
-// TestFormatMetricScientific pins the scientific-notation path for very small
-// non-zero magnitudes (table.go:148).
+// TestFormatMetricScientific pins the scientific-notation path in formatMetric for
+// very small non-zero magnitudes.
 func TestFormatMetricScientific(t *testing.T) {
 	if got := formatMetric(0.00001, 4); got != "1.00e-05" {
 		t.Errorf("formatMetric(0.00001) = %q, want %q", got, "1.00e-05")
@@ -161,7 +161,7 @@ func TestFormatMetricScientific(t *testing.T) {
 	}
 }
 
-// TestFormatMetricSigned pins explicit-sign rendering (table.go:219).
+// TestFormatMetricSigned pins explicit-sign rendering in formatMetricSigned.
 func TestFormatMetricSigned(t *testing.T) {
 	cases := []struct {
 		in   float64
@@ -179,8 +179,7 @@ func TestFormatMetricSigned(t *testing.T) {
 	}
 }
 
-// TestFormatDuration pins the legacy human-readable duration output
-// (report_common.go:45).
+// TestFormatDuration pins the human-readable duration output of formatDuration.
 func TestFormatDuration(t *testing.T) {
 	cases := []struct {
 		in   time.Duration
@@ -199,7 +198,7 @@ func TestFormatDuration(t *testing.T) {
 	}
 }
 
-// TestChannelName pins the legacy channel-name output (report_common.go:63).
+// TestChannelName pins the channel-name output of channelName.
 func TestChannelName(t *testing.T) {
 	cases := []struct {
 		in   int

--- a/internal/report/metricrow.go
+++ b/internal/report/metricrow.go
@@ -1,0 +1,159 @@
+package report
+
+// This file holds the metric-table engine shared by the metric-domain section
+// renderers (loudness, dynamics, spectral, region samples): the per-stage row
+// shape, the stage getter factory, the format-rule dispatch, and the table
+// builder. The leaf section renderers in sections.go supply rows; this engine
+// turns them into Markdown.
+//
+// The metric tables share one shape: column 0 Metric (label), column 1 the
+// objective definition gloss + unit, then one value column per present stage
+// (Input/Filtered/Final). The Filtered and Final columns are omitted when their
+// stage pointer is nil (analysis-only / Pass-1-only records carry Input only).
+//
+// Input and output stages are DIFFERENT Go types (e.g. loudness input is
+// *InputLoudnessMetrics, filtered/final are *OutputLoudnessMetrics) that share
+// JSON field names. Each metric row pulls its value from whichever stage struct
+// is present via a small per-stage closure, so the type split stays local to the
+// row definition and the table builder sees only formatted strings.
+
+// metricFormat selects which formatMetric* rule a row uses, matching the unit
+// semantics the legacy .log formatters applied per metric class.
+type metricFormat int
+
+const (
+	fmtDB       metricFormat = iota // dB / dBFS levels: "< -120" digital-silence floor
+	fmtLUFS                         // LUFS loudness: "< -70" measurement floor
+	fmtPeakDB                       // dBTP true peak: dB scale, digital-silence floor
+	fmtSpectral                     // dimensionless / Hz spectral + astats values
+	fmtSigned                       // explicit-sign values (target offset)
+)
+
+// metricRow defines one table row: the RunRecord field key (for its definition)
+// the formatting rule, and per-stage value getters. A getter returns the metric
+// value and whether the stage carries it; a nil getter (or a getter reporting
+// false) leaves the cell as the placeholder. The value-vs-stage-type split lives
+// in the getter closures the section renderers supply.
+type metricRow struct {
+	key    string
+	format metricFormat
+	input  func() (float64, bool)
+	filt   func() (float64, bool)
+	final  func() (float64, bool)
+}
+
+// stageColumns reports which of Filtered/Final any row populates, so a renderer
+// can omit absent stage columns wholesale (analysis-only carries Input only).
+func stageColumns(rows []metricRow) (hasFiltered, hasFinal bool) {
+	for i := range rows {
+		if rows[i].filt != nil {
+			hasFiltered = true
+		}
+		if rows[i].final != nil {
+			hasFinal = true
+		}
+	}
+	return hasFiltered, hasFinal
+}
+
+// stageGetter builds a metricRow value getter for one stage struct: a nil stage
+// yields a nil getter (formatCell renders the placeholder), otherwise the getter
+// reads the metric off the stage and reports it present. It folds the nil-guarded
+// closure factory the section renderers share across their stage types.
+func stageGetter[T any](s *T, f func(*T) float64) func() (float64, bool) {
+	if s == nil {
+		return nil
+	}
+	return func() (float64, bool) { return f(s), true }
+}
+
+// formatCell formats one stage value through the row's metric rule, returning the
+// placeholder when the stage is absent (getter nil or reporting false).
+func formatCell(getter func() (float64, bool), format metricFormat) string {
+	if getter == nil {
+		return placeholder
+	}
+	value, ok := getter()
+	if !ok {
+		return placeholder
+	}
+	decimals := 2
+	if format == fmtSpectral {
+		decimals = 4
+	}
+	return formatByRule(value, format, decimals)
+}
+
+// formatByRule dispatches a value to the formatter named by the metric rule,
+// passing the caller-chosen decimal count. It holds the single format->formatter
+// mapping shared by formatCell and loudnormValueCell; the callers own the decimal
+// count (formatCell uses 4 for spectral, 2 otherwise; loudnormValueCell uses 2).
+func formatByRule(value float64, format metricFormat, decimals int) string {
+	switch format {
+	case fmtDB, fmtPeakDB:
+		return formatMetricDB(value, decimals)
+	case fmtLUFS:
+		return formatMetricLUFS(value, decimals)
+	case fmtSpectral:
+		return formatMetric(value, decimals)
+	case fmtSigned:
+		return formatMetricSigned(value, decimals)
+	default:
+		return formatMetric(value, decimals)
+	}
+}
+
+// renderMetricTable builds a metric table: Metric | Definition | Input
+// [| Filtered] [| Final]. The Filtered/Final columns are omitted when no row
+// populates them. Each row's second column carries the definition gloss and unit
+// from Definitions, so every metric row is self-describing.
+func renderMetricTable(rows []metricRow) string {
+	hasFiltered, hasFinal := stageColumns(rows)
+
+	headers := []string{"Metric", "Definition", "Input"}
+	if hasFiltered {
+		headers = append(headers, "Filtered")
+	}
+	if hasFinal {
+		headers = append(headers, "Final")
+	}
+
+	body := make([][]string, 0, len(rows))
+	for i := range rows {
+		row := &rows[i]
+		cells := []string{metricLabel(row.key), metricDefinition(row.key), formatCell(row.input, row.format)}
+		if hasFiltered {
+			cells = append(cells, formatCell(row.filt, row.format))
+		}
+		if hasFinal {
+			cells = append(cells, formatCell(row.final, row.format))
+		}
+		body = append(body, cells)
+	}
+
+	return mdTable(headers, body)
+}
+
+// metricLabel returns the human-readable label for a key, falling back to the raw
+// key when no definition exists (a missing definition is caught by the
+// required-key test, not here).
+func metricLabel(key string) string {
+	if d, ok := DefinitionFor(key); ok {
+		return d.Label
+	}
+	return key
+}
+
+// metricDefinition returns the objective gloss with its unit appended in
+// parentheses, e.g. "Gated programme loudness... (LUFS)". Unit-less metrics omit
+// the parenthetical. Every loudness/dynamics/spectral row carries this gloss.
+func metricDefinition(key string) string {
+	d, ok := DefinitionFor(key)
+	if !ok {
+		return placeholder
+	}
+	if d.Unit == "" {
+		return d.Gloss
+	}
+	return d.Gloss + " (" + d.Unit + ")"
+}

--- a/internal/report/sections.go
+++ b/internal/report/sections.go
@@ -835,8 +835,8 @@ func renderFilterDiagnostics(d *processor.AdaptiveDiagnostics) string {
 }
 
 // afftdnNoiseFloorCell renders the afftdn nf value, showing the placeholder when
-// unset (zero or non-negative). A set floor is always negative.
-// The value is the VAD momentary-LUFS percentile floor, re-clamped to afftdn's [-80, -20] dB range.
+// unset (zero or non-negative). A set floor is always negative. The value is the
+// VAD momentary-LUFS percentile floor, re-clamped to afftdn's [-80, -20] dB range.
 func afftdnNoiseFloorCell(floor float64) string {
 	if floor >= 0 {
 		return placeholder

--- a/internal/report/sections.go
+++ b/internal/report/sections.go
@@ -8,181 +8,13 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
-// paramRow is one Parameter | Value row for the filter and normalisation tables.
-// Those blocks render configuration values keyed by static descriptive labels
-// (fixed-design statements, not metric-definition glosses), so they use this
-// flat shape rather than the metricRow/Definitions machinery the loudness,
-// dynamics, and spectral tables use.
-type paramRow struct {
-	label string
-	value string
-}
-
-// renderParamTable builds a Parameter | Value table from param rows.
-func renderParamTable(rows []paramRow) string {
-	body := make([][]string, 0, len(rows))
-	for _, r := range rows {
-		body = append(body, []string{r.label, r.value})
-	}
-	return mdTable([]string{"Parameter", "Value"}, body)
-}
-
 // This file holds the per-domain section renderers: Header, Processing Summary,
-// Loudness, Dynamics, Spectral, and the rest. Each is a pure func(...) string
-// reading ONLY the run record (and Timings for the summary) - no
-// AudioMeasurements, no .json re-read, no internal/logging.
-//
-// The metric tables share one shape: column 0 Metric (label), column 1 the
-// objective definition gloss + unit, then one value column per present stage
-// (Input/Filtered/Final). The Filtered and Final columns are omitted when their
-// stage pointer is nil (analysis-only / Pass-1-only records carry Input only).
-//
-// Input and output stages are DIFFERENT Go types (e.g. loudness input is
-// *InputLoudnessMetrics, filtered/final are *OutputLoudnessMetrics) that share
-// JSON field names. Each metric row pulls its value from whichever stage struct
-// is present via a small per-stage closure, so the type split stays local to the
-// row definition and the table builder sees only formatted strings.
-
-// metricFormat selects which formatMetric* rule a row uses, matching the unit
-// semantics the legacy .log formatters applied per metric class.
-type metricFormat int
-
-const (
-	fmtDB       metricFormat = iota // dB / dBFS levels: "< -120" digital-silence floor
-	fmtLUFS                         // LUFS loudness: "< -70" measurement floor
-	fmtPeakDB                       // dBTP true peak: dB scale, digital-silence floor
-	fmtSpectral                     // dimensionless / Hz spectral + astats values
-	fmtSigned                       // explicit-sign values (target offset)
-)
-
-// metricRow defines one table row: the RunRecord field key (for its definition)
-// the formatting rule, and per-stage value getters. A getter returns the metric
-// value and whether the stage carries it; a nil getter (or a getter reporting
-// false) leaves the cell as the placeholder. The value-vs-stage-type split lives
-// in the getter closures the section renderers supply.
-type metricRow struct {
-	key    string
-	format metricFormat
-	input  func() (float64, bool)
-	filt   func() (float64, bool)
-	final  func() (float64, bool)
-}
-
-// stageColumns reports which of Filtered/Final any row populates, so a renderer
-// can omit absent stage columns wholesale (analysis-only carries Input only).
-func stageColumns(rows []metricRow) (hasFiltered, hasFinal bool) {
-	for i := range rows {
-		if rows[i].filt != nil {
-			hasFiltered = true
-		}
-		if rows[i].final != nil {
-			hasFinal = true
-		}
-	}
-	return hasFiltered, hasFinal
-}
-
-// stageGetter builds a metricRow value getter for one stage struct: a nil stage
-// yields a nil getter (formatCell renders the placeholder), otherwise the getter
-// reads the metric off the stage and reports it present. It folds the nil-guarded
-// closure factory the section renderers share across their stage types.
-func stageGetter[T any](s *T, f func(*T) float64) func() (float64, bool) {
-	if s == nil {
-		return nil
-	}
-	return func() (float64, bool) { return f(s), true }
-}
-
-// formatCell formats one stage value through the row's metric rule, returning the
-// placeholder when the stage is absent (getter nil or reporting false).
-func formatCell(getter func() (float64, bool), format metricFormat) string {
-	if getter == nil {
-		return placeholder
-	}
-	value, ok := getter()
-	if !ok {
-		return placeholder
-	}
-	decimals := 2
-	if format == fmtSpectral {
-		decimals = 4
-	}
-	return formatByRule(value, format, decimals)
-}
-
-// formatByRule dispatches a value to the formatter named by the metric rule,
-// passing the caller-chosen decimal count. It holds the single format->formatter
-// mapping shared by formatCell and parseLoudnormCell; the callers own the decimal
-// count (formatCell uses 4 for spectral, 2 otherwise; parseLoudnormCell uses 2).
-func formatByRule(value float64, format metricFormat, decimals int) string {
-	switch format {
-	case fmtDB, fmtPeakDB:
-		return formatMetricDB(value, decimals)
-	case fmtLUFS:
-		return formatMetricLUFS(value, decimals)
-	case fmtSpectral:
-		return formatMetric(value, decimals)
-	case fmtSigned:
-		return formatMetricSigned(value, decimals)
-	default:
-		return formatMetric(value, decimals)
-	}
-}
-
-// renderMetricTable builds a metric table: Metric | Definition | Input
-// [| Filtered] [| Final]. The Filtered/Final columns are omitted when no row
-// populates them. Each row's second column carries the definition gloss and unit
-// from Definitions, so every metric row is self-describing.
-func renderMetricTable(rows []metricRow) string {
-	hasFiltered, hasFinal := stageColumns(rows)
-
-	headers := []string{"Metric", "Definition", "Input"}
-	if hasFiltered {
-		headers = append(headers, "Filtered")
-	}
-	if hasFinal {
-		headers = append(headers, "Final")
-	}
-
-	body := make([][]string, 0, len(rows))
-	for i := range rows {
-		row := &rows[i]
-		cells := []string{metricLabel(row.key), metricDefinition(row.key), formatCell(row.input, row.format)}
-		if hasFiltered {
-			cells = append(cells, formatCell(row.filt, row.format))
-		}
-		if hasFinal {
-			cells = append(cells, formatCell(row.final, row.format))
-		}
-		body = append(body, cells)
-	}
-
-	return mdTable(headers, body)
-}
-
-// metricLabel returns the human-readable label for a key, falling back to the raw
-// key when no definition exists (a missing definition is caught by the
-// required-key test, not here).
-func metricLabel(key string) string {
-	if d, ok := DefinitionFor(key); ok {
-		return d.Label
-	}
-	return key
-}
-
-// metricDefinition returns the objective gloss with its unit appended in
-// parentheses, e.g. "Gated programme loudness... (LUFS)". Unit-less metrics omit
-// the parenthetical. Every loudness/dynamics/spectral row carries this gloss.
-func metricDefinition(key string) string {
-	d, ok := DefinitionFor(key)
-	if !ok {
-		return placeholder
-	}
-	if d.Unit == "" {
-		return d.Gloss
-	}
-	return d.Gloss + " (" + d.Unit + ")"
-}
+// Loudness, Dynamics, Spectral, Noise Floor, Regions, and Interval Summary. Each
+// is a pure func(...) string reading ONLY the run record (and Timings for the
+// summary) - no AudioMeasurements, no .json re-read, no internal/logging. The
+// metric-table engine lives in metricrow.go; the filter/normalisation and
+// spectrogram renderers live in sections_filters.go and
+// sections_spectrograms.go.
 
 // =============================================================================
 // Header
@@ -412,19 +244,18 @@ func renderNoiseFloor(rec *processor.RunRecord) string {
 	}
 
 	rows := [][]string{
-		valueRow("floor_dbfs", formatMetricDB(n.Floor, 2)),
+		metricValueRow("floor_dbfs", n.Floor),
 		{metricLabel("floor_source"), metricDefinition("floor_source"), stringCell(n.FloorSource)},
-		valueRow("floor_prescan_dbfs", formatMetricDB(n.FloorPrescan, 2)),
-		valueRow("floor_astats_dbfs", formatMetricDB(n.FloorAstats, 2)),
-		valueRow("room_tone_detect_level_dbfs", formatMetricDB(n.RoomToneDetectLevel, 2)),
+		metricValueRow("floor_prescan_dbfs", n.FloorPrescan),
+		metricValueRow("floor_astats_dbfs", n.FloorAstats),
+		metricValueRow("room_tone_detect_level_dbfs", n.RoomToneDetectLevel),
 		{metricLabel("voice_activated"), metricDefinition("voice_activated"), boolCell(n.VoiceActivated)},
+		// reduction_headroom_db (unit "dB") renders through formatMetric, not the
+		// formatMetricDB its unit would select; keep it explicit.
 		valueRow("reduction_headroom_db", formatMetric(n.ReductionHeadroom, 2)),
 	}
 
-	var b strings.Builder
-	b.WriteString("## Noise Floor\n\n")
-	b.WriteString(mdTable([]string{"Metric", "Definition", "Value"}, rows))
-	return b.String()
+	return renderValueTable("## Noise Floor\n\n", rows)
 }
 
 // =============================================================================
@@ -483,16 +314,13 @@ func renderGateStatistics(g *processor.GateStatistics) string {
 	}
 
 	rows := [][]string{
-		valueRow("voiced_low_percentile_dbfs", formatMetricDB(g.VoicedLowPercentile, 2)),
-		valueRow("noise_high_percentile_dbfs", formatMetricDB(g.NoiseHighPercentile, 2)),
+		metricValueRow("voiced_low_percentile_dbfs", g.VoicedLowPercentile),
+		metricValueRow("noise_high_percentile_dbfs", g.NoiseHighPercentile),
+		// gate_separation_db (unit "dB") renders through formatMetric; keep it explicit.
 		valueRow("gate_separation_db", formatMetric(g.SeparationDB, 2)),
 	}
 
-	var b strings.Builder
-	b.WriteString("### Gate Statistics\n\n")
-	b.WriteString(mdTable([]string{"Metric", "Definition", "Value"}, rows))
-	b.WriteString("\n")
-	return b.String()
+	return renderValueTable("### Gate Statistics\n\n", rows)
 }
 
 // renderRoomToneElected renders the elected room-tone NoiseProfile metrics as a
@@ -504,22 +332,20 @@ func renderRoomToneElected(p *processor.NoiseProfile) string {
 	}
 
 	rows := [][]string{
+		// start_s / duration_s (unit "s") render through formatFloat; keep them explicit.
 		valueRow("start_s", formatFloat(p.Start.Seconds(), 2)),
 		valueRow("duration_s", formatFloat(p.Duration.Seconds(), 2)),
-		valueRow("measured_floor_dbfs", formatMetricDB(p.MeasuredNoiseFloor, 2)),
-		valueRow("peak_level_dbfs", formatMetricDB(p.PeakLevel, 2)),
+		metricValueRow("measured_floor_dbfs", p.MeasuredNoiseFloor),
+		metricValueRow("peak_level_dbfs", p.PeakLevel),
+		// crest_factor_db (unit "dB") renders through formatMetric; keep it explicit.
 		valueRow("crest_factor_db", formatMetric(p.CrestFactor, 2)),
-		valueRow("entropy", formatMetric(p.Entropy, 4)),
-		valueRow("spectral_centroid_hz", formatMetric(p.SpectralCentroid, 2)),
-		valueRow("spectral_flatness", formatMetric(p.SpectralFlatness, 4)),
-		valueRow("spectral_kurtosis", formatMetric(p.SpectralKurtosis, 4)),
+		metricValueRow("entropy", p.Entropy),
+		metricValueRow("spectral_centroid_hz", p.Spectral.Centroid),
+		metricValueRow("spectral_flatness", p.Spectral.Flatness),
+		metricValueRow("spectral_kurtosis", p.Spectral.Kurtosis),
 	}
 
-	var b strings.Builder
-	b.WriteString("**Elected profile**\n\n")
-	b.WriteString(mdTable([]string{"Metric", "Definition", "Value"}, rows))
-	b.WriteString("\n")
-	return b.String()
+	return renderValueTable("**Elected profile**\n\n", rows)
 }
 
 // renderSpeechElected renders the elected speech-candidate metrics (region length,
@@ -531,25 +357,23 @@ func renderSpeechElected(p *processor.SpeechCandidateMetrics) string {
 	}
 
 	rows := [][]string{
+		// duration_s (unit "s") renders through formatFloat; keep it explicit.
 		valueRow("duration_s", formatFloat(p.Region.Duration.Seconds(), 2)),
-		valueRow("rms_level_dbfs", formatMetricDB(p.RMSLevel, 2)),
-		valueRow("peak_level_dbfs", formatMetricDB(p.PeakLevel, 2)),
+		metricValueRow("rms_level_dbfs", p.RMSLevel),
+		metricValueRow("peak_level_dbfs", p.PeakLevel),
+		// crest_factor_db (unit "dB") renders through formatMetric; keep it explicit.
 		valueRow("crest_factor_db", formatMetric(p.CrestFactor, 2)),
-		valueRow("momentary_lufs", formatMetricLUFS(p.MomentaryLUFS, 2)),
-		valueRow("short_term_lufs", formatMetricLUFS(p.ShortTermLUFS, 2)),
-		valueRow("true_peak_dbtp", formatMetricDB(p.TruePeak, 2)),
-		valueRow("sample_peak_dbfs", formatMetricDB(p.SamplePeak, 2)),
-		valueRow("speech_band_body_rms_dbfs", formatMetricDB(p.BodyBandRMS, 2)),
-		valueRow("speech_band_sib_rms_dbfs", formatMetricDB(p.SibBandRMS, 2)),
-		valueRow("voicing_density", formatMetric(p.VoicingDensity, 4)),
-		valueRow("score", formatMetric(p.Score, 4)),
+		metricValueRow("momentary_lufs", p.MomentaryLUFS),
+		metricValueRow("short_term_lufs", p.ShortTermLUFS),
+		metricValueRow("true_peak_dbtp", p.TruePeak),
+		metricValueRow("sample_peak_dbfs", p.SamplePeak),
+		metricValueRow("speech_band_body_rms_dbfs", p.BodyBandRMS),
+		metricValueRow("speech_band_sib_rms_dbfs", p.SibBandRMS),
+		metricValueRow("voicing_density", p.VoicingDensity),
+		metricValueRow("score", p.Score),
 	}
 
-	var b strings.Builder
-	b.WriteString("**Elected profile**\n\n")
-	b.WriteString(mdTable([]string{"Metric", "Definition", "Value"}, rows))
-	b.WriteString("\n")
-	return b.String()
+	return renderValueTable("**Elected profile**\n\n", rows)
 }
 
 // renderCandidatesSummary renders the bare candidate summary: the evaluated count
@@ -646,33 +470,79 @@ func renderIntervalSummary(rec *processor.RunRecord) string {
 	}
 	if s.RMS != nil {
 		rows = append(rows,
-			valueRow("rms_dist_min_dbfs", formatMetricDB(s.RMS.Min, 2)),
-			valueRow("rms_dist_p10_dbfs", formatMetricDB(s.RMS.P10, 2)),
-			valueRow("rms_dist_p25_dbfs", formatMetricDB(s.RMS.P25, 2)),
-			valueRow("rms_dist_p50_dbfs", formatMetricDB(s.RMS.P50, 2)),
-			valueRow("rms_dist_p75_dbfs", formatMetricDB(s.RMS.P75, 2)),
-			valueRow("rms_dist_p90_dbfs", formatMetricDB(s.RMS.P90, 2)),
-			valueRow("rms_dist_max_dbfs", formatMetricDB(s.RMS.Max, 2)),
+			metricValueRow("rms_dist_min_dbfs", s.RMS.Min),
+			metricValueRow("rms_dist_p10_dbfs", s.RMS.P10),
+			metricValueRow("rms_dist_p25_dbfs", s.RMS.P25),
+			metricValueRow("rms_dist_p50_dbfs", s.RMS.P50),
+			metricValueRow("rms_dist_p75_dbfs", s.RMS.P75),
+			metricValueRow("rms_dist_p90_dbfs", s.RMS.P90),
+			metricValueRow("rms_dist_max_dbfs", s.RMS.Max),
 		)
 	}
 	if s.LargestGapDB != nil {
+		// largest_gap_db (unit "dB") renders through formatMetric; keep it explicit.
 		rows = append(rows, valueRow("largest_gap_db", formatMetric(*s.LargestGapDB, 2)))
 	}
 
-	var b strings.Builder
-	b.WriteString("## Interval Summary\n\n")
-	b.WriteString(mdTable([]string{"Metric", "Definition", "Value"}, rows))
-	return b.String()
+	return renderValueTable("## Interval Summary\n\n", rows)
 }
 
 // =============================================================================
 // Region/summary cell helpers
 // =============================================================================
 
+// renderValueTable builds a single-stage Metric | Definition | Value table under
+// the given heading, with a trailing blank line. It owns the header literal, the
+// builder, and the newline the five single-stage renderers (noise floor, gate
+// statistics, room-tone/speech elected, interval summary) shared verbatim.
+func renderValueTable(heading string, rows [][]string) string {
+	var b strings.Builder
+	b.WriteString(heading)
+	b.WriteString(mdTable([]string{"Metric", "Definition", "Value"}, rows))
+	b.WriteString("\n")
+	return b.String()
+}
+
 // valueRow builds a three-cell Metric | Definition | Value row for a single-stage
 // table, looking up the label and gloss from Definitions by key.
 func valueRow(key, value string) []string {
 	return []string{metricLabel(key), metricDefinition(key), value}
+}
+
+// metricValueRow builds a single-stage value row, formatting the float through
+// formatByRule keyed off the key's catalogued Unit so the formatter choice is not
+// re-encoded per call site. It covers the unit classes whose single-stage cells
+// route cleanly through formatByRule: dBFS/dBTP (formatMetricDB), LUFS
+// (formatMetricLUFS), and Hz / unit-less (formatMetric). Decimals follow the unit
+// (4 for unit-less spectral ratios, 2 otherwise), matching every existing cell.
+// Rows on other units (plain "dB" through formatMetric, "s" through formatFloat)
+// keep their explicit formatter at the call site; routing them here would change
+// the rendered bytes.
+func metricValueRow(key string, value float64) []string {
+	format, decimals := unitMetricFormat(key)
+	return valueRow(key, formatByRule(value, format, decimals))
+}
+
+// unitMetricFormat maps a metric key's catalogued Unit to the formatByRule rule
+// and decimal count for its single-stage cell. It is defined only for the unit
+// classes metricValueRow routes; an unhandled unit panics so a new single-stage
+// row cannot silently mis-format (the caller picks an explicit formatter instead).
+func unitMetricFormat(key string) (metricFormat, int) {
+	d, _ := DefinitionFor(key)
+	switch d.Unit {
+	case "dBFS":
+		return fmtDB, 2
+	case "dBTP":
+		return fmtPeakDB, 2
+	case "LUFS":
+		return fmtLUFS, 2
+	case "Hz":
+		return fmtSpectral, 2
+	case "":
+		return fmtSpectral, 4
+	default:
+		panic("report: metricValueRow: unrouted unit " + d.Unit + " for key " + key)
+	}
 }
 
 // stringCell renders a categorical string value, the placeholder when empty.
@@ -694,343 +564,4 @@ func boolCell(b bool) string {
 // formatInt renders an integer count cell.
 func formatInt(n int) string {
 	return strconv.Itoa(n)
-}
-
-// =============================================================================
-// Filter Chain
-// =============================================================================
-
-// renderFilters renders the Pass-2 filter chain in PROCESSING ORDER (downmix →
-// high-pass → low-pass → noise removal → gate → levelling compressor → de-esser), one
-// Parameter/Value sub-table per filter, plus the adaptive diagnostics block. Each
-// filter's heading carries the factual fixed-design label (e.g. "Rumble high-pass:
-// 80 Hz, 12 dB/oct") as a STATIC descriptive statement, not a per-file verdict;
-// the rows carry the per-file parameters off filters.<filter>.*. The gate
-// threshold_db/range_db are already dB-converted at record assembly
-// (newFiltersBlock), so they render as-is. Reads only rec.Filters. Returns the
-// empty string when the record carries no filters block (analysis-only).
-func renderFilters(rec *processor.RunRecord) string {
-	f := rec.Filters
-	if f == nil {
-		return ""
-	}
-
-	var b strings.Builder
-	b.WriteString("## Filter Chain\n\n")
-
-	b.WriteString("### Downmix\n\n")
-	b.WriteString("Stereo-to-mono downmix using FFmpeg's standard downmix matrix.\n\n")
-
-	b.WriteString("### Rumble high-pass\n\n")
-	b.WriteString("Removes subsonic rumble before the gate. Fixed corner, 2-pole Butterworth (12 dB/oct), non-adaptive.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.RumbleHighPass.Enabled)},
-		{"Frequency (Hz)", formatMetric(f.RumbleHighPass.Frequency, 0)},
-		{"Poles", formatInt(f.RumbleHighPass.Poles)},
-		{"Width (Q)", formatMetric(f.RumbleHighPass.Width, 3)},
-		{"Mix", formatMetric(f.RumbleHighPass.Mix, 2)},
-		{"Transform", stringCell(f.RumbleHighPass.Transform)},
-	}))
-	b.WriteString("\n")
-
-	b.WriteString("### Band-limit low-pass\n\n")
-	b.WriteString("Unconditional 20.5 kHz band-limit (2-pole, 12 dB/oct), giving the encoder a consistent bandwidth. Non-adaptive.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.BandlimitLowPass.Enabled)},
-		{"Frequency (Hz)", formatMetric(f.BandlimitLowPass.Frequency, 0)},
-		{"Poles", formatInt(f.BandlimitLowPass.Poles)},
-		{"Width (Q)", formatMetric(f.BandlimitLowPass.Width, 3)},
-		{"Mix", formatMetric(f.BandlimitLowPass.Mix, 2)},
-		{"Transform", stringCell(f.BandlimitLowPass.Transform)},
-	}))
-	b.WriteString("\n")
-
-	b.WriteString("### Noise removal\n\n")
-	b.WriteString("anlmdn Non-Local Means denoiser at the source rate, followed by an afftdn FFT spectral denoise tail.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.NoiseReduction.Enabled)},
-		{"Strength (s)", formatMetric(f.NoiseReduction.Strength, 5)},
-		{"Patch (s)", formatMetric(f.NoiseReduction.PatchSec, 4)},
-		{"Research (s)", formatMetric(f.NoiseReduction.ResearchSec, 4)},
-		{"Smooth (m)", formatMetric(f.NoiseReduction.Smooth, 0)},
-		{"afftdn enabled", boolCell(f.NoiseReduction.AfftdnEnabled)},
-		{"afftdn noise reduction (dB)", formatMetric(f.NoiseReduction.AfftdnNoiseReduction, 0)},
-		{"afftdn noise floor (dB)", afftdnNoiseFloorCell(f.NoiseReduction.AfftdnNoiseFloor)},
-		{"afftdn noise type", stringCell(f.NoiseReduction.AfftdnNoiseType)},
-		{"afftdn band noise", stringCell(f.NoiseReduction.AfftdnBandNoise)},
-		{"afftdn track noise", boolCell(f.NoiseReduction.AfftdnTrackNoise)},
-	}))
-	b.WriteString("\n")
-
-	b.WriteString("### Speech gate\n\n")
-	b.WriteString("Soft expander for inter-speech cleanup. Threshold and range are adapted per file; the threshold and range values below are in dB.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.SpeechGate.Enabled)},
-		{"Threshold (dB)", formatMetric(f.SpeechGate.Threshold, 2)},
-		{"Ratio", formatMetric(f.SpeechGate.Ratio, 1)},
-		{"Attack (ms)", formatMetric(f.SpeechGate.Attack, 0)},
-		{"Release (ms)", formatMetric(f.SpeechGate.Release, 0)},
-		{"Range (dB)", formatMetric(f.SpeechGate.Range, 2)},
-		{"Knee", formatMetric(f.SpeechGate.Knee, 1)},
-		{"Makeup", formatMetric(f.SpeechGate.Makeup, 1)},
-		{"Detection", stringCell(f.SpeechGate.Detection)},
-	}))
-	b.WriteString("\n")
-
-	b.WriteString("### Levelling compressor\n\n")
-	b.WriteString("Gentle levelling. Threshold is speech-RMS-relative (adapted per file); ratio, attack, release, knee are fixed.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.LevellingCompressor.Enabled)},
-		{"Threshold (dB)", formatMetric(f.LevellingCompressor.Threshold, 2)},
-		{"Ratio", formatMetric(f.LevellingCompressor.Ratio, 1)},
-		{"Attack (ms)", formatMetric(f.LevellingCompressor.Attack, 0)},
-		{"Release (ms)", formatMetric(f.LevellingCompressor.Release, 0)},
-		{"Makeup (dB)", formatMetric(f.LevellingCompressor.Makeup, 1)},
-		{"Knee", formatMetric(f.LevellingCompressor.Knee, 1)},
-		{"Mix", formatMetric(f.LevellingCompressor.Mix, 2)},
-	}))
-	b.WriteString("\n")
-
-	b.WriteString("### De-esser\n\n")
-	b.WriteString("Sibilance reduction. Intensity is adapted from the speech-region sibilant-band excess; amount and frequency are fixed (FFmpeg deesser 0-1 normalised params).\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.Deesser.Enabled)},
-		{"Intensity (i)", formatMetric(f.Deesser.Intensity, 2)},
-		{"Amount (m)", formatMetric(f.Deesser.Amount, 2)},
-		{"Frequency (f)", formatMetric(f.Deesser.Frequency, 2)},
-	}))
-	b.WriteString("\n")
-
-	b.WriteString(renderFilterDiagnostics(f.Diagnostics))
-
-	return b.String()
-}
-
-// renderFilterDiagnostics renders the adaptive-adaptation rationale from
-// filters.diagnostics.* as objective values (separation, clamp reason, gate
-// depth, etc.) - no verdicts. Returns the empty string when no diagnostics
-// block is present.
-func renderFilterDiagnostics(d *processor.AdaptiveDiagnostics) string {
-	if d == nil {
-		return ""
-	}
-
-	var b strings.Builder
-	b.WriteString("### Adaptation diagnostics\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Low-pass reason", stringCell(d.BandlimitLPReason)},
-		{"Gate dynamic range (dB)", formatMetric(d.SpeechGateDynamicRange, 2)},
-		{"Quiet-speech estimate (dBFS)", formatMetricDB(d.SpeechGateQuietSpeechEstimate, 2)},
-		{"Speech separation (dB)", formatMetric(d.SpeechGateSpeechSeparation, 2)},
-		{"Speech headroom (dB)", formatMetric(d.SpeechGateSpeechHeadroom, 2)},
-		{"Gate threshold unclamped (dB)", formatMetric(d.SpeechGateThresholdUnclamped, 2)},
-		{"Clamp reason", stringCell(d.SpeechGateClampReason)},
-		{"Gate depth (dB)", formatMetric(d.SpeechGateDepthDB, 2)},
-		{"afftdn enabled", boolCell(d.AfftdnEnabled)},
-		{"afftdn noise floor (dB)", afftdnNoiseFloorCell(d.AfftdnNoiseFloorDB)},
-		{"afftdn noise type", stringCell(d.AfftdnNoiseType)},
-		{"afftdn disable reason", stringCell(d.AfftdnDisableReason)},
-	}))
-	return b.String()
-}
-
-// afftdnNoiseFloorCell renders the afftdn nf value, showing the placeholder when
-// unset (zero or non-negative). A set floor is always negative. The value is the
-// VAD momentary-LUFS percentile floor, re-clamped to afftdn's [-80, -20] dB range.
-func afftdnNoiseFloorCell(floor float64) string {
-	if floor >= 0 {
-		return placeholder
-	}
-	return formatMetric(floor, 2)
-}
-
-// =============================================================================
-// Normalisation (Peak Limiter + Loudnorm)
-// =============================================================================
-
-// renderNormalisation renders the Pass 3/4 Peak Limiter and Loudnorm numbers from
-// normalisation.*. Reads the wrapped *NormalisationResult via the record's
-// Result() read seam (the wrapper type is unexported, like the elected-profile
-// seams in renderRegions). Returns the empty string when the record carries no
-// normalisation block (analysis-only).
-//
-// within_target is rendered as a RAW SIGNED LU deviation number, NOT a
-// "✓ Within target / ⚠ Outside tolerance" boolean: it
-// is output_integrated_lufs (the loudnorm-measured output, normalisation.
-// loudnorm_measured.output_integrated_lufs, parsed from LoudnormStats.OutputI)
-// minus normalisation.effective_target_lufs (EffectiveTargetI), formatted via
-// formatMetricSigned. No glyph, no boolean.
-func renderNormalisation(rec *processor.RunRecord) string {
-	r := rec.Normalisation.Result()
-	if r == nil {
-		return ""
-	}
-
-	var b strings.Builder
-	b.WriteString("## Peak Limiter\n\n")
-	b.WriteString("Transparent limiter that creates true-peak headroom so loudnorm reaches the target in linear mode. Pre-gain raises very quiet recordings before limiting.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(r.LimiterEnabled)},
-		{"Ceiling (dBTP)", formatMetricDB(r.LimiterCeiling, 2)},
-		{"Gain required (dB)", formatMetric(r.LimiterGain, 2)},
-		{"Filtered true peak (dBTP)", formatMetricDB(r.LimiterFilteredTP, 2)},
-		{"Pre-gain (dB)", formatMetric(r.PreGainDB, 2)},
-		{"Ceiling clamped", boolCell(r.LimiterClamped)},
-	}))
-	b.WriteString("\n")
-
-	b.WriteString("## Loudnorm\n\n")
-	b.WriteString("EBU R128 loudness normalisation in linear mode using the Pass-3 measured input statistics.\n\n")
-	rows := []paramRow{
-		{"Requested target (LUFS)", formatMetricLUFS(r.RequestedTargetI, 2)},
-		{"Effective target (LUFS)", formatMetricLUFS(r.EffectiveTargetI, 2)},
-		{"Gain applied (dB)", formatMetric(r.GainApplied, 2)},
-		{"Linear mode forced", boolCell(r.LinearModeForced)},
-		{"Input loudness (LUFS)", formatMetricLUFS(r.InputLUFS, 2)},
-		{"Input true peak (dBTP)", formatMetricDB(r.InputTP, 2)},
-		{"Output loudness (LUFS)", formatMetricLUFS(r.OutputLUFS, 2)},
-		{"Output true peak (dBTP)", formatMetricDB(r.OutputTP, 2)},
-	}
-	if stats := r.LoudnormStats; stats != nil {
-		rows = append(rows,
-			paramRow{"Measured input integrated (LUFS)", parseLoudnormCell(stats.InputI, fmtLUFS)},
-			paramRow{"Measured input true peak (dBTP)", parseLoudnormCell(stats.InputTP, fmtPeakDB)},
-			paramRow{"Measured input LRA (LU)", parseLoudnormCell(stats.InputLRA, fmtSpectral)},
-			paramRow{"Measured input threshold (LUFS)", parseLoudnormCell(stats.InputThresh, fmtLUFS)},
-			paramRow{"Measured output integrated (LUFS)", parseLoudnormCell(stats.OutputI, fmtLUFS)},
-			paramRow{"Measured output true peak (dBTP)", parseLoudnormCell(stats.OutputTP, fmtPeakDB)},
-			paramRow{"Measured output LRA (LU)", parseLoudnormCell(stats.OutputLRA, fmtSpectral)},
-			paramRow{"Measured output threshold (LUFS)", parseLoudnormCell(stats.OutputThresh, fmtLUFS)},
-			paramRow{"Normalisation type", stringCell(stats.NormalizationType)},
-		)
-	}
-	// Raw signed LU deviation from the effective target: the loudnorm-measured
-	// output integrated loudness minus the effective target. A signed number,
-	// never a boolean or glyph.
-	rows = append(rows, paramRow{"Deviation from target (LU)", targetDeviationCell(r)})
-	b.WriteString(renderParamTable(rows))
-
-	return b.String()
-}
-
-// targetDeviationCell computes the raw signed LU deviation of the loudnorm-measured
-// output integrated loudness from the effective target:
-// output_integrated_lufs (parsed from LoudnormStats.OutputI) minus
-// effective_target_lufs. Returns the placeholder when the measured output value is
-// missing or unparseable, so the cell never fabricates a deviation.
-func targetDeviationCell(r *processor.NormalisationResult) string {
-	if r.LoudnormStats == nil {
-		return placeholder
-	}
-	out, err := strconv.ParseFloat(strings.TrimSpace(r.LoudnormStats.OutputI), 64)
-	if err != nil {
-		return placeholder
-	}
-	return formatMetricSigned(out-r.EffectiveTargetI, 2)
-}
-
-// parseLoudnormCell parses a loudnorm stats string value and formats it through
-// the given metric rule, returning the placeholder on a parse failure (graceful:
-// the cell never fabricates a value).
-func parseLoudnormCell(value string, format metricFormat) string {
-	f, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
-	if err != nil {
-		return placeholder
-	}
-	return formatByRule(f, format, 2)
-}
-
-// =============================================================================
-// Spectrograms
-// =============================================================================
-
-// spectrogramKindOrder is the stable kind order for the Spectrograms table
-// (whole-file first, then the two elected regions). Each kind carries the row
-// label shown in column 0.
-var spectrogramKindOrder = []struct {
-	kind  string
-	label string
-}{
-	{processor.SpectrogramKindWhole, "Whole file"},
-	{processor.SpectrogramKindRoomTone, "Room tone"},
-	{processor.SpectrogramKindSpeech, "Speech"},
-}
-
-// spectrogramStageOrder is the stable stage (column) order. Processing records
-// carry before+after; analysis-only records carry input only. A column is
-// emitted only when at least one image populates it, mirroring the absent-stage
-// convention the metric tables use (renderLoudness etc.).
-var spectrogramStageOrder = []struct {
-	stage  string
-	header string
-}{
-	{processor.SpectrogramStageBefore, "Before"},
-	{processor.SpectrogramStageAfter, "After"},
-	{processor.SpectrogramStageInput, "Input"},
-}
-
-// renderSpectrograms renders the Spectrograms section from rec.Spectrograms ONLY:
-// a Markdown table grouped by kind (whole -> roomtone -> speech) with one column
-// per present stage. Processing records yield a Before | After pair per kind;
-// analysis-only records yield a single Input column. Cells are Markdown image
-// links to the record's relative basenames (![<kind> <stage>](<path>)). This
-// renderer is a PURE record consumer - it reads the slice and builds Markdown,
-// never calling ffmpeg/exec. An empty slice returns "" so the orchestrator emits
-// no heading, matching the empty-section discipline the other renderers follow.
-func renderSpectrograms(rec *processor.RunRecord) string {
-	if len(rec.Spectrograms) == 0 {
-		return ""
-	}
-
-	// Index the images by kind+stage for stable, order-independent lookup.
-	type key struct{ kind, stage string }
-	byKey := make(map[key]processor.SpectrogramImage, len(rec.Spectrograms))
-	present := make(map[string]bool)
-	for _, img := range rec.Spectrograms {
-		byKey[key{img.Kind, img.Stage}] = img
-		present[img.Stage] = true
-	}
-
-	// Columns: keep only stages that at least one image populates.
-	stages := make([]struct{ stage, header string }, 0, len(spectrogramStageOrder))
-	for _, s := range spectrogramStageOrder {
-		if present[s.stage] {
-			stages = append(stages, s)
-		}
-	}
-
-	headers := make([]string, 0, len(stages)+1)
-	headers = append(headers, "Region")
-	for _, s := range stages {
-		headers = append(headers, s.header)
-	}
-
-	body := make([][]string, 0, len(spectrogramKindOrder))
-	for _, k := range spectrogramKindOrder {
-		row := []string{k.label}
-		any := false
-		for _, s := range stages {
-			img, ok := byKey[key{k.kind, s.stage}]
-			if !ok {
-				row = append(row, placeholder)
-				continue
-			}
-			any = true
-			row = append(row, spectrogramCell(k.kind, s.stage, img.Path))
-		}
-		if any {
-			body = append(body, row)
-		}
-	}
-
-	var b strings.Builder
-	b.WriteString("## Spectrograms\n\n")
-	b.WriteString(mdTable(headers, body))
-	return b.String()
-}
-
-// spectrogramCell renders one Markdown image link to a relative basename:
-// ![<kind> <stage>](<path>).
-func spectrogramCell(kind, stage, path string) string {
-	return "![" + kind + " " + stage + "](" + path + ")"
 }

--- a/internal/report/sections.go
+++ b/internal/report/sections.go
@@ -836,6 +836,7 @@ func renderFilterDiagnostics(d *processor.AdaptiveDiagnostics) string {
 
 // afftdnNoiseFloorCell renders the afftdn nf value, showing the placeholder when
 // unset (zero or non-negative). A set floor is always negative.
+// The value is the VAD momentary-LUFS percentile floor, re-clamped to afftdn's [-80, -20] dB range.
 func afftdnNoiseFloorCell(floor float64) string {
 	if floor >= 0 {
 		return placeholder

--- a/internal/report/sections_filters.go
+++ b/internal/report/sections_filters.go
@@ -1,0 +1,271 @@
+package report
+
+import (
+	"strings"
+
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+// This file holds the filter-chain and normalisation renderers: the Pass-2
+// filter prose/param tables, the adaptive diagnostics block, and the Pass-3/4
+// Peak Limiter + Loudnorm numbers. They share the flat paramRow shape (static
+// descriptive labels keyed to configuration values, not metric-definition
+// glosses), so they live together on the filter/normalisation change axis.
+
+// paramRow is one Parameter | Value row for the filter and normalisation tables.
+// Those blocks render configuration values keyed by static descriptive labels
+// (fixed-design statements, not metric-definition glosses), so they use this
+// flat shape rather than the metricRow/Definitions machinery the loudness,
+// dynamics, and spectral tables use.
+type paramRow struct {
+	label string
+	value string
+}
+
+// renderParamTable builds a Parameter | Value table from param rows.
+func renderParamTable(rows []paramRow) string {
+	body := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		body = append(body, []string{r.label, r.value})
+	}
+	return mdTable([]string{"Parameter", "Value"}, body)
+}
+
+// =============================================================================
+// Filter Chain
+// =============================================================================
+
+// renderFilters renders the Pass-2 filter chain in PROCESSING ORDER (downmix →
+// high-pass → low-pass → noise removal → gate → levelling compressor → de-esser), one
+// Parameter/Value sub-table per filter, plus the adaptive diagnostics block. Each
+// filter's heading carries the factual fixed-design label (e.g. "Rumble high-pass:
+// 80 Hz, 12 dB/oct") as a STATIC descriptive statement, not a per-file verdict;
+// the rows carry the per-file parameters off filters.<filter>.*. The gate
+// threshold_db/range_db are already dB-converted at record assembly
+// (newFiltersBlock), so they render as-is. Reads only rec.Filters. Returns the
+// empty string when the record carries no filters block (analysis-only).
+func renderFilters(rec *processor.RunRecord) string {
+	f := rec.Filters
+	if f == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Filter Chain\n\n")
+
+	b.WriteString("### Downmix\n\n")
+	b.WriteString("Stereo-to-mono downmix using FFmpeg's standard downmix matrix.\n\n")
+
+	b.WriteString("### Rumble high-pass\n\n")
+	b.WriteString("Removes subsonic rumble before the gate. Fixed corner, 2-pole Butterworth (12 dB/oct), non-adaptive.\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Enabled", boolCell(f.RumbleHighPass.Enabled)},
+		{"Frequency (Hz)", formatMetric(f.RumbleHighPass.Frequency, 0)},
+		{"Poles", formatInt(f.RumbleHighPass.Poles)},
+		{"Width (Q)", formatMetric(f.RumbleHighPass.Width, 3)},
+		{"Mix", formatMetric(f.RumbleHighPass.Mix, 2)},
+		{"Transform", stringCell(f.RumbleHighPass.Transform)},
+	}))
+	b.WriteString("\n")
+
+	b.WriteString("### Band-limit low-pass\n\n")
+	b.WriteString("Unconditional 20.5 kHz band-limit (2-pole, 12 dB/oct), giving the encoder a consistent bandwidth. Non-adaptive.\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Enabled", boolCell(f.BandlimitLowPass.Enabled)},
+		{"Frequency (Hz)", formatMetric(f.BandlimitLowPass.Frequency, 0)},
+		{"Poles", formatInt(f.BandlimitLowPass.Poles)},
+		{"Width (Q)", formatMetric(f.BandlimitLowPass.Width, 3)},
+		{"Mix", formatMetric(f.BandlimitLowPass.Mix, 2)},
+		{"Transform", stringCell(f.BandlimitLowPass.Transform)},
+	}))
+	b.WriteString("\n")
+
+	b.WriteString("### Noise removal\n\n")
+	b.WriteString("anlmdn Non-Local Means denoiser at the source rate, followed by an afftdn FFT spectral denoise tail.\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Enabled", boolCell(f.NoiseReduction.Enabled)},
+		{"Strength (s)", formatMetric(f.NoiseReduction.Strength, 5)},
+		{"Patch (s)", formatMetric(f.NoiseReduction.PatchSec, 4)},
+		{"Research (s)", formatMetric(f.NoiseReduction.ResearchSec, 4)},
+		{"Smooth (m)", formatMetric(f.NoiseReduction.Smooth, 0)},
+		{"afftdn enabled", boolCell(f.NoiseReduction.AfftdnEnabled)},
+		{"afftdn noise reduction (dB)", formatMetric(f.NoiseReduction.AfftdnNoiseReduction, 0)},
+		{"afftdn noise floor (dB)", afftdnNoiseFloorCell(f.NoiseReduction.AfftdnNoiseFloor)},
+		{"afftdn noise type", stringCell(f.NoiseReduction.AfftdnNoiseType)},
+		{"afftdn band noise", stringCell(f.NoiseReduction.AfftdnBandNoise)},
+		{"afftdn track noise", boolCell(f.NoiseReduction.AfftdnTrackNoise)},
+	}))
+	b.WriteString("\n")
+
+	b.WriteString("### Speech gate\n\n")
+	b.WriteString("Soft expander for inter-speech cleanup. Threshold and range are adapted per file; the threshold and range values below are in dB.\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Enabled", boolCell(f.SpeechGate.Enabled)},
+		{"Threshold (dB)", formatMetric(f.SpeechGate.Threshold, 2)},
+		{"Ratio", formatMetric(f.SpeechGate.Ratio, 1)},
+		{"Attack (ms)", formatMetric(f.SpeechGate.Attack, 0)},
+		{"Release (ms)", formatMetric(f.SpeechGate.Release, 0)},
+		{"Range (dB)", formatMetric(f.SpeechGate.Range, 2)},
+		{"Knee", formatMetric(f.SpeechGate.Knee, 1)},
+		{"Makeup", formatMetric(f.SpeechGate.Makeup, 1)},
+		{"Detection", stringCell(f.SpeechGate.Detection)},
+	}))
+	b.WriteString("\n")
+
+	b.WriteString("### Levelling compressor\n\n")
+	b.WriteString("Gentle levelling. Threshold is speech-RMS-relative (adapted per file); ratio, attack, release, knee are fixed.\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Enabled", boolCell(f.LevellingCompressor.Enabled)},
+		{"Threshold (dB)", formatMetric(f.LevellingCompressor.Threshold, 2)},
+		{"Ratio", formatMetric(f.LevellingCompressor.Ratio, 1)},
+		{"Attack (ms)", formatMetric(f.LevellingCompressor.Attack, 0)},
+		{"Release (ms)", formatMetric(f.LevellingCompressor.Release, 0)},
+		{"Makeup (dB)", formatMetric(f.LevellingCompressor.Makeup, 1)},
+		{"Knee", formatMetric(f.LevellingCompressor.Knee, 1)},
+		{"Mix", formatMetric(f.LevellingCompressor.Mix, 2)},
+	}))
+	b.WriteString("\n")
+
+	b.WriteString("### De-esser\n\n")
+	b.WriteString("Sibilance reduction. Intensity is adapted from the speech-region sibilant-band excess; amount and frequency are fixed (FFmpeg deesser 0-1 normalised params).\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Enabled", boolCell(f.Deesser.Enabled)},
+		{"Intensity (i)", formatMetric(f.Deesser.Intensity, 2)},
+		{"Amount (m)", formatMetric(f.Deesser.Amount, 2)},
+		{"Frequency (f)", formatMetric(f.Deesser.Frequency, 2)},
+	}))
+	b.WriteString("\n")
+
+	b.WriteString(renderFilterDiagnostics(f.Diagnostics))
+
+	return b.String()
+}
+
+// renderFilterDiagnostics renders the adaptive-adaptation rationale from
+// filters.diagnostics.* as objective values (separation, clamp reason, gate
+// depth, etc.) - no verdicts. Returns the empty string when no diagnostics
+// block is present.
+func renderFilterDiagnostics(d *processor.AdaptiveDiagnostics) string {
+	if d == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("### Adaptation diagnostics\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Low-pass reason", stringCell(d.BandlimitLPReason)},
+		{"Gate dynamic range (dB)", formatMetric(d.SpeechGateDynamicRange, 2)},
+		{"Quiet-speech estimate (dBFS)", formatMetricDB(d.SpeechGateQuietSpeechEstimate, 2)},
+		{"Speech separation (dB)", formatMetric(d.SpeechGateSpeechSeparation, 2)},
+		{"Speech headroom (dB)", formatMetric(d.SpeechGateSpeechHeadroom, 2)},
+		{"Gate threshold unclamped (dB)", formatMetric(d.SpeechGateThresholdUnclamped, 2)},
+		{"Clamp reason", stringCell(d.SpeechGateClampReason)},
+		{"Gate depth (dB)", formatMetric(d.SpeechGateDepthDB, 2)},
+		{"afftdn enabled", boolCell(d.AfftdnEnabled)},
+		{"afftdn noise floor (dB)", afftdnNoiseFloorCell(d.AfftdnNoiseFloorDB)},
+		{"afftdn noise type", stringCell(d.AfftdnNoiseType)},
+		{"afftdn disable reason", stringCell(d.AfftdnDisableReason)},
+	}))
+	return b.String()
+}
+
+// afftdnNoiseFloorCell renders the afftdn nf value, showing the placeholder when
+// unset (zero or non-negative). A set floor is always negative. The value is the
+// VAD momentary-LUFS percentile floor, re-clamped to afftdn's [-80, -20] dB range.
+func afftdnNoiseFloorCell(floor float64) string {
+	if floor >= 0 {
+		return placeholder
+	}
+	return formatMetric(floor, 2)
+}
+
+// =============================================================================
+// Normalisation (Peak Limiter + Loudnorm)
+// =============================================================================
+
+// renderNormalisation renders the Pass 3/4 Peak Limiter and Loudnorm numbers from
+// normalisation.*. Reads the wrapped *NormalisationResult via the record's
+// Result() read seam (the wrapper type is unexported, like the elected-profile
+// seams in renderRegions). Returns the empty string when the record carries no
+// normalisation block (analysis-only).
+//
+// within_target is rendered as a RAW SIGNED LU deviation number, NOT a
+// "✓ Within target / ⚠ Outside tolerance" boolean: it
+// is output_integrated_lufs (the loudnorm-measured output) minus
+// normalisation.effective_target_lufs (EffectiveTargetI), precomputed at record
+// assembly (LoudnormParsed.TargetDeviation) and formatted via formatMetricSigned.
+// No glyph, no boolean.
+func renderNormalisation(rec *processor.RunRecord) string {
+	r := rec.Normalisation.Result()
+	if r == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Peak Limiter\n\n")
+	b.WriteString("Transparent limiter that creates true-peak headroom so loudnorm reaches the target in linear mode. Pre-gain raises very quiet recordings before limiting.\n\n")
+	b.WriteString(renderParamTable([]paramRow{
+		{"Enabled", boolCell(r.LimiterEnabled)},
+		{"Ceiling (dBTP)", formatMetricDB(r.LimiterCeiling, 2)},
+		{"Gain required (dB)", formatMetric(r.LimiterGain, 2)},
+		{"Filtered true peak (dBTP)", formatMetricDB(r.LimiterFilteredTP, 2)},
+		{"Pre-gain (dB)", formatMetric(r.PreGainDB, 2)},
+		{"Ceiling clamped", boolCell(r.LimiterClamped)},
+	}))
+	b.WriteString("\n")
+
+	b.WriteString("## Loudnorm\n\n")
+	b.WriteString("EBU R128 loudness normalisation in linear mode using the Pass-3 measured input statistics.\n\n")
+	rows := []paramRow{
+		{"Requested target (LUFS)", formatMetricLUFS(r.RequestedTargetI, 2)},
+		{"Effective target (LUFS)", formatMetricLUFS(r.EffectiveTargetI, 2)},
+		{"Gain applied (dB)", formatMetric(r.GainApplied, 2)},
+		{"Linear mode forced", boolCell(r.LinearModeForced)},
+		{"Input loudness (LUFS)", formatMetricLUFS(r.InputLUFS, 2)},
+		{"Input true peak (dBTP)", formatMetricDB(r.InputTP, 2)},
+		{"Output loudness (LUFS)", formatMetricLUFS(r.OutputLUFS, 2)},
+		{"Output true peak (dBTP)", formatMetricDB(r.OutputTP, 2)},
+	}
+	if m := r.LoudnormParsed; m != nil {
+		rows = append(rows,
+			paramRow{"Measured input integrated (LUFS)", loudnormValueCell(m.InputI, fmtLUFS)},
+			paramRow{"Measured input true peak (dBTP)", loudnormValueCell(m.InputTP, fmtPeakDB)},
+			paramRow{"Measured input LRA (LU)", loudnormValueCell(m.InputLRA, fmtSpectral)},
+			paramRow{"Measured input threshold (LUFS)", loudnormValueCell(m.InputThresh, fmtLUFS)},
+			paramRow{"Measured output integrated (LUFS)", loudnormValueCell(m.OutputI, fmtLUFS)},
+			paramRow{"Measured output true peak (dBTP)", loudnormValueCell(m.OutputTP, fmtPeakDB)},
+			paramRow{"Measured output LRA (LU)", loudnormValueCell(m.OutputLRA, fmtSpectral)},
+			paramRow{"Measured output threshold (LUFS)", loudnormValueCell(m.OutputThresh, fmtLUFS)},
+			paramRow{"Normalisation type", stringCell(r.LoudnormStats.NormalizationType)},
+		)
+	}
+	// Raw signed LU deviation from the effective target: the loudnorm-measured
+	// output integrated loudness minus the effective target. A signed number,
+	// never a boolean or glyph. Precomputed at record assembly (LoudnormParsed).
+	rows = append(rows, paramRow{"Deviation from target (LU)", targetDeviationCell(r)})
+	b.WriteString(renderParamTable(rows))
+
+	return b.String()
+}
+
+// targetDeviationCell renders the raw signed LU deviation of the loudnorm-measured
+// output integrated loudness from the effective target (output_integrated_lufs
+// minus effective_target_lufs), precomputed at record assembly. Returns the
+// placeholder when the deviation is unavailable (no stats or an unparseable
+// measured output), so the cell never fabricates a deviation.
+func targetDeviationCell(r *processor.NormalisationResult) string {
+	if r.LoudnormParsed == nil || !r.LoudnormParsed.TargetDeviation.OK {
+		return placeholder
+	}
+	return formatMetricSigned(r.LoudnormParsed.TargetDeviation.Value, 2)
+}
+
+// loudnormValueCell formats a typed loudnorm measurement through the given metric
+// rule, returning the placeholder when the value did not parse (graceful: the cell
+// never fabricates a value).
+func loudnormValueCell(v processor.LoudnormValue, format metricFormat) string {
+	if !v.OK {
+		return placeholder
+	}
+	return formatByRule(v.Value, format, 2)
+}

--- a/internal/report/sections_spectrograms.go
+++ b/internal/report/sections_spectrograms.go
@@ -1,0 +1,103 @@
+package report
+
+import (
+	"strings"
+
+	"github.com/linuxmatters/jivetalking/internal/processor"
+)
+
+// This file holds the Spectrograms section renderer: the kind/stage order tables
+// and the pure record-to-Markdown image-link builder. It is a separate change
+// axis from the metric and filter renderers - it reads rec.Spectrograms only and
+// emits image links, never numbers.
+
+// spectrogramKindOrder is the stable kind order for the Spectrograms table
+// (whole-file first, then the two elected regions). Each kind carries the row
+// label shown in column 0.
+var spectrogramKindOrder = []struct {
+	kind  string
+	label string
+}{
+	{processor.SpectrogramKindWhole, "Whole file"},
+	{processor.SpectrogramKindRoomTone, "Room tone"},
+	{processor.SpectrogramKindSpeech, "Speech"},
+}
+
+// spectrogramStageOrder is the stable stage (column) order. Processing records
+// carry before+after; analysis-only records carry input only. A column is
+// emitted only when at least one image populates it, mirroring the absent-stage
+// convention the metric tables use (renderLoudness etc.).
+var spectrogramStageOrder = []struct {
+	stage  string
+	header string
+}{
+	{processor.SpectrogramStageBefore, "Before"},
+	{processor.SpectrogramStageAfter, "After"},
+	{processor.SpectrogramStageInput, "Input"},
+}
+
+// renderSpectrograms renders the Spectrograms section from rec.Spectrograms ONLY:
+// a Markdown table grouped by kind (whole -> roomtone -> speech) with one column
+// per present stage. Processing records yield a Before | After pair per kind;
+// analysis-only records yield a single Input column. Cells are Markdown image
+// links to the record's relative basenames (![<kind> <stage>](<path>)). This
+// renderer is a PURE record consumer - it reads the slice and builds Markdown,
+// never calling ffmpeg/exec. An empty slice returns "" so the orchestrator emits
+// no heading, matching the empty-section discipline the other renderers follow.
+func renderSpectrograms(rec *processor.RunRecord) string {
+	if len(rec.Spectrograms) == 0 {
+		return ""
+	}
+
+	// Index the images by kind+stage for stable, order-independent lookup.
+	type key struct{ kind, stage string }
+	byKey := make(map[key]processor.SpectrogramImage, len(rec.Spectrograms))
+	present := make(map[string]bool)
+	for _, img := range rec.Spectrograms {
+		byKey[key{img.Kind, img.Stage}] = img
+		present[img.Stage] = true
+	}
+
+	// Columns: keep only stages that at least one image populates.
+	stages := make([]struct{ stage, header string }, 0, len(spectrogramStageOrder))
+	for _, s := range spectrogramStageOrder {
+		if present[s.stage] {
+			stages = append(stages, s)
+		}
+	}
+
+	headers := make([]string, 0, len(stages)+1)
+	headers = append(headers, "Region")
+	for _, s := range stages {
+		headers = append(headers, s.header)
+	}
+
+	body := make([][]string, 0, len(spectrogramKindOrder))
+	for _, k := range spectrogramKindOrder {
+		row := []string{k.label}
+		any := false
+		for _, s := range stages {
+			img, ok := byKey[key{k.kind, s.stage}]
+			if !ok {
+				row = append(row, placeholder)
+				continue
+			}
+			any = true
+			row = append(row, spectrogramCell(k.kind, s.stage, img.Path))
+		}
+		if any {
+			body = append(body, row)
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("## Spectrograms\n\n")
+	b.WriteString(mdTable(headers, body))
+	return b.String()
+}
+
+// spectrogramCell renders one Markdown image link to a relative basename:
+// ![<kind> <stage>](<path>).
+func spectrogramCell(kind, stage, path string) string {
+	return "![" + kind + " " + stage + "](" + path + ")"
+}

--- a/internal/report/sections_test.go
+++ b/internal/report/sections_test.go
@@ -258,9 +258,11 @@ func regionsRecord() *processor.RunRecord {
 		PeakLevel:          -71.22,
 		CrestFactor:        13.36,
 		Entropy:            0.0011,
-		SpectralCentroid:   8707.02,
-		SpectralFlatness:   0.8246,
-		SpectralKurtosis:   1.835,
+		Spectral: processor.SpectralMetrics{
+			Centroid: 8707.02,
+			Flatness: 0.8246,
+			Kurtosis: 1.835,
+		},
 	}
 	speech := processor.SpeechCandidateMetrics{
 		Region: processor.SpeechRegion{

--- a/internal/report/unit_format_test.go
+++ b/internal/report/unit_format_test.go
@@ -1,0 +1,46 @@
+package report
+
+import "testing"
+
+// TestUnitMetricFormat pins the unit-to-formatter routing in unitMetricFormat.
+// Each routed unit class is exercised through a real catalogued metric key so a
+// new key on an unrouted unit cannot silently mis-format, and the default branch
+// panic contract is asserted so a future unrouted unit fails loudly.
+func TestUnitMetricFormat(t *testing.T) {
+	cases := []struct {
+		name         string
+		key          string // a catalogued key whose Unit is the routed class
+		wantFormat   metricFormat
+		wantDecimals int
+	}{
+		{"dBFS", "rms_level_dbfs", fmtDB, 2},
+		{"dBTP", "true_peak_dbtp", fmtPeakDB, 2},
+		{"LUFS", "momentary_lufs", fmtLUFS, 2},
+		{"Hz", "centroid_hz", fmtSpectral, 2},
+		{"unit-less", "flatness", fmtSpectral, 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			format, decimals := unitMetricFormat(tc.key)
+			if format != tc.wantFormat {
+				t.Errorf("unitMetricFormat(%q) format = %d, want %d", tc.key, format, tc.wantFormat)
+			}
+			if decimals != tc.wantDecimals {
+				t.Errorf("unitMetricFormat(%q) decimals = %d, want %d", tc.key, decimals, tc.wantDecimals)
+			}
+		})
+	}
+}
+
+// TestUnitMetricFormatUnroutedPanics pins the default-branch panic contract: a
+// catalogued key on an unrouted unit (here "dB") must panic so it cannot reach a
+// silent mis-format. "crest_factor_astats_db" has Unit "dB", which the switch
+// does not route.
+func TestUnitMetricFormatUnroutedPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("unitMetricFormat on an unrouted unit did not panic")
+		}
+	}()
+	unitMetricFormat("crest_factor_astats_db")
+}

--- a/internal/report/write.go
+++ b/internal/report/write.go
@@ -1,8 +1,12 @@
 // Package report renders a processor.RunRecord into a Markdown report. It is a
 // clean break from the legacy .log formatters in internal/logging: it reads only
 // the in-memory run record (and optional run metadata via Timings), never the
-// .json artefact or AudioMeasurements, so a future .json -> .md re-render is a
-// thin adapter over RenderMarkdown.
+// .json artefact or AudioMeasurements. A .json -> .md re-render over RenderMarkdown
+// is currently PARTIAL, not a thin adapter: the elected-profile metric tables and
+// the normalisation (Peak Limiter + Loudnorm) sections do not survive an
+// encoding/json round-trip, because their wrappers hold an unexported src field and
+// apply unit conversions with no reversing UnmarshalJSON. TestRoundTripFromEmittedJSON
+// pins what survives and what does not.
 package report
 
 import (

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -95,20 +95,11 @@ func (m AnalysisModel) Init() tea.Cmd {
 
 // Update handles messages and updates the model
 func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if handled, cmd := handleCommonMsg(msg, &m.Width, &m.Height, &m.Done, &m.progress, analysisBarOverhead); handled {
+		return m, cmd
+	}
+
 	switch msg := msg.(type) {
-	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			return m, tea.Quit
-		}
-
-	case tea.WindowSizeMsg:
-		m.Width = msg.Width
-		m.Height = msg.Height
-		if msg.Width > 0 {
-			m.progress.SetWidth(progressWidthFor(msg.Width, analysisBarOverhead))
-		}
-
 	case AnalysisStartMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
 			m.Files[msg.FileIndex].FileName = filepath.Base(msg.FilePath)
@@ -135,10 +126,6 @@ func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
-
-	case AllCompleteMsg:
-		m.Done = true
-		return m, tea.Quit
 	}
 
 	return m, nil

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -34,7 +34,11 @@ type AnalysisModel struct {
 
 	// Global state
 	StartTime time.Time
-	Done      bool
+	// ElapsedTime is frozen from time.Since(StartTime) in Update on each progress
+	// message, so View stays a pure function of model state (no clock read at
+	// render). Mirrors FileProgress.ElapsedTime in the processing model.
+	ElapsedTime time.Duration
+	Done        bool
 
 	// Progress bar (owned by Update; rendered via ViewAs)
 	progress progress.Model
@@ -107,6 +111,7 @@ func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case AnalysisProgressMsg:
+		m.ElapsedTime = time.Since(m.StartTime)
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
 			m.Files[msg.FileIndex].Progress = msg.Progress
 			m.Files[msg.FileIndex].Level = msg.Level
@@ -163,7 +168,7 @@ func (m AnalysisModel) View() tea.View {
 	activeIcon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("∿")
 	doneStyle := lipgloss.NewStyle().Foreground(cli.ColorGreen)
 	errorStyle := lipgloss.NewStyle().Foreground(cli.ColorRed)
-	elapsed := time.Since(m.StartTime)
+	elapsed := m.ElapsedTime
 
 	for i := range m.Files {
 		f := &m.Files[i]

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -213,9 +213,9 @@ func renderAnalysisVerdict(m *processor.AudioMeasurements) string {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "   %s  %s  %s\n",
-		labelStyle.Render("Recording"), starStyle.Render(qualityStars(rec.Stars)), rec.Label)
+		labelStyle.Render("Recording"), starStyle.Render(QualityStars(rec.Stars)), rec.Label)
 	fmt.Fprintf(&b, "   %s  %s  %s\n",
-		labelStyle.Render("Gain     "), gainBar(m.Loudness.InputTP), advice.Message())
+		labelStyle.Render("Gain     "), GainBar(m.Loudness.InputTP), advice.Message())
 	return b.String()
 }
 

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -18,7 +18,7 @@ import (
 type analysisFileState struct {
 	FileName string
 	Progress float64 // 0.0 to 1.0
-	Level    float64 // Current audio level in dB
+	Level    float64 // Current audio level, raw decode dBFS axis (not a VAD output)
 	Done     bool
 	Err      error
 	Result   *processor.AnalysisResult

--- a/internal/ui/analysis_model_test.go
+++ b/internal/ui/analysis_model_test.go
@@ -105,7 +105,7 @@ func TestGainBarFill(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			n := countFilled(gainBar(tc.inputTP))
+			n := countFilled(GainBar(tc.inputTP))
 			if n < tc.minF || n > tc.maxF {
 				t.Errorf("inputTP=%.1f: %d filled cells, want [%d,%d]", tc.inputTP, n, tc.minF, tc.maxF)
 			}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -23,9 +23,12 @@ type FileStartMsg struct {
 	FileName  string
 }
 
-// FileCompleteMsg indicates a file has finished processing
-type FileCompleteMsg struct {
-	FileIndex  int
+// CompletionResult carries the per-file completion payload shared by
+// FileCompleteMsg (sent by the pool) and FileProgress (held by the model). Both
+// embed it so the model can copy the whole payload in one assignment; a field
+// added here reaches FileProgress without a matching copy line, and a dropped
+// copy becomes a compile error rather than a silent omission.
+type CompletionResult struct {
 	InputLUFS  float64
 	OutputLUFS float64
 	// FinalNoiseFloor is the output room-tone noise floor in dBFS (lower = cleaner),
@@ -59,6 +62,12 @@ type FileCompleteMsg struct {
 	// resets per pass.
 	ProcessingTime time.Duration
 	Error          error
+}
+
+// FileCompleteMsg indicates a file has finished processing
+type FileCompleteMsg struct {
+	FileIndex int
+	CompletionResult
 }
 
 // AdaptedSummaryMsg carries the filter-chain status view-model for a single file,

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -12,7 +12,7 @@ type ProgressMsg struct {
 	Pass         processor.PassNumber
 	PassName     string
 	Progress     float64
-	Level        float64
+	Level        float64 // raw decode-loop level (raw dBFS), not a VAD output
 	Duration     float64 // total audio length, seconds
 	Measurements *processor.AudioMeasurements
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -143,6 +143,15 @@ type FileProgress struct {
 	// (meter rows appear or disappear). Render-only state; the pool never touches it.
 	statusBoxCache statusBoxCache
 
+	// fileDetailsTitleCache memoises the spliced "Pass N/4" top-border line for the
+	// active-file Pass box (the renderFileDetails overlayBorderTitle call). The line
+	// depends only on (title, top-border width): the colour is fixed at
+	// cli.ColorSkyBlue for this site. The title is stable within a pass, so the strip
+	// + rune-slice + 3-render overlay work runs only when the pass number changes
+	// (new title) or the box width changes, not on every 60 fps frame. Render-only
+	// state; the pool never touches it.
+	fileDetailsTitleCache overlayTitleCache
+
 	// Processing statistics
 	CurrentLevel float64 // Current audio level in dB
 	PeakLevel    float64 // Peak level seen so far
@@ -184,6 +193,18 @@ type statusBoxCache struct {
 	joinHeight int
 	chain      string
 	analysis   string
+}
+
+// overlayTitleCache holds a memoised overlayBorderTitle result keyed on the inputs
+// that vary it: the title text and the rendered box's top-border width. valid guards
+// the zero-value (a genuine key of {"", 0}). line is the spliced first border line.
+// The colour is not part of the key: this cache serves a single-colour call site
+// (cli.ColorSkyBlue), so colour never varies.
+type overlayTitleCache struct {
+	valid bool
+	title string
+	width int
+	line  string
 }
 
 // Model is the Bubbletea model for the processing UI

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -49,6 +49,38 @@ func progressWidthFor(termWidth, overhead int) int {
 	return w
 }
 
+// handleCommonMsg processes the messages both Update methods treat identically:
+// the quit keys ("q"/"ctrl+c"), WindowSizeMsg (store dimensions + clamp the
+// progress width via progressWidthFor with the caller's chrome overhead), and
+// AllCompleteMsg (mark done + quit). It mutates the shared fields through
+// pointers and returns handled=true when it owned the message, so each Update
+// can return early; per-model messages fall through with handled=false to the
+// model's own switch. Kept to the genuinely-identical block: the models share no
+// struct shape, only these four fields.
+func handleCommonMsg(msg tea.Msg, width, height *int, done *bool, prog *progress.Model, overhead int) (handled bool, cmd tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			return true, tea.Quit
+		}
+
+	case tea.WindowSizeMsg:
+		*width = msg.Width
+		*height = msg.Height
+		if msg.Width > 0 {
+			prog.SetWidth(progressWidthFor(msg.Width, overhead))
+		}
+		return true, nil
+
+	case AllCompleteMsg:
+		*done = true
+		return true, tea.Quit
+	}
+
+	return false, nil
+}
+
 // meterFPS is the spring step rate for the eased audio level meter (~60fps).
 const meterFPS = 60
 
@@ -103,9 +135,8 @@ const (
 
 // FileProgress tracks progress for a single audio file
 type FileProgress struct {
-	InputPath  string
-	OutputPath string
-	Status     FileStatus
+	InputPath string
+	Status    FileStatus
 
 	// Phase tracking
 	CurrentPass processor.PassNumber
@@ -115,11 +146,6 @@ type FileProgress struct {
 	Progress    float64 // 0.0 to 1.0
 	StartTime   time.Time
 	ElapsedTime time.Duration
-
-	// ProcessingTime is the total wall-clock time across all four passes, plumbed
-	// from the pool via FileCompleteMsg. ElapsedTime resets per pass, so the
-	// done-box Time row uses this instead.
-	ProcessingTime time.Duration
 
 	// Duration is the total audio length in seconds (constant per file; the
 	// first non-zero value is kept). Drives the realtime-speed badge.
@@ -156,31 +182,11 @@ type FileProgress struct {
 	CurrentLevel float64 // Current audio level in dB
 	PeakLevel    float64 // Peak level seen so far
 
-	// Completion results
-	InputLUFS  float64
-	OutputLUFS float64
-	// FinalNoiseFloor is the output room-tone noise floor in dBFS (lower = cleaner),
-	// shown in the done box and aligned with the quality score's noise component.
-	// InputNoiseFloor is the input room-tone floor on the same astats RMS dBFS axis;
-	// the done box shows the input->output pair. The Have* flags gate each end.
-	FinalNoiseFloor     float64
-	InputNoiseFloor     float64
-	HaveFinalNoiseFloor bool
-	HaveInputNoiseFloor bool
-	// OutputTP / OutputLRA are the post-normalisation true peak (dBTP) and loudness
-	// range (LU), surfaced from NormResult at the pool send site. Paired with
-	// Summary.TruePeakDBTP / Summary.InputLRA they drive the done-box True peak and
-	// Dynamics before→after rows.
-	OutputTP  float64
-	OutputLRA float64
-	// Quality is the OUTPUT (Processed) score; RecordingQuality is the INPUT
-	// (Recording) source-capture score. The done box shows both, Recording above
-	// Processed.
-	Quality          processor.QualityScore
-	RecordingQuality processor.QualityScore
-
-	// Error tracking
-	Error error
+	// Completion results, copied wholesale from FileCompleteMsg.CompletionResult.
+	// Carries the done-box numbers (InputLUFS/OutputLUFS, noise floors and their
+	// Have* gates, OutputTP/OutputLRA, the two quality scores, ProcessingTime) and
+	// the per-file Error.
+	CompletionResult
 }
 
 // statusBoxCache holds the memoised side-panel render keyed on the inputs the
@@ -302,20 +308,11 @@ func (m Model) Init() tea.Cmd {
 
 // Update handles messages and updates the model
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if handled, cmd := handleCommonMsg(msg, &m.Width, &m.Height, &m.Done, &m.progress, processingBarOverhead); handled {
+		return m, cmd
+	}
+
 	switch msg := msg.(type) {
-	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			return m, tea.Quit
-		}
-
-	case tea.WindowSizeMsg:
-		m.Width = msg.Width
-		m.Height = msg.Height
-		if msg.Width > 0 {
-			m.progress.SetWidth(progressWidthFor(msg.Width, processingBarOverhead))
-		}
-
 	case ProgressMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
 			m.Files[msg.FileIndex] = updateFileProgress(m.Files[msg.FileIndex], msg)
@@ -346,19 +343,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case FileCompleteMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
 			m.Files[msg.FileIndex].Status = StatusComplete
-			m.Files[msg.FileIndex].InputLUFS = msg.InputLUFS
-			m.Files[msg.FileIndex].OutputLUFS = msg.OutputLUFS
-			m.Files[msg.FileIndex].FinalNoiseFloor = msg.FinalNoiseFloor
-			m.Files[msg.FileIndex].InputNoiseFloor = msg.InputNoiseFloor
-			m.Files[msg.FileIndex].HaveFinalNoiseFloor = msg.HaveFinalNoiseFloor
-			m.Files[msg.FileIndex].HaveInputNoiseFloor = msg.HaveInputNoiseFloor
-			m.Files[msg.FileIndex].OutputTP = msg.OutputTP
-			m.Files[msg.FileIndex].OutputLRA = msg.OutputLRA
-			m.Files[msg.FileIndex].OutputPath = msg.OutputPath
-			m.Files[msg.FileIndex].Quality = msg.Quality
-			m.Files[msg.FileIndex].RecordingQuality = msg.RecordingQuality
-			m.Files[msg.FileIndex].ProcessingTime = msg.ProcessingTime
-			m.Files[msg.FileIndex].Error = msg.Error
+			m.Files[msg.FileIndex].CompletionResult = msg.CompletionResult
 
 			if msg.Error != nil {
 				m.Files[msg.FileIndex].Status = StatusError
@@ -395,10 +380,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, meterTick()
-
-	case AllCompleteMsg:
-		m.Done = true
-		return m, tea.Quit
 	}
 
 	return m, nil

--- a/internal/ui/model_routing_test.go
+++ b/internal/ui/model_routing_test.go
@@ -47,7 +47,7 @@ func TestFileCompleteMsgIndexRouting(t *testing.T) {
 	m = updated.(Model)
 	before := m.Files[0]
 
-	updated, _ = m.Update(FileCompleteMsg{FileIndex: 1, InputLUFS: -23, OutputLUFS: -16, OutputPath: "b-out.wav"})
+	updated, _ = m.Update(FileCompleteMsg{FileIndex: 1, CompletionResult: CompletionResult{InputLUFS: -23, OutputLUFS: -16, OutputPath: "b-out.wav"}})
 	m = updated.(Model)
 
 	if m.Files[1].Status != StatusComplete {
@@ -70,7 +70,7 @@ func TestUpdateOutOfRangeSafety(t *testing.T) {
 	for _, idx := range indices {
 		updated, _ := m.Update(ProgressMsg{FileIndex: idx, Pass: processor.PassProcessing, Progress: 0.9})
 		m = updated.(Model)
-		updated, _ = m.Update(FileCompleteMsg{FileIndex: idx, OutputPath: "x"})
+		updated, _ = m.Update(FileCompleteMsg{FileIndex: idx, CompletionResult: CompletionResult{OutputPath: "x"}})
 		m = updated.(Model)
 	}
 
@@ -116,9 +116,9 @@ func TestRenderOverallProgressFooter(t *testing.T) {
 	m := NewModel([]string{"a.wav", "b.wav", "c.wav"})
 
 	// One complete, one failed, one in progress.
-	updated, _ := m.Update(FileCompleteMsg{FileIndex: 0, OutputPath: "a-out.wav"})
+	updated, _ := m.Update(FileCompleteMsg{FileIndex: 0, CompletionResult: CompletionResult{OutputPath: "a-out.wav"}})
 	m = updated.(Model)
-	updated, _ = m.Update(FileCompleteMsg{FileIndex: 1, Error: errors.New("boom")})
+	updated, _ = m.Update(FileCompleteMsg{FileIndex: 1, CompletionResult: CompletionResult{Error: errors.New("boom")}})
 	m = updated.(Model)
 	updated, _ = m.Update(ProgressMsg{FileIndex: 2, Pass: processor.PassProcessing, Progress: 0.4})
 	m = updated.(Model)

--- a/internal/ui/progress_bar_test.go
+++ b/internal/ui/progress_bar_test.go
@@ -576,7 +576,7 @@ func TestProcessingRowFitsTerminal(t *testing.T) {
 		updated, _ = m.Update(ProgressMsg{FileIndex: 0, Pass: 2, PassName: "Processing", Progress: 0.5})
 		m = updated.(Model)
 
-		row := renderFileDetails(m.Files[0], m.progress, -20.0, 0.5, -12.0)
+		row := renderFileDetails(&m.Files[0], m.progress, -20.0, 0.5, -12.0)
 		for line := range strings.SplitSeq(row, "\n") {
 			if w := ansi.StringWidth(line); w > term {
 				t.Errorf("term=%d line width %d overflows:\n%q", term, w, line)

--- a/internal/ui/statusboxes.go
+++ b/internal/ui/statusboxes.go
@@ -182,6 +182,38 @@ func overlayBorderTitle(box, title string, borderColor color.Color) string {
 	return b.String() + rest
 }
 
+// cachedOverlayTitle is a memoised overlayBorderTitle for the single-colour
+// active-file Pass box (cli.ColorSkyBlue). It splices the title into box's top
+// border, but reuses the cached top-border line when (title, top-border width) is
+// unchanged: the title is stable within a pass, so the strip + rune-slice +
+// 3-render overlay work runs only when the pass number changes or the box width
+// changes, not on every 60 fps frame. The box body (after the first line) always
+// comes from box, so per-frame inner content still renders; only the top-border
+// overlay is cached. A box with no newline has no overlayable top border, so it is
+// returned unchanged (matching overlayBorderTitle).
+func cachedOverlayTitle(c *overlayTitleCache, box, title string) string {
+	nl := strings.IndexByte(box, '\n')
+	if nl < 0 {
+		return box
+	}
+	top, rest := box[:nl], box[nl:]
+
+	width := lipgloss.Width(top)
+	if !c.valid || c.title != title || c.width != width {
+		// Miss: run the full overlay on this box and cache only its first line.
+		full := overlayBorderTitle(box, title, cli.ColorSkyBlue)
+		// overlayBorderTitle preserves the box structure, so full has the same first
+		// newline; cache only its first line. A box with no newline returned earlier.
+		firstLine, _, _ := strings.Cut(full, "\n")
+		c.line = firstLine
+		c.title = title
+		c.width = width
+		c.valid = true
+	}
+
+	return c.line + rest
+}
+
 // fitWidth pads s with trailing spaces to exactly width display columns, or
 // hard-truncates (dropping trailing ANSI styling) if it overflows. Used so each
 // status-box row occupies exactly one line.

--- a/internal/ui/statusboxes_test.go
+++ b/internal/ui/statusboxes_test.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/linuxmatters/jivetalking/internal/cli"
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
@@ -342,11 +343,59 @@ func TestBorderTitleInTopBorder(t *testing.T) {
 	}
 }
 
+// TestCachedOverlayTitle confirms cachedOverlayTitle memoises the spliced top-border
+// line on (title, top-border width): a repeat call with the same key serves the
+// stored line, and a changed title recomputes. The body after the first line always
+// comes from the live box, so per-frame inner content is never cached.
+func TestCachedOverlayTitle(t *testing.T) {
+	box := fileDetailsBox.Render("first row\nsecond row")
+
+	var c overlayTitleCache
+
+	// First call: cache miss, computes and stores the spliced line.
+	out := cachedOverlayTitle(&c, box, "Pass 2/4")
+	if !c.valid {
+		t.Fatal("cache should be valid after the first call")
+	}
+	if c.title != "Pass 2/4" {
+		t.Errorf("cache title = %q, want %q", c.title, "Pass 2/4")
+	}
+	want := overlayBorderTitle(box, "Pass 2/4", cli.ColorSkyBlue)
+	if out != want {
+		t.Errorf("first call differs from overlayBorderTitle:\ngot= %q\nwant=%q",
+			ansi.Strip(out), ansi.Strip(want))
+	}
+
+	// Same (title, width): the stored line must be served. Poison the cached line
+	// with a sentinel; the helper must return it verbatim (proving no recompute).
+	c.line = "SENTINEL"
+	nl := strings.IndexByte(box, '\n')
+	hit := cachedOverlayTitle(&c, box, "Pass 2/4")
+	if hit != "SENTINEL"+box[nl:] {
+		t.Errorf("cache hit should serve the stored line, got %q", ansi.Strip(hit))
+	}
+
+	// Changed title (pass boundary): key mismatch must recompute, replacing the
+	// sentinel with a fresh splice for the new title.
+	recomputed := cachedOverlayTitle(&c, box, "Pass 3/4")
+	if strings.Contains(recomputed, "SENTINEL") {
+		t.Error("title change should recompute, not serve the stale sentinel line")
+	}
+	if c.title != "Pass 3/4" {
+		t.Errorf("cache title after recompute = %q, want %q", c.title, "Pass 3/4")
+	}
+	want3 := overlayBorderTitle(box, "Pass 3/4", cli.ColorSkyBlue)
+	if recomputed != want3 {
+		t.Errorf("recomputed line differs from overlayBorderTitle:\ngot= %q\nwant=%q",
+			ansi.Strip(recomputed), ansi.Strip(want3))
+	}
+}
+
 // TestPassBoxTitleInBorder confirms the Pass box splits "Pass N/4: <Name>" into a
 // border title ("Pass N/4") and a first content row carrying only the pass name.
 func TestPassBoxTitleInBorder(t *testing.T) {
 	file := FileProgress{CurrentPass: processor.PassNormalising, Status: StatusNormalising}
-	plain := ansi.Strip(renderFileDetails(file, newProgressModel(), 0, 0, 0))
+	plain := ansi.Strip(renderFileDetails(&file, newProgressModel(), 0, 0, 0))
 	lines := strings.Split(plain, "\n")
 	if len(lines) < 2 {
 		t.Fatalf("pass box too short:\n%s", plain)

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -98,9 +98,9 @@ func NewAdaptedSummary(cfg *processor.EffectiveFilterConfig, diag *processor.Ada
 		}
 		if sp.BandsMeasured {
 			s.HasSibilance = true
-			// Recompute the same band excess the de-esser uses, so box and report
-			// never drift (adaptive_deesser.go).
-			s.SibilanceDB = sp.SibBandRMS - sp.BodyBandRMS
+			// Source the same band excess the de-esser uses, so box and report
+			// never drift (processor.SpeechCandidateMetrics.SibilanceExcessDB).
+			s.SibilanceDB = sp.SibilanceExcessDB()
 		}
 	}
 

--- a/internal/ui/view_layout_test.go
+++ b/internal/ui/view_layout_test.go
@@ -111,7 +111,7 @@ func TestProcessingViewOverallProgressContent(t *testing.T) {
 	m := NewModel([]string{"a.wav", "b.wav", "c.wav"})
 	m.Width = 120
 
-	updated, _ := m.Update(FileCompleteMsg{FileIndex: 0, OutputPath: "a-out.wav"})
+	updated, _ := m.Update(FileCompleteMsg{FileIndex: 0, CompletionResult: CompletionResult{OutputPath: "a-out.wav"}})
 	m = updated.(Model)
 
 	view := renderProcessingView(m)
@@ -133,15 +133,19 @@ func TestFinalSummaryReturnsCompletionContent(t *testing.T) {
 	updated, _ := m.Update(ProgressMsg{FileIndex: 0, Pass: processor.PassProcessing, Progress: 0.5, Level: -12})
 	m = updated.(Model)
 	updated, _ = m.Update(FileCompleteMsg{
-		FileIndex: 0, OutputPath: "a-out.wav", InputLUFS: -30.9, OutputLUFS: -15.9,
-		FinalNoiseFloor: -80.0, HaveFinalNoiseFloor: true,
-		Quality: processor.QualityScore{Stars: 4, Label: "Great"},
+		FileIndex: 0, CompletionResult: CompletionResult{
+			OutputPath: "a-out.wav", InputLUFS: -30.9, OutputLUFS: -15.9,
+			FinalNoiseFloor: -80.0, HaveFinalNoiseFloor: true,
+			Quality: processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	})
 	m = updated.(Model)
 	updated, _ = m.Update(FileCompleteMsg{
-		FileIndex: 1, OutputPath: "b-out.wav", InputLUFS: -20.0, OutputLUFS: -16.0,
-		FinalNoiseFloor: -65.0, HaveFinalNoiseFloor: true,
-		Quality: processor.QualityScore{Stars: 5, Label: "Excellent"},
+		FileIndex: 1, CompletionResult: CompletionResult{
+			OutputPath: "b-out.wav", InputLUFS: -20.0, OutputLUFS: -16.0,
+			FinalNoiseFloor: -65.0, HaveFinalNoiseFloor: true,
+			Quality: processor.QualityScore{Stars: 5, Label: "Excellent"},
+		},
 	})
 	m = updated.(Model)
 	m.Done = true
@@ -175,14 +179,16 @@ func TestFinalSummaryReturnsCompletionContent(t *testing.T) {
 // the processed (output) filename, never the input name nor a "→".
 func TestDoneBoxRendersIndigoLabelledRows(t *testing.T) {
 	file := FileProgress{
-		InputPath:           "LMP-81-mark.flac",
-		OutputPath:          "LMP-81-mark-LUFS-16-processed.flac",
-		Status:              StatusComplete,
-		InputLUFS:           -30.9,
-		OutputLUFS:          -15.9,
-		FinalNoiseFloor:     -80.0,
-		HaveFinalNoiseFloor: true,
-		Quality:             processor.QualityScore{Stars: 4, Label: "Excellent"},
+		InputPath: "LMP-81-mark.flac",
+		Status:    StatusComplete,
+		CompletionResult: CompletionResult{
+			OutputPath:          "LMP-81-mark-LUFS-16-processed.flac",
+			InputLUFS:           -30.9,
+			OutputLUFS:          -15.9,
+			FinalNoiseFloor:     -80.0,
+			HaveFinalNoiseFloor: true,
+			Quality:             processor.QualityScore{Stars: 4, Label: "Excellent"},
+		},
 	}
 
 	raw := renderDoneBox(file)
@@ -255,22 +261,26 @@ func TestDoneBoxRendersIndigoLabelledRows(t *testing.T) {
 // number sat next to fewer stars.
 func TestDoneBoxNoiseAndStarsMoveTogether(t *testing.T) {
 	clean := FileProgress{
-		InputPath:           "clean.flac",
-		OutputPath:          "clean-out.flac",
-		Status:              StatusComplete,
-		OutputLUFS:          -16.0,
-		FinalNoiseFloor:     -80.0,
-		HaveFinalNoiseFloor: true,
-		Quality:             processor.QualityScore{Stars: 5, Label: "Excellent"},
+		InputPath: "clean.flac",
+		Status:    StatusComplete,
+		CompletionResult: CompletionResult{
+			OutputPath:          "clean-out.flac",
+			OutputLUFS:          -16.0,
+			FinalNoiseFloor:     -80.0,
+			HaveFinalNoiseFloor: true,
+			Quality:             processor.QualityScore{Stars: 5, Label: "Excellent"},
+		},
 	}
 	noisy := FileProgress{
-		InputPath:           "noisy.flac",
-		OutputPath:          "noisy-out.flac",
-		Status:              StatusComplete,
-		OutputLUFS:          -16.0,
-		FinalNoiseFloor:     -55.0,
-		HaveFinalNoiseFloor: true,
-		Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		InputPath: "noisy.flac",
+		Status:    StatusComplete,
+		CompletionResult: CompletionResult{
+			OutputPath:          "noisy-out.flac",
+			OutputLUFS:          -16.0,
+			FinalNoiseFloor:     -55.0,
+			HaveFinalNoiseFloor: true,
+			Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 
 	cleanPlain := ansi.Strip(renderDoneBox(clean))
@@ -299,11 +309,13 @@ func TestDoneBoxNoiseAndStarsMoveTogether(t *testing.T) {
 // zero the placeholder "⚡ —×" shows alongside a 00:00 clock.
 func TestDoneBoxTimeRow(t *testing.T) {
 	known := FileProgress{
-		OutputPath:     "a-out.flac",
-		Status:         StatusComplete,
-		Duration:       120.0,
-		ProcessingTime: 48 * time.Second,
-		Quality:        processor.QualityScore{Stars: 4, Label: "Great"},
+		Status:   StatusComplete,
+		Duration: 120.0,
+		CompletionResult: CompletionResult{
+			OutputPath:     "a-out.flac",
+			ProcessingTime: 48 * time.Second,
+			Quality:        processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	plain := ansi.Strip(renderDoneBox(known))
 
@@ -319,10 +331,12 @@ func TestDoneBoxTimeRow(t *testing.T) {
 	}
 
 	zero := FileProgress{
-		OutputPath: "b-out.flac",
-		Status:     StatusComplete,
-		Duration:   120.0,
-		Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		Status:   StatusComplete,
+		Duration: 120.0,
+		CompletionResult: CompletionResult{
+			OutputPath: "b-out.flac",
+			Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	zeroPlain := ansi.Strip(renderDoneBox(zero))
 
@@ -350,11 +364,13 @@ func TestDoneBoxNoiseFloorClamp(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			file := FileProgress{
-				OutputPath:          "x-out.flac",
-				Status:              StatusComplete,
-				FinalNoiseFloor:     tc.floor,
-				HaveFinalNoiseFloor: true,
-				Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+				Status: StatusComplete,
+				CompletionResult: CompletionResult{
+					OutputPath:          "x-out.flac",
+					FinalNoiseFloor:     tc.floor,
+					HaveFinalNoiseFloor: true,
+					Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+				},
 			}
 			plain := ansi.Strip(renderDoneBox(file))
 			if !strings.Contains(plain, tc.want) {
@@ -369,11 +385,13 @@ func TestDoneBoxNoiseFloorClamp(t *testing.T) {
 // Pass-1 Summary (ChainReady), output TP from the completion message.
 func TestDoneBoxTruePeakRow(t *testing.T) {
 	file := FileProgress{
-		OutputPath: "tp-out.flac",
-		Status:     StatusComplete,
-		OutputTP:   -2.0,
-		Summary:    AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
-		Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		Status:  StatusComplete,
+		Summary: AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
+		CompletionResult: CompletionResult{
+			OutputPath: "tp-out.flac",
+			OutputTP:   -2.0,
+			Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	plain := ansi.Strip(renderDoneBox(file))
 
@@ -394,11 +412,13 @@ func TestDoneBoxTruePeakRow(t *testing.T) {
 // loudness range in LU with a signed Δ carrying no unit.
 func TestDoneBoxDynamicsRow(t *testing.T) {
 	file := FileProgress{
-		OutputPath: "lra-out.flac",
-		Status:     StatusComplete,
-		OutputLRA:  8.0,
-		Summary:    AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
-		Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		Status:  StatusComplete,
+		Summary: AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
+		CompletionResult: CompletionResult{
+			OutputPath: "lra-out.flac",
+			OutputLRA:  8.0,
+			Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	plain := ansi.Strip(renderDoneBox(file))
 
@@ -421,17 +441,19 @@ func TestDoneBoxDynamicsRow(t *testing.T) {
 // (Recording) and output-quality (Processed) star rows, Recording above Processed.
 func TestDoneBoxRowOrder(t *testing.T) {
 	file := FileProgress{
-		OutputPath:          "order-out.flac",
-		Status:              StatusComplete,
-		InputLUFS:           -30.9,
-		OutputLUFS:          -15.9,
-		OutputTP:            -2.0,
-		OutputLRA:           8.0,
-		FinalNoiseFloor:     -80.0,
-		HaveFinalNoiseFloor: true,
-		Summary:             AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
-		Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
-		RecordingQuality:    processor.QualityScore{Stars: 3, Label: "Good"},
+		Status:  StatusComplete,
+		Summary: AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
+		CompletionResult: CompletionResult{
+			OutputPath:          "order-out.flac",
+			InputLUFS:           -30.9,
+			OutputLUFS:          -15.9,
+			OutputTP:            -2.0,
+			OutputLRA:           8.0,
+			FinalNoiseFloor:     -80.0,
+			HaveFinalNoiseFloor: true,
+			Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+			RecordingQuality:    processor.QualityScore{Stars: 3, Label: "Good"},
+		},
 	}
 	plain := ansi.Strip(renderDoneBox(file))
 
@@ -457,14 +479,16 @@ func TestDoneBoxRowOrder(t *testing.T) {
 // wide ㏈/arrow glyphs count as their true column span.
 func TestDoneBoxColumnsAlign(t *testing.T) {
 	file := FileProgress{
-		OutputPath: "align-out.flac",
-		Status:     StatusComplete,
-		InputLUFS:  -29.8,
-		OutputLUFS: -16.0,
-		OutputTP:   -2.2,
-		OutputLRA:  8.8,
-		Summary:    AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
-		Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		Status:  StatusComplete,
+		Summary: AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
+		CompletionResult: CompletionResult{
+			OutputPath: "align-out.flac",
+			InputLUFS:  -29.8,
+			OutputLUFS: -16.0,
+			OutputTP:   -2.2,
+			OutputLRA:  8.8,
+			Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	plain := ansi.Strip(renderDoneBox(file))
 
@@ -531,14 +555,16 @@ func noiseFloorRowOf(t *testing.T, file FileProgress) string {
 // sentinel would mislead).
 func TestDoneBoxNoiseFloorBeforeAfter(t *testing.T) {
 	file := FileProgress{
-		OutputPath:          "nf-out.flac",
-		Status:              StatusComplete,
-		InputNoiseFloor:     -64.0,
-		FinalNoiseFloor:     -82.0,
-		HaveInputNoiseFloor: true,
-		HaveFinalNoiseFloor: true,
-		Summary:             AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
-		Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		Status:  StatusComplete,
+		Summary: AdaptedSummary{ChainReady: true, TruePeakDBTP: -0.1, InputLRA: 12.3},
+		CompletionResult: CompletionResult{
+			OutputPath:          "nf-out.flac",
+			InputNoiseFloor:     -64.0,
+			FinalNoiseFloor:     -82.0,
+			HaveInputNoiseFloor: true,
+			HaveFinalNoiseFloor: true,
+			Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	noiseLine := noiseFloorRowOf(t, file)
 
@@ -557,11 +583,13 @@ func TestDoneBoxNoiseFloorBeforeAfter(t *testing.T) {
 // single value (no broken arrow) when only one end is available.
 func TestDoneBoxNoiseFloorSingleEnd(t *testing.T) {
 	outputOnly := FileProgress{
-		OutputPath:          "nf-out.flac",
-		Status:              StatusComplete,
-		FinalNoiseFloor:     -80.0,
-		HaveFinalNoiseFloor: true,
-		Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		Status: StatusComplete,
+		CompletionResult: CompletionResult{
+			OutputPath:          "nf-out.flac",
+			FinalNoiseFloor:     -80.0,
+			HaveFinalNoiseFloor: true,
+			Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	line := noiseFloorRowOf(t, outputOnly)
 	if strings.Contains(line, "→") {
@@ -572,11 +600,13 @@ func TestDoneBoxNoiseFloorSingleEnd(t *testing.T) {
 	}
 
 	inputOnly := FileProgress{
-		OutputPath:          "nf-out.flac",
-		Status:              StatusComplete,
-		InputNoiseFloor:     -64.0,
-		HaveInputNoiseFloor: true,
-		Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		Status: StatusComplete,
+		CompletionResult: CompletionResult{
+			OutputPath:          "nf-out.flac",
+			InputNoiseFloor:     -64.0,
+			HaveInputNoiseFloor: true,
+			Quality:             processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	line = noiseFloorRowOf(t, inputOnly)
 	if strings.Contains(line, "→") {
@@ -592,12 +622,14 @@ func TestDoneBoxNoiseFloorSingleEnd(t *testing.T) {
 // unset input never produces a misleading comparison.
 func TestDoneBoxGuardsEmptySummary(t *testing.T) {
 	file := FileProgress{
-		OutputPath: "guard-out.flac",
-		Status:     StatusComplete,
-		OutputTP:   -2.0,
-		OutputLRA:  8.0,
-		Summary:    AdaptedSummary{ChainReady: false},
-		Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		Status:  StatusComplete,
+		Summary: AdaptedSummary{ChainReady: false},
+		CompletionResult: CompletionResult{
+			OutputPath: "guard-out.flac",
+			OutputTP:   -2.0,
+			OutputLRA:  8.0,
+			Quality:    processor.QualityScore{Stars: 4, Label: "Great"},
+		},
 	}
 	plain := ansi.Strip(renderDoneBox(file))
 
@@ -632,12 +664,14 @@ func TestDoneBoxGuardsEmptySummary(t *testing.T) {
 func TestFileCompleteMsgCopiesOutputTPAndLRA(t *testing.T) {
 	m := NewModel([]string{"a.flac"})
 	updated, _ := m.Update(FileCompleteMsg{
-		FileIndex:  0,
-		InputLUFS:  -30.9,
-		OutputLUFS: -15.9,
-		OutputTP:   -2.0,
-		OutputLRA:  8.0,
-		OutputPath: "a-out.flac",
+		FileIndex: 0,
+		CompletionResult: CompletionResult{
+			InputLUFS:  -30.9,
+			OutputLUFS: -15.9,
+			OutputTP:   -2.0,
+			OutputLRA:  8.0,
+			OutputPath: "a-out.flac",
+		},
 	})
 	mm := updated.(Model)
 	if got := mm.Files[0].OutputTP; got != -2.0 {
@@ -653,10 +687,12 @@ func TestFileCompleteMsgCopiesOutputTPAndLRA(t *testing.T) {
 // star count and word label, Recording directly above Processed.
 func TestDoneBoxRecordingAndProcessedRows(t *testing.T) {
 	file := FileProgress{
-		OutputPath:       "rp-out.flac",
-		Status:           StatusComplete,
-		RecordingQuality: processor.QualityScore{Stars: 2, Label: "Fair"},
-		Quality:          processor.QualityScore{Stars: 5, Label: "Excellent"},
+		Status: StatusComplete,
+		CompletionResult: CompletionResult{
+			OutputPath:       "rp-out.flac",
+			RecordingQuality: processor.QualityScore{Stars: 2, Label: "Fair"},
+			Quality:          processor.QualityScore{Stars: 5, Label: "Excellent"},
+		},
 	}
 	plain := ansi.Strip(renderDoneBox(file))
 
@@ -709,10 +745,12 @@ func TestDoneBoxRecordingAndProcessedRows(t *testing.T) {
 func TestFileCompleteMsgCopiesRecordingQuality(t *testing.T) {
 	m := NewModel([]string{"a.flac"})
 	updated, _ := m.Update(FileCompleteMsg{
-		FileIndex:        0,
-		OutputPath:       "a-out.flac",
-		Quality:          processor.QualityScore{Stars: 5, Label: "Excellent"},
-		RecordingQuality: processor.QualityScore{Stars: 2, Label: "Fair"},
+		FileIndex: 0,
+		CompletionResult: CompletionResult{
+			OutputPath:       "a-out.flac",
+			Quality:          processor.QualityScore{Stars: 5, Label: "Excellent"},
+			RecordingQuality: processor.QualityScore{Stars: 2, Label: "Fair"},
+		},
 	})
 	mm := updated.(Model)
 	if got := mm.Files[0].RecordingQuality.Stars; got != 2 {

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -69,7 +69,7 @@ func renderFileEntry(file *FileProgress, prog progress.Model, easedLevel, easedP
 		// active file with detailed progress, with the filter-chain status boxes
 		// joined to the right of the Pass box.
 		icon := lipgloss.NewStyle().Foreground(cli.ColorOrange).Render("∿")
-		passBox := renderFileDetails(*file, prog, easedLevel, easedProgress, easedPeak)
+		passBox := renderFileDetails(file, prog, easedLevel, easedProgress, easedPeak)
 		body := joinStatusBoxes(passBox, file, termWidth)
 		return fmt.Sprintf(" %s %s\n%s", icon, fileName, body)
 
@@ -85,14 +85,18 @@ func renderFileEntry(file *FileProgress, prog progress.Model, easedLevel, easedP
 	}
 }
 
+// fileDetailsBox is the active-file Pass box frame: a sky-blue rounded border with
+// horizontal padding. Its inputs are all compile-time constants, so it is identical
+// every frame; hoisting it off renderFileDetails keeps the style allocation off the
+// 60fps redraw (one active file rebuilds it per frame otherwise).
+var fileDetailsBox = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(cli.ColorSkyBlue).
+	Padding(0, 1)
+
 // renderFileDetails renders detailed progress for the active file. easedLevel is
 // the spring-smoothed audio level used for the meter display.
-func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, easedProgress, easedPeak float64) string {
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(cli.ColorSkyBlue).
-		Padding(0, 1)
-
+func renderFileDetails(file *FileProgress, prog progress.Model, easedLevel, easedProgress, easedPeak float64) string {
 	var content strings.Builder
 
 	// Pass indicator. "Pass N/4" sits in the top border (spliced below, matching
@@ -118,7 +122,7 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 
 	// Time block: elapsed clock, mini dot timeline, projected total clock, and a
 	// realtime-speed badge.
-	content.WriteString(renderTimeline(file))
+	content.WriteString(renderTimeline(*file))
 	content.WriteByte('\n')
 
 	// Audio level visualization. Both the displayed level and the peak marker ease
@@ -130,7 +134,7 @@ func renderFileDetails(file FileProgress, prog progress.Model, easedLevel, eased
 	}
 
 	title := fmt.Sprintf("Pass %d/4", file.CurrentPass)
-	return overlayBorderTitle(box.Render(content.String()), title, cli.ColorSkyBlue)
+	return cachedOverlayTitle(&file.fileDetailsTitleCache, fileDetailsBox.Render(content.String()), title)
 }
 
 // timelineWidth is the cell count of the mini dot timeline in the Time block.
@@ -243,6 +247,25 @@ var meterRamp = sync.OnceValue(func() []color.Color {
 	return ramp
 })
 
+// meterRampStyles caches one lipgloss.Style per meterRamp colour so the meter
+// flush indexes a pre-built style instead of allocating lipgloss.NewStyle() per
+// colour run on the 60fps redraw. It derives its colours from meterRamp() inside
+// the same closure, so the ramp is the single source of truth (the styles and the
+// ramp can never drift). Lazy and thread-safe for the same reasons as meterRamp.
+var meterRampStyles = sync.OnceValue(func() []lipgloss.Style {
+	ramp := meterRamp()
+	styles := make([]lipgloss.Style, len(ramp))
+	for i, c := range ramp {
+		styles[i] = lipgloss.NewStyle().Foreground(c)
+	}
+	return styles
+})
+
+// meterOffRampStyle is the off-ramp fallback style: cells whose index falls
+// outside the cached ramp resolve to cli.ColorRed, matching cellColor in
+// renderAudioLevelMeter. Built once at package init so the flush never allocates.
+var meterOffRampStyle = lipgloss.NewStyle().Foreground(cli.ColorRed)
+
 // renderAudioLevelMeter renders a live audio level meter with dB visualization.
 // elapsed drives the gentle pulse of the peak-hold marker; it is the file's
 // running elapsed time, advanced once per meter tick, so no second tick loop is
@@ -273,7 +296,10 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	// meterRamp): its inputs (meterWidth, meterFloorDB, the -16 dB threshold, and
 	// the package-level colours) are all compile-time constants, so the ramp never
 	// varies per frame. Indexing the cached slice keeps this off the 60fps path.
+	// The matching per-colour styles are cached too (meterRampStyles), so the flush
+	// indexes a pre-built style rather than allocating one per run.
 	ramp := meterRamp()
+	rampStyles := meterRampStyles()
 
 	cellColor := func(i int) color.Color {
 		if i < 0 || i >= len(ramp) {
@@ -290,14 +316,23 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	}
 
 	// Build contiguous same-colour runs and style each as one segment so
-	// lipgloss emits a single colour sequence per run rather than per rune.
+	// lipgloss emits a single colour sequence per run rather than per rune. The
+	// run is coalesced by colour equality over the cell index, and cellColor maps
+	// cell i to ramp position i, so the run's START cell index is its ramp
+	// position. Index the cached style by that position; an off-ramp run (position
+	// outside the ramp, the cli.ColorRed fallback) uses the package red style.
 	var run strings.Builder
 	var runColor color.Color
+	runStart := 0
 	flush := func() {
 		if run.Len() == 0 {
 			return
 		}
-		b.WriteString(lipgloss.NewStyle().Foreground(runColor).Render(run.String()))
+		style := meterOffRampStyle
+		if runStart >= 0 && runStart < len(rampStyles) {
+			style = rampStyles[runStart]
+		}
+		b.WriteString(style.Render(run.String()))
 		run.Reset()
 	}
 
@@ -305,6 +340,7 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 		color := cellColor(i)
 		if run.Len() > 0 && color != runColor {
 			flush()
+			runStart = i
 		}
 		runColor = color
 		run.WriteRune(meterChar(i))

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -482,8 +482,8 @@ func lerpClamp(v, inLo, inHi, outLo, outHi float64) float64 {
 
 // rgb8 resolves a color.Color to 8-bit sRGB channels.
 func rgb8(c color.Color) (r, g, b uint8) {
-	r16, g16, b16, _ := c.RGBA()
-	return uint8((r16 >> 8) & 0xFF), uint8((g16 >> 8) & 0xFF), uint8((b16 >> 8) & 0xFF)
+	rgba := color.RGBAModel.Convert(c).(color.RGBA)
+	return rgba.R, rgba.G, rgba.B
 }
 
 // renderOverallProgress renders the overall progress footer

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -451,12 +451,6 @@ func peakMarkerColor(elapsed time.Duration) color.Color {
 // across width.
 const gainBarWidth = 5
 
-// gainBar returns the gain bar; thin alias kept for in-package call sites,
-// mirroring qualityStars/QualityStars. See GainBar.
-func gainBar(inputTP float64) string {
-	return GainBar(inputTP)
-}
-
 // GainBar renders the input true peak as a short horizontal bar that fills and
 // colours with the peak, mirroring separationBar's grammar. It is pure
 // presentation, derived from the same true peak as GainAdvice, with the fill and
@@ -759,20 +753,15 @@ func renderDoneBox(file FileProgress) string {
 	// Quality rows: source-capture stars (Recording) above output-quality stars
 	// (Processed). The pair tells the value story: a low Recording beside a high
 	// Processed shows what the tool rescued. Both use the same star/label styling.
-	recStars := starStyle.Render(qualityStars(file.RecordingQuality.Stars))
+	recStars := starStyle.Render(QualityStars(file.RecordingQuality.Stars))
 	fmt.Fprintf(&content, "%s%s  %s\n",
 		labelStyle.Render("Recording"), recStars, valueStyle.Render(file.RecordingQuality.Label))
 
-	procStars := starStyle.Render(qualityStars(file.Quality.Stars))
+	procStars := starStyle.Render(QualityStars(file.Quality.Stars))
 	fmt.Fprintf(&content, "%s%s  %s",
 		labelStyle.Render("Processed"), procStars, valueStyle.Render(file.Quality.Label))
 
 	return heading + "\n" + box.Render(content.String())
-}
-
-// qualityStars renders an n-of-5 star bar as filled ★ followed by empty ☆.
-func qualityStars(n int) string {
-	return QualityStars(n)
 }
 
 // QualityStars renders an n-of-5 star bar as filled ★ followed by empty ☆,

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -292,12 +292,31 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	// place the marker and elbow one cell beyond the bar.
 	peakPos := max(0, min(int(((peakLevel-minDB)/(maxDB-minDB))*float64(width)), width-1))
 
-	// The green→yellow→orange→red colour ramp is built once and cached (see
-	// meterRamp): its inputs (meterWidth, meterFloorDB, the -16 dB threshold, and
-	// the package-level colours) are all compile-time constants, so the ramp never
-	// varies per frame. Indexing the cached slice keeps this off the 60fps path.
-	// The matching per-colour styles are cached too (meterRampStyles), so the flush
-	// indexes a pre-built style rather than allocating one per run.
+	b.WriteString(renderMeterBar(width, currentPos))
+
+	if marker := renderPeakMarker(peakLevel, peakPos, width, minDB, elapsed); marker != "" {
+		b.WriteByte('\n')
+		b.WriteString(marker)
+	}
+
+	return b.String()
+}
+
+// renderMeterBar draws the width-cell level meter: the first currentPos cells use
+// the filled glyph, the rest the empty glyph. It does NOT reuse renderFilledBar:
+// the ramp colour spans both filled and empty cells (so the bar is coloured along
+// its whole length), and contiguous same-colour cells are coalesced into one
+// styled run so lipgloss emits a single colour sequence per run rather than per
+// rune, keeping it off the 60fps path.
+//
+// The green→yellow→orange→red colour ramp is built once and cached (see
+// meterRamp): its inputs (meterWidth, meterFloorDB, the -16 dB threshold, and the
+// package-level colours) are all compile-time constants, so the ramp never varies
+// per frame. The matching per-colour styles are cached too (meterRampStyles), so
+// the flush indexes a pre-built style rather than allocating one per run.
+func renderMeterBar(width, currentPos int) string {
+	var b strings.Builder
+
 	ramp := meterRamp()
 	rampStyles := meterRampStyles()
 
@@ -315,12 +334,11 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 		return '░' // Empty
 	}
 
-	// Build contiguous same-colour runs and style each as one segment so
-	// lipgloss emits a single colour sequence per run rather than per rune. The
-	// run is coalesced by colour equality over the cell index, and cellColor maps
-	// cell i to ramp position i, so the run's START cell index is its ramp
-	// position. Index the cached style by that position; an off-ramp run (position
-	// outside the ramp, the cli.ColorRed fallback) uses the package red style.
+	// Build contiguous same-colour runs and style each as one segment. The run is
+	// coalesced by colour equality over the cell index, and cellColor maps cell i
+	// to ramp position i, so the run's START cell index is its ramp position. Index
+	// the cached style by that position; an off-ramp run (position outside the
+	// ramp, the cli.ColorRed fallback) uses the package red style.
 	var run strings.Builder
 	var runColor color.Color
 	runStart := 0
@@ -347,42 +365,49 @@ func renderAudioLevelMeter(currentLevel, peakLevel float64, elapsed time.Duratio
 	}
 	flush()
 
-	// Peak-hold marker: a single pulsing line beneath the bar that tethers the
-	// peak value to its column via an up-tip arrow, with the value in Unicode
-	// superscript so the label and its pointer share one row. The "Level:" header
-	// already names the unit, so the marker carries only the value. Skip it when
-	// there is no meaningful peak yet (peak still at the silence floor), so no
-	// stray marker sits at column 0. Alignment uses lipgloss.Width (display
-	// columns), not byte length: every superscript rune is width 1, including the
-	// '·' decimal separator pinned to width 1 at startup (see main.go), so the
-	// arrow lands exactly under the peak column.
-	if peakLevel > minDB {
-		pulseColor := peakMarkerColor(elapsed)
-		arrowStyle := lipgloss.NewStyle().Foreground(pulseColor)
-		valueStyle := lipgloss.NewStyle().Foreground(cli.ColorOrange)
-		supValue := superscriptValue(fmt.Sprintf("%.1f", peakLevel))
+	return b.String()
+}
 
-		b.WriteByte('\n')
-		// Default: arrow leads, value to its right (⬑ value). When that form would
-		// overflow the bar, flip so the value leads and the arrow trails (value ⬏),
-		// keeping the label within meterWidth. The right form renders as
-		// `<peakPos spaces>⬑ <supValue>` = peakPos + 1 (⬑) + 1 (space) +
-		// lipgloss.Width(supValue) columns; the arrow sits at the peak column.
-		if peakPos+lipgloss.Width(supValue)+2 <= width {
-			b.WriteString(strings.Repeat(" ", peakPos))
-			b.WriteString(arrowStyle.Render("⬑"))
-			b.WriteByte(' ')
-			b.WriteString(valueStyle.Render(supValue))
-		} else {
-			// value then a right-up arrow ⬏ ending under the peak column. The form
-			// is `<lead spaces><supValue> ⬏`, so lead + width(supValue) + 1 ==
-			// peakPos places the arrow at the peak column.
-			lead := max(peakPos-(lipgloss.Width(supValue)+1), 0)
-			b.WriteString(strings.Repeat(" ", lead))
-			b.WriteString(valueStyle.Render(supValue))
-			b.WriteByte(' ')
-			b.WriteString(arrowStyle.Render("⬏"))
-		}
+// renderPeakMarker lays out the peak-hold marker: a single pulsing line beneath
+// the bar that tethers the peak value to its column via an up-tip arrow, with the
+// value in Unicode superscript so the label and its pointer share one row. The
+// "Level:" header already names the unit, so the marker carries only the value. It
+// returns "" when there is no meaningful peak yet (peak still at the silence
+// floor), so no stray marker sits at column 0. Alignment uses lipgloss.Width
+// (display columns), not byte length: every superscript rune is width 1, including
+// the '·' decimal separator pinned to width 1 at startup (see main.go), so the
+// arrow lands exactly under the peak column.
+func renderPeakMarker(peakLevel float64, peakPos, width int, minDB float64, elapsed time.Duration) string {
+	if peakLevel <= minDB {
+		return ""
+	}
+
+	var b strings.Builder
+
+	pulseColor := peakMarkerColor(elapsed)
+	arrowStyle := lipgloss.NewStyle().Foreground(pulseColor)
+	valueStyle := lipgloss.NewStyle().Foreground(cli.ColorOrange)
+	supValue := superscriptValue(fmt.Sprintf("%.1f", peakLevel))
+
+	// Default: arrow leads, value to its right (⬑ value). When that form would
+	// overflow the bar, flip so the value leads and the arrow trails (value ⬏),
+	// keeping the label within meterWidth. The right form renders as
+	// `<peakPos spaces>⬑ <supValue>` = peakPos + 1 (⬑) + 1 (space) +
+	// lipgloss.Width(supValue) columns; the arrow sits at the peak column.
+	if peakPos+lipgloss.Width(supValue)+2 <= width {
+		b.WriteString(strings.Repeat(" ", peakPos))
+		b.WriteString(arrowStyle.Render("⬑"))
+		b.WriteByte(' ')
+		b.WriteString(valueStyle.Render(supValue))
+	} else {
+		// value then a right-up arrow ⬏ ending under the peak column. The form
+		// is `<lead spaces><supValue> ⬏`, so lead + width(supValue) + 1 ==
+		// peakPos places the arrow at the peak column.
+		lead := max(peakPos-(lipgloss.Width(supValue)+1), 0)
+		b.WriteString(strings.Repeat(" ", lead))
+		b.WriteString(valueStyle.Render(supValue))
+		b.WriteByte(' ')
+		b.WriteString(arrowStyle.Render("⬏"))
 	}
 
 	return b.String()

--- a/internal/ui/views_test.go
+++ b/internal/ui/views_test.go
@@ -92,6 +92,37 @@ func TestMeterRampStableAcrossCalls(t *testing.T) {
 	}
 }
 
+// TestMeterRampStylesMatchRamp asserts the cached style slice has one style per
+// ramp colour (same length) and that each style's foreground resolves to the
+// matching ramp colour, so the flush's position-indexed style matches the
+// per-cell colour the oracle paints. It also checks the off-ramp fallback style
+// resolves to cli.ColorRed, matching cellColor's out-of-range branch.
+func TestMeterRampStylesMatchRamp(t *testing.T) {
+	ramp := meterRamp()
+	styles := meterRampStyles()
+
+	if len(styles) != len(ramp) {
+		t.Fatalf("meterRampStyles length = %d, want ramp length %d", len(styles), len(ramp))
+	}
+	for i := range ramp {
+		if !colorsEqual(styles[i].GetForeground(), ramp[i]) {
+			sr, sg, sb, _ := styles[i].GetForeground().RGBA()
+			rr, rg, rb, _ := ramp[i].RGBA()
+			t.Errorf("style[%d] foreground = (%d,%d,%d), want ramp (%d,%d,%d)",
+				i, sr>>8, sg>>8, sb>>8, rr>>8, rg>>8, rb>>8)
+		}
+	}
+
+	// Off-ramp fallback: cellColor returns cli.ColorRed for an out-of-range index;
+	// the flush uses meterOffRampStyle for the same case.
+	if !colorsEqual(meterOffRampStyle.GetForeground(), cli.ColorRed) {
+		or, og, ob, _ := meterOffRampStyle.GetForeground().RGBA()
+		rr, rg, rb, _ := cli.ColorRed.RGBA()
+		t.Errorf("meterOffRampStyle foreground = (%d,%d,%d), want cli.ColorRed (%d,%d,%d)",
+			or>>8, og>>8, ob>>8, rr>>8, rg>>8, rb>>8)
+	}
+}
+
 // TestRenderAudioLevelMeterMatchesOracle renders the meter across a range of dB
 // fill levels and asserts the output equals a reference renderer that uses the
 // per-frame ramp oracle. A mismatch means the cache changed the visible meter.


### PR DESCRIPTION
  ## Summary

  This pull request brings the cleanup branch into main, closing peer-review findings across processor, UI, report, audio, CLI, and documentation. The changes improve resource safety (nil checks, CGO ownership), eliminate duplication,
  unify naming, and embed performance optimisations (seek to region for spectrograms, UI render caching). The processor and report packages see significant refactoring to improve clarity and testability; documentation captures
  normalisation tuning rationale in a dedicated guide.

  ## Changes

  - Remove dead `NoiseFloor` field from `ProcessingResult` and simplify builtins across processor
  - Replace `math.Max`/`Min` with built-in `min`/`max` functions
  - Simplify UI RGB colour handling via `RGBAModel.Convert`
  - Use `sync.WaitGroup.Go` for cleaner goroutine spawning in CLI
  - Extract `SpectrogramBounds` helper to reduce duplication
  - Consolidate doc comments across processor and audio packages; improve comment accuracy and consistency
  - Extend `NoiseProfile` to carry the full spectral set (eliminate measurement scatter)
  - Seek to speech region before band measurement decodes (Pass 1 performance)
  - Cache UI render styles on first layout to avoid repeated computation (TUI responsiveness)
  - Improve resource safety: add nil checks in audio reader accessors, fix CGO string ownership, enhance test coverage
  - Unify naming and idiomatic Go patterns (RMS method naming, error wrapping, seam names across analysis pool)
  - Pin `CGO_ENABLED=1` on CI builder workflow to prevent build surprises
  - Split `report/sections.go` into `sections_filters.go`, `sections_spectrograms.go`, and new `metricrow.go` for readability
  - Extract normalisation tuning rationale to `docs/Normalisation-Tuning.md`; add sign-posts from AGENTS.md and README.md
  - Update AGENTS.md and README.md with architecture and measurement-axis clarity