### PR TITLE
refactor: address peer-review findings across README and UI layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,5 +220,6 @@ The full source layout, architecture, and contribution standards live in [AGENTS
 - [Usage Guide](docs/Usage.md): driving Jivetalking in depth: quality ratings, analysis-only mode, and diagnostics
 - [Audio Pipeline](docs/Pipeline.md): how and why the processing pipeline is built and tuned, with a diagram
 - [The hardware that taught me](docs/Inspiration.md): the influences and heritage behind jivetalking's processing approach
+- [Levelator Comparison](docs/Levelator-Comparison-And-Gap-Analysis.md): how Jivetalking compares to The Levelator, with capabilities and gaps
 - [Spectral Metrics Reference](docs/Spectral-Metrics-Reference.md): how measurements drive adaptation
 - [Normalisation Tuning](docs/Normalisation-Tuning.md): why the loudnorm and limiter constants hold their corpus-derived values

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -240,6 +240,8 @@ type progressHandler struct {
 	fileIndex  int
 	pass1Start time.Time
 	pass1Time  time.Duration
+	pass2Start time.Time
+	pass2Time  time.Duration
 	pass3Start time.Time
 	pass3Time  time.Duration
 	pass4Start time.Time
@@ -271,6 +273,13 @@ func (ph *progressHandler) callback(update processor.ProgressUpdate) {
 		}
 		if update.Progress >= passCompleteThreshold {
 			ph.pass1Time = time.Since(ph.pass1Start)
+		}
+	case processor.PassProcessing:
+		if ph.pass2Start.IsZero() {
+			ph.pass2Start = time.Now()
+		}
+		if update.Progress >= passCompleteThreshold {
+			ph.pass2Time = time.Since(ph.pass2Start)
 		}
 	case processor.PassMeasuring:
 		if ph.pass3Start.IsZero() {

--- a/cmd/jivetalking/pool.go
+++ b/cmd/jivetalking/pool.go
@@ -204,7 +204,6 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 
 			clone := env.base.CloneForWorker(wlog)
 
-			pass2Start := time.Now()
 			wlog("[POOL] Starting ProcessAudio for %s", inputPath)
 			result, err := deps.processAudio(env.ctx, inputPath, clone, ph.callback)
 			if err != nil {
@@ -216,11 +215,10 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 				return
 			}
 
-			// ProcessAudio runs all four passes; isolate Pass 2 by subtracting the
-			// passes the progress handler timed directly.
-			pass2Time := time.Since(pass2Start) - ph.pass1Time - ph.pass3Time - ph.pass4Time
-
-			emitProcessingReport(env, inputPath, result, ph, processingTimings{fileStart: fileStartTime, pass2: pass2Time}, diagnostics, reportWarnings, render)
+			// Pass 2 is bracketed directly by the progress handler (the Pass-2
+			// start/end updates), matching passes 1/3/4, so a missed timer cannot
+			// silently land in Pass 2.
+			emitProcessingReport(env, inputPath, result, ph, processingTimings{fileStart: fileStartTime, pass2: ph.pass2Time}, diagnostics, reportWarnings, render)
 		})
 }
 
@@ -343,9 +341,9 @@ func emitReportArtefacts(a reportArtefacts) {
 
 // processingTimings is the timing data clump emitProcessingReport needs from the
 // pool worker: fileStart marks when the worker began (feeds both the report's
-// real-time factor and the FileCompleteMsg ProcessingTime), pass2 is the isolated
-// Pass-2 wall-clock the worker computes by subtracting the progress-handler-timed
-// passes. Bundling the pair keeps the emitProcessingReport signature short.
+// real-time factor and the FileCompleteMsg ProcessingTime), pass2 is the Pass-2
+// wall-clock the progress handler brackets directly (ph.pass2Time). Bundling the
+// pair keeps the emitProcessingReport signature short.
 type processingTimings struct {
 	fileStart time.Time
 	pass2     time.Duration

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -3,7 +3,48 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/alecthomas/kong"
 )
+
+// helpTestCLI is a minimal Kong grammar exercising every branch of getFlags and
+// getArguments: a bool flag, a value flag with a placeholder, a short+long flag,
+// and a positional argument. Kong synthesises the -h/--help flag itself, so it is
+// not declared here.
+type helpTestCLI struct {
+	Files []string `arg:"" name:"files" help:"Audio files to process" optional:""`
+
+	Debug   bool   `name:"debug" help:"Enable debug logging"`
+	Output  string `name:"output" placeholder:"path" help:"Write result here"`
+	Verbose bool   `short:"v" name:"verbose"`
+}
+
+// newHelpTestContext builds a kong.Context from helpTestCLI the same way main.go
+// does (kong.New then Parse), so getFlags/getArguments see a real flag model.
+func newHelpTestContext(t *testing.T, args ...string) *kong.Context {
+	t.Helper()
+	k, err := kong.New(&helpTestCLI{}, kong.Name("jivetalking"))
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	ctx, err := k.Parse(args)
+	if err != nil {
+		t.Fatalf("kong parse: %v", err)
+	}
+	return ctx
+}
+
+// findRow returns the helpRow whose label matches, or fails the test.
+func findRow(t *testing.T, rows []helpRow, label string) helpRow {
+	t.Helper()
+	for _, r := range rows {
+		if r.label == label {
+			return r
+		}
+	}
+	t.Fatalf("no row with label %q in %+v", label, rows)
+	return helpRow{}
+}
 
 // TestWriteHelpSectionRendersRows asserts the shared section writer produces the
 // header, the two-space indent, the styled label, the two-space help separator,
@@ -33,5 +74,84 @@ func TestWriteHelpSectionEmptyRowsWritesNothing(t *testing.T) {
 	writeHelpSection(&sb, "Arguments:", helpArgStyle, nil)
 	if got := sb.String(); got != "" {
 		t.Errorf("expected no output for empty rows, got %q", got)
+	}
+}
+
+// TestGetFlagsFormatsLabels pins the hand-rolled flag-string formatting in
+// getFlags: the prepended -h/--help row, the long-only bool flag, the
+// short+long join, and the upcased =PLACEHOLDER on a value flag.
+func TestGetFlagsFormatsLabels(t *testing.T) {
+	rows := getFlags(newHelpTestContext(t))
+
+	tests := []struct {
+		name      string
+		wantLabel string
+		wantHelp  string
+	}{
+		{
+			name:      "help prepended by hand",
+			wantLabel: "-h, --help",
+			wantHelp:  "Show context-sensitive help.",
+		},
+		{
+			name:      "long-only bool flag has no placeholder",
+			wantLabel: "--debug",
+			wantHelp:  "Enable debug logging",
+		},
+		{
+			name:      "value flag upcases its placeholder",
+			wantLabel: "--output=PATH",
+			wantHelp:  "Write result here",
+		},
+		{
+			name:      "short and long flag join with comma",
+			wantLabel: "-v, --verbose",
+			wantHelp:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			row := findRow(t, rows, tt.wantLabel)
+			if row.help != tt.wantHelp {
+				t.Errorf("help for %q = %q, want %q", tt.wantLabel, row.help, tt.wantHelp)
+			}
+		})
+	}
+}
+
+// TestGetFlagsHelpFirstAndDeduplicated confirms the manual --help row is first
+// and Kong's own help flag is not emitted a second time.
+func TestGetFlagsHelpFirstAndDeduplicated(t *testing.T) {
+	rows := getFlags(newHelpTestContext(t))
+
+	if len(rows) == 0 || rows[0].label != "-h, --help" {
+		t.Fatalf("first row = %+v, want -h, --help first", rows)
+	}
+
+	help := 0
+	for _, r := range rows {
+		if strings.Contains(r.label, "--help") {
+			help++
+		}
+	}
+	if help != 1 {
+		t.Errorf("--help appears %d times, want exactly 1", help)
+	}
+}
+
+// TestGetArgumentsRendersPositionals confirms getArguments lists positional
+// arguments with their summary label and help text.
+func TestGetArgumentsRendersPositionals(t *testing.T) {
+	rows := getArguments(newHelpTestContext(t))
+
+	if len(rows) != 1 {
+		t.Fatalf("got %d argument rows, want 1: %+v", len(rows), rows)
+	}
+	if !strings.Contains(rows[0].label, "files") {
+		t.Errorf("argument label = %q, want it to mention files", rows[0].label)
+	}
+	if rows[0].help != "Audio files to process" {
+		t.Errorf("argument help = %q, want %q", rows[0].help, "Audio files to process")
 	}
 }

--- a/internal/processor/encoder.go
+++ b/internal/processor/encoder.go
@@ -225,12 +225,17 @@ func (e *Encoder) Close() error {
 // package must not import internal/ui, so the value is mirrored here.
 const meterLevelFloorDB = -70.0
 
+// meterLevelUnsupportedDB is the level reported when a frame's sample format is
+// unsupported. It is a mid-range sentinel, not the silence floor, so an
+// unsupported format shows a visible meter reading rather than looking silent.
+const meterLevelUnsupportedDB = -30.0
+
 // calculateFrameLevel returns the RMS (Root Mean Square) level of an audio frame
 // in dB, clamped to the VU-meter display range [meterLevelFloorDB, 0].
 func calculateFrameLevel(frame *ffmpeg.AVFrame) float64 {
 	sumSquares, sampleCount, _, ok := frameSumSquaresAndPeak(frame)
 	if !ok {
-		return -30.0 // Unsupported format
+		return meterLevelUnsupportedDB
 	}
 	if sampleCount == 0 {
 		return meterLevelFloorDB // Silence threshold

--- a/internal/report/metricrow.go
+++ b/internal/report/metricrow.go
@@ -91,6 +91,11 @@ func formatCell(getter func() (float64, bool), format metricFormat) string {
 // count (formatCell uses 4 for spectral, 2 otherwise; loudnormValueCell uses 2).
 func formatByRule(value float64, format metricFormat, decimals int) string {
 	switch format {
+	// fmtDB (dBFS levels) and fmtPeakDB (dBTP true peak) share formatMetricDB
+	// today: both want the "< -120" digital-silence floor and +Inf placeholder.
+	// fmtPeakDB stays a separate name so true-peak call sites read on their own
+	// axis and can diverge later (e.g. a dBTP value may exceed 0 for inter-sample
+	// peaks, so a future ceiling or infSign policy could differ from dBFS).
 	case fmtDB, fmtPeakDB:
 		return formatMetricDB(value, decimals)
 	case fmtLUFS:

--- a/internal/ui/analysis_model.go
+++ b/internal/ui/analysis_model.go
@@ -139,7 +139,7 @@ func (m AnalysisModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View renders the UI
 func (m AnalysisModel) View() tea.View {
 	if m.Width == 0 {
-		return tea.NewView("Initializing...")
+		return tea.NewView("Initialising...")
 	}
 
 	var b strings.Builder

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -315,6 +315,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case ProgressMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
+			// Deliberate in-place write into the aliased Files backing array; safe because Bubbletea drives Update/View serially.
 			m.Files[msg.FileIndex] = updateFileProgress(m.Files[msg.FileIndex], msg)
 		}
 		return m, nil
@@ -369,6 +370,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				continue
 			}
 			target := m.Files[i].CurrentLevel
+			// Deliberate in-place write into the aliased meters backing array; safe because Bubbletea drives Update/View serially.
 			m.meters[i].pos, m.meters[i].vel = m.spring.Update(
 				m.meters[i].pos, m.meters[i].vel, target)
 			m.meters[i].progPos, m.meters[i].progVel = m.progressSpring.Update(
@@ -389,7 +391,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) View() tea.View {
 	// Render a placeholder until the first WindowSizeMsg sets m.Width.
 	if m.Width == 0 {
-		view := tea.NewView(fmt.Sprintf("Initializing...\nFiles: %d\n", len(m.Files)))
+		view := tea.NewView(fmt.Sprintf("Initialising...\nFiles: %d\n", len(m.Files)))
 		view.AltScreen = true
 		return view
 	}

--- a/internal/ui/statusboxes.go
+++ b/internal/ui/statusboxes.go
@@ -97,6 +97,7 @@ func joinStatusBoxes(passBox string, file *FileProgress, termWidth int) string {
 	// the early return above. AdaptedSummary is comparable, so == is a complete key
 	// check. A height change (meter rows appearing/disappearing) re-renders here.
 	c := &file.statusBoxCache
+	// Deliberate in-place cache write during View; safe because Bubbletea drives Update/View serially.
 	if !c.valid || c.summary != file.Summary || c.joinHeight != passHeight {
 		c.chain = renderChainBox(file.Summary, passHeight)
 		c.analysis = renderAnalysisBox(file.Summary, passHeight)


### PR DESCRIPTION
  - Link Levelator comparison doc from README
  - Measure Pass 2 with dedicated timing bracket instead of subtraction
  - Add table-driven test coverage for Kong flag formatting
  - Promote bare -30.0 sentinel to named meterLevelUnsupportedDB constant
  - Document axis intent for fmtDB and fmtPeakDB separation (dBFS vs dBTP)
  - Add "deliberate in-place write" comments at Bubbletea mutation sites
  - Fix American "Initializing" spelling to British "Initialising"