### PR TITLE
fix(ui): make viewport scrollable and add visual scroll indicators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ internal/
 ├── ui/
 │   ├── analysis_model.go   # AnalysisModel - Bubbletea model for --analysis-only progress TUI
 │   ├── messages.go         # ProgressMsg, FileStartMsg, FileCompleteMsg, AllCompleteMsg
-│   ├── model.go            # Main processing TUI model
+│   ├── model.go            # Main processing TUI model; file queue sits in a bubbles/v2 viewport (scrollable under alt-screen), header pinned above
 │   └── views.go            # TUI rendering
 └── cli/                    # Help styling, version output, error formatting
 ```
@@ -120,7 +120,7 @@ Pass 4: volume (pre-gain, when clamped) → alimiter (levelling limiter, peak re
 - **Stream processing:** Check `AVErrorEOF` and `EAgain` for processing loops
 - **Submodule:** Uses `github.com/linuxmatters/ffmpeg-statigo` in `third_party/ffmpeg-statigo/` (go.mod replace directive points there)
 - **Debug logging:** `processor.DebugLog` is a package-level `func(string, ...any)` set by `main.go` when `--debug` is active; use `debugLog()` (internal wrapper) inside the processor package
-- **Charm v2:** Import `charm.land/bubbletea/v2` and `charm.land/lipgloss/v2`; never `github.com/charmbracelet/...`. Models return `View() tea.View` built with `tea.NewView(...)`, not `View() string`. Match key presses on `tea.KeyPressMsg` (interface), not `tea.KeyMsg`. Set program options as View fields (`view.AltScreen = true`), not via `tea.WithAltScreen()`. `lipgloss.Color` returns `image/color.Color`.
+- **Charm v2:** Import `charm.land/bubbletea/v2` and `charm.land/lipgloss/v2`; never `github.com/charmbracelet/...`. Models return `View() tea.View` built with `tea.NewView(...)`, not `View() string`. Match key presses on `tea.KeyPressMsg` (interface), not `tea.KeyMsg`. Set program options as View fields (`view.AltScreen = true`, `view.MouseMode = tea.MouseModeCellMotion`), not via `tea.WithAltScreen()`/`tea.WithMouseCellMotion()`. `lipgloss.Color` returns `image/color.Color`. The processing model (`model.go`) runs alt-screen (no native scrollback), so its file queue lives in a `charm.land/bubbles/v2/viewport`: built on the first `WindowSizeMsg` (sized to terminal height minus the rendered header). `View` has a VALUE receiver, so it must stay pure: content is set on the PERSISTENT viewport in `Update` via `refreshViewportContent` (called after every queue-changing message AND every `meterTickMsg`, so the live meters animate), never in `View` (a `SetContent` there mutates a throwaway copy and the real viewport stays empty/unscrollable). Scrolling: mouse wheel + pager keys are forwarded through `m.vp.Update(msg)` after `handleCommonMsg` (which owns the quit keys and the resize); that branch does NOT call `refreshViewportContent` (re-pinning would cancel an upward scroll). The header (title + overall box) is pinned outside the viewport. The viewport follows the active files (`refreshViewportContent` re-pins to bottom while the user is at bottom; a user who scrolls up keeps position).
 
 ## Testing instructions
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -3,6 +3,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/progress"
@@ -317,10 +318,18 @@ func (m Model) Init() tea.Cmd {
 	return meterTick()
 }
 
-// processingFooterHeight is the row count View() reserves below the viewport.
-// The processing view has no footer, so it is zero; named so the viewport-height
-// maths reads symmetrically with the header reservation.
-const processingFooterHeight = 0
+// processingFooterHeight is the row count View() reserves below the viewport for
+// the scroll-hint footer. It is ALWAYS 1, even when the queue fits and the hint
+// is blank: reserving the row unconditionally keeps the viewport height (and so
+// the file boxes) from reflowing when the hint toggles on overflow.
+const processingFooterHeight = 1
+
+// scrollbarWidth is the column reserved at the right edge of the viewport for the
+// vertical scrollbar strip. The viewport is sized to m.Width - scrollbarWidth so
+// the strip joins beside it without pushing content off-screen; the column is
+// reserved unconditionally (a blank strip when the queue fits) so the file boxes
+// never reflow when the scrollbar toggles on overflow.
+const scrollbarWidth = 1
 
 // sizeViewport (re)builds and sizes the file-queue viewport from the current
 // terminal dimensions. The viewport height is the terminal height minus the
@@ -334,12 +343,15 @@ func (m *Model) sizeViewport() {
 	}
 	headerHeight := lipgloss.Height(renderProcessingHeader(*m))
 	vpHeight := max(m.Height-headerHeight-processingFooterHeight, 1)
+	// Reserve one column for the scrollbar strip, floored at 1 so a tiny terminal
+	// still yields a usable viewport.
+	vpWidth := max(m.Width-scrollbarWidth, 1)
 	if !m.vpReady {
-		m.vp = viewport.New(viewport.WithWidth(m.Width), viewport.WithHeight(vpHeight))
+		m.vp = viewport.New(viewport.WithWidth(vpWidth), viewport.WithHeight(vpHeight))
 		m.vpReady = true
 		return
 	}
-	m.vp.SetWidth(m.Width)
+	m.vp.SetWidth(vpWidth)
 	m.vp.SetHeight(vpHeight)
 }
 
@@ -512,7 +524,34 @@ func (m Model) renderScrollingView() string {
 	}
 	// Pure render: the viewport's content and scroll offset are managed in Update
 	// (refreshViewportContent), since View's value receiver discards any mutation.
-	return renderProcessingHeader(m) + "\n" + m.vp.View()
+	//
+	// The scrollbar and the scroll hint appear ONLY when the file queue overflows
+	// the viewport. Both the scrollbar column and the hint row are reserved
+	// unconditionally in sizeViewport / processingFooterHeight, so toggling them
+	// fills a pre-reserved slot and never reflows the file boxes.
+	overflow := m.vp.TotalLineCount() > m.vp.Height()
+
+	body := lipgloss.JoinHorizontal(lipgloss.Top, m.vp.View(), m.scrollbarStrip(overflow))
+
+	hint := ""
+	if overflow {
+		hint = renderScrollHint()
+	}
+
+	return renderProcessingHeader(m) + "\n" + body + "\n" + hint
+}
+
+// scrollbarStrip returns the right-edge scrollbar column for the viewport. On
+// overflow it is the live thumb/track strip from the viewport's scroll state; when
+// the queue fits it is a blank strip of spaces so the reserved column holds its
+// width and the file boxes do not reflow. Read-only viewport queries only, keeping
+// renderScrollingView pure.
+func (m Model) scrollbarStrip(overflow bool) string {
+	vpHeight := m.vp.Height()
+	if !overflow {
+		return strings.TrimRight(strings.Repeat(" \n", vpHeight), "\n")
+	}
+	return renderScrollbar(vpHeight, m.vp.TotalLineCount(), vpHeight, m.vp.ScrollPercent())
 }
 
 // updateFileProgress updates a FileProgress based on a ProgressMsg

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/progress"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/harmonica"
 	"github.com/linuxmatters/jivetalking/internal/cli"
 	"github.com/linuxmatters/jivetalking/internal/processor"
@@ -228,6 +230,15 @@ type Model struct {
 	// Progress bar (owned by Update; rendered via ViewAs)
 	progress progress.Model
 
+	// vp scrolls the file queue inside the alt-screen processing view, which has
+	// no native scrollback. The title + overall-progress header stays pinned
+	// above it; vp holds only the file list. Built on the first WindowSizeMsg
+	// (the zero Model has no usable viewport: New() sets MouseWheelEnabled and the
+	// initialised flag), then resized on each subsequent resize. vpReady gates the
+	// pre-size frames so View() renders the unscrolled fallback until then.
+	vp      viewport.Model
+	vpReady bool
+
 	// Eased audio level meter and progress bar state, parallel to Files (keyed
 	// by file index). Owned and mutated only in Update; never touched by pool
 	// workers.
@@ -306,9 +317,79 @@ func (m Model) Init() tea.Cmd {
 	return meterTick()
 }
 
+// processingFooterHeight is the row count View() reserves below the viewport.
+// The processing view has no footer, so it is zero; named so the viewport-height
+// maths reads symmetrically with the header reservation.
+const processingFooterHeight = 0
+
+// sizeViewport (re)builds and sizes the file-queue viewport from the current
+// terminal dimensions. The viewport height is the terminal height minus the
+// rendered header height (title + overall box) and the footer reservation,
+// floored at 1 so a tiny terminal still yields a usable viewport. The header
+// height is measured from the rendered header, not guessed, so it tracks any
+// future header change automatically.
+func (m *Model) sizeViewport() {
+	if m.Width <= 0 || m.Height <= 0 {
+		return
+	}
+	headerHeight := lipgloss.Height(renderProcessingHeader(*m))
+	vpHeight := max(m.Height-headerHeight-processingFooterHeight, 1)
+	if !m.vpReady {
+		m.vp = viewport.New(viewport.WithWidth(m.Width), viewport.WithHeight(vpHeight))
+		m.vpReady = true
+		return
+	}
+	m.vp.SetWidth(m.Width)
+	m.vp.SetHeight(vpHeight)
+}
+
+// refreshViewportContent re-renders the file queue into the PERSISTENT viewport
+// so its content (and therefore its scrollable height) tracks the model. It must
+// run in Update, not View: View has a value receiver, so any SetContent there
+// mutates a throwaway copy and the real viewport stays empty and unscrollable.
+//
+// Follow-the-active-files: if the user has not scrolled up (still at the bottom),
+// re-pin to the bottom after setting content so in-progress entries stay visible
+// as the list grows. A user who scrolled up keeps their offset (the wheel/key
+// branch never calls this, so it never yanks them back down). renderFileQueue
+// takes the model by value, hence *m.
+func (m *Model) refreshViewportContent() {
+	if !m.vpReady {
+		return
+	}
+	atBottom := m.vp.AtBottom()
+	m.vp.SetContent(renderFileQueue(*m, m.progress))
+	if atBottom {
+		m.vp.GotoBottom()
+	}
+}
+
 // Update handles messages and updates the model
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if handled, cmd := handleCommonMsg(msg, &m.Width, &m.Height, &m.Done, &m.progress, processingBarOverhead); handled {
+		// handleCommonMsg owns WindowSizeMsg (it stores the new dimensions); size
+		// the file-queue viewport to the area below the fixed header, then load its
+		// content so the scrollable height is correct from the first frame.
+		if _, ok := msg.(tea.WindowSizeMsg); ok {
+			m.sizeViewport()
+			m.refreshViewportContent()
+		}
+		// Scroll keys (PgUp/PgDn/arrows) are KeyPressMsg values that handleCommonMsg
+		// does NOT own (only the quit keys), so they fall through below. The quit
+		// keys return tea.Quit here and never reach the viewport.
+		return m, cmd
+	}
+
+	// Forward scroll input (mouse wheel + pager keys) to the viewport so it can
+	// page the file queue. handleCommonMsg already consumed the quit keys and the
+	// resize, so they never reach here; everything else is safe to forward. Do NOT
+	// refresh content here: refreshViewportContent re-pins to the bottom, which
+	// would cancel the user's upward scroll. The content set on the prior message
+	// is still loaded, so there is something to scroll.
+	switch msg.(type) {
+	case tea.MouseWheelMsg, tea.KeyPressMsg:
+		var cmd tea.Cmd
+		m.vp, cmd = m.vp.Update(msg)
 		return m, cmd
 	}
 
@@ -318,6 +399,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Deliberate in-place write into the aliased Files backing array; safe because Bubbletea drives Update/View serially.
 			m.Files[msg.FileIndex] = updateFileProgress(m.Files[msg.FileIndex], msg)
 		}
+		m.refreshViewportContent()
 		return m, nil
 
 	case FileStartMsg:
@@ -325,6 +407,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Files[msg.FileIndex].Status = StatusAnalysing
 			m.Files[msg.FileIndex].StartTime = time.Now()
 		}
+		m.refreshViewportContent()
 		return m, nil
 
 	case AdaptedSummaryMsg:
@@ -339,6 +422,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// input the panels read.
 			m.Files[msg.FileIndex].statusBoxCache.valid = false
 		}
+		m.refreshViewportContent()
 		return m, nil
 
 	case FileCompleteMsg:
@@ -353,6 +437,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.CompletedFiles++
 			}
 		}
+		m.refreshViewportContent()
 		return m, nil
 
 	case meterTickMsg:
@@ -378,6 +463,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.meters[i].peakPos, m.meters[i].peakVel = m.peakSpring.Update(
 				m.meters[i].peakPos, m.meters[i].peakVel, m.Files[i].PeakLevel)
 		}
+		// The meters change every tick, so the eased display in the viewport must
+		// re-render every tick too, else the live level/progress freezes once the
+		// content is loaded.
+		m.refreshViewportContent()
 		if !m.anyActive() {
 			return m, nil
 		}
@@ -398,12 +487,32 @@ func (m Model) View() tea.View {
 
 	var view tea.View
 	if m.Done {
+		// On completion the program quits to the normal buffer (AllCompleteMsg ->
+		// tea.Quit), where the completion summary is reprinted with native
+		// scrollback. Render it whole here for the brief final frame.
 		view = tea.NewView(renderCompletionSummary(m))
 	} else {
-		view = tea.NewView(renderProcessingView(m))
+		view = tea.NewView(m.renderScrollingView())
 	}
 	view.AltScreen = true
+	// Enable mouse cell-motion so the viewport receives MouseWheelMsg; its own
+	// MouseWheelEnabled (default true) then scrolls the file queue.
+	view.MouseMode = tea.MouseModeCellMotion
 	return view
+}
+
+// renderScrollingView composes the pinned header with the scrollable file queue.
+// The header (title + overall progress) stays fixed; the file list lives inside
+// the viewport so the user can scroll it with the wheel or pager keys during a
+// run. Before the first WindowSizeMsg sizes the viewport, it falls back to the
+// unscrolled stack so early frames still render.
+func (m Model) renderScrollingView() string {
+	if !m.vpReady {
+		return renderProcessingView(m)
+	}
+	// Pure render: the viewport's content and scroll offset are managed in Update
+	// (refreshViewportContent), since View's value receiver discards any mutation.
+	return renderProcessingHeader(m) + "\n" + m.vp.View()
 }
 
 // updateFileProgress updates a FileProgress based on a ProgressMsg

--- a/internal/ui/model_routing_test.go
+++ b/internal/ui/model_routing_test.go
@@ -139,15 +139,17 @@ func TestWindowSizeMsgSizesViewport(t *testing.T) {
 	if !m.vpReady {
 		t.Fatal("WindowSizeMsg did not build the viewport")
 	}
-	if m.vp.Width() != 100 {
-		t.Errorf("viewport width = %d, want 100", m.vp.Width())
+	// Width is the terminal width minus the reserved scrollbar column.
+	if m.vp.Width() != 100-scrollbarWidth {
+		t.Errorf("viewport width = %d, want %d (100 - scrollbar %d)", m.vp.Width(), 100-scrollbarWidth, scrollbarWidth)
 	}
-	// Height must be the terminal height minus the rendered header, never the
-	// full terminal height (the header stays pinned outside the viewport).
+	// Height must be the terminal height minus the rendered header and the
+	// scroll-hint footer row, never the full terminal height (the header stays
+	// pinned outside the viewport; the footer row is reserved unconditionally).
 	headerHeight := lipgloss.Height(renderProcessingHeader(m))
-	wantHeight := 30 - headerHeight
+	wantHeight := 30 - headerHeight - processingFooterHeight
 	if m.vp.Height() != wantHeight {
-		t.Errorf("viewport height = %d, want %d (30 - header %d)", m.vp.Height(), wantHeight, headerHeight)
+		t.Errorf("viewport height = %d, want %d (30 - header %d - footer %d)", m.vp.Height(), wantHeight, headerHeight, processingFooterHeight)
 	}
 	if m.vp.Height() >= 30 {
 		t.Errorf("viewport height %d not reduced below terminal height 30; header not reserved", m.vp.Height())
@@ -156,8 +158,8 @@ func TestWindowSizeMsgSizesViewport(t *testing.T) {
 	// A second resize re-sizes the existing viewport rather than rebuilding.
 	updated, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
 	m = updated.(Model)
-	if m.vp.Width() != 80 {
-		t.Errorf("viewport width after resize = %d, want 80", m.vp.Width())
+	if m.vp.Width() != 80-scrollbarWidth {
+		t.Errorf("viewport width after resize = %d, want %d (80 - scrollbar %d)", m.vp.Width(), 80-scrollbarWidth, scrollbarWidth)
 	}
 }
 

--- a/internal/ui/model_routing_test.go
+++ b/internal/ui/model_routing_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
@@ -104,12 +105,156 @@ func TestWindowSizeMsgPreservesRoutedFiles(t *testing.T) {
 	if m.Width != 120 || m.Height != 40 {
 		t.Errorf("dimensions not stored: Width=%d Height=%d, want 120/40", m.Width, m.Height)
 	}
+	// The resize builds and fills the viewport, so the file queue now renders
+	// inside Update on the persistent model. Rendering populates the presentation
+	// -only render caches (statusBoxCache / fileDetailsTitleCache) in place, so a
+	// whole-struct equality would trip on those. Assert the routed DATA contract
+	// survives instead (that is what this test guards); the render caches are
+	// derived state and excluded by clearing them on both sides before comparing.
 	for i := range want {
-		if m.Files[i] != want[i] {
-			t.Errorf("Files[%d] changed after WindowSizeMsg: got %+v, want %+v", i, m.Files[i], want[i])
+		got := m.Files[i]
+		got.statusBoxCache = statusBoxCache{}
+		got.fileDetailsTitleCache = overlayTitleCache{}
+		wantData := want[i]
+		wantData.statusBoxCache = statusBoxCache{}
+		wantData.fileDetailsTitleCache = overlayTitleCache{}
+		if got != wantData {
+			t.Errorf("Files[%d] routed data changed after WindowSizeMsg: got %+v, want %+v", i, got, wantData)
 		}
 	}
 	_ = m.progress.ViewAs(m.Files[0].Progress)
+}
+
+func TestWindowSizeMsgSizesViewport(t *testing.T) {
+	m := NewModel([]string{"a.wav", "b.wav"})
+
+	// Before a resize the viewport is not built.
+	if m.vpReady {
+		t.Fatal("viewport ready before any WindowSizeMsg, want unbuilt")
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(Model)
+
+	if !m.vpReady {
+		t.Fatal("WindowSizeMsg did not build the viewport")
+	}
+	if m.vp.Width() != 100 {
+		t.Errorf("viewport width = %d, want 100", m.vp.Width())
+	}
+	// Height must be the terminal height minus the rendered header, never the
+	// full terminal height (the header stays pinned outside the viewport).
+	headerHeight := lipgloss.Height(renderProcessingHeader(m))
+	wantHeight := 30 - headerHeight
+	if m.vp.Height() != wantHeight {
+		t.Errorf("viewport height = %d, want %d (30 - header %d)", m.vp.Height(), wantHeight, headerHeight)
+	}
+	if m.vp.Height() >= 30 {
+		t.Errorf("viewport height %d not reduced below terminal height 30; header not reserved", m.vp.Height())
+	}
+
+	// A second resize re-sizes the existing viewport rather than rebuilding.
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	m = updated.(Model)
+	if m.vp.Width() != 80 {
+		t.Errorf("viewport width after resize = %d, want 80", m.vp.Width())
+	}
+}
+
+func TestQuitKeysStillQuitWithViewport(t *testing.T) {
+	m := NewModel([]string{"a.wav"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(Model)
+
+	keys := []tea.KeyPressMsg{
+		{Text: "q", Code: 'q'},
+		{Mod: tea.ModCtrl, Code: 'c'},
+	}
+	for _, key := range keys {
+		_, cmd := m.Update(key)
+		if cmd == nil {
+			t.Fatalf("%q produced nil cmd, want tea.Quit", key.String())
+		}
+		if msg := cmd(); msg == nil {
+			t.Errorf("%q cmd yielded nil msg, want a QuitMsg", key.String())
+		} else if _, ok := msg.(tea.QuitMsg); !ok {
+			t.Errorf("%q cmd yielded %T, want tea.QuitMsg", key.String(), msg)
+		}
+	}
+}
+
+// scrollableModel builds a processing model with enough queued files that the
+// file queue overflows a short viewport, so scrolling has somewhere to go. It
+// drives only real messages through Update, so the PERSISTENT viewport holds the
+// content (the regression these tests guard: content was previously set on a
+// throwaway copy in View and never reached the real viewport).
+func scrollableModel(t *testing.T) Model {
+	t.Helper()
+	files := make([]string, 40)
+	for i := range files {
+		files[i] = "file.wav"
+	}
+	m := NewModel(files)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 12})
+	return updated.(Model)
+}
+
+// TestViewportReceivesContentFromUpdate proves the file queue reaches the
+// PERSISTENT viewport, not a throwaway copy in View. After a resize plus a
+// routed message, the viewport's content height must exceed its own height so it
+// is actually scrollable. This fails against the prior View-only SetContent,
+// where the real viewport stayed empty (content height <= viewport height).
+func TestViewportReceivesContentFromUpdate(t *testing.T) {
+	m := scrollableModel(t)
+
+	// A routed message goes through the content-refresh path in Update.
+	updated, _ := m.Update(FileStartMsg{FileIndex: 0})
+	m = updated.(Model)
+
+	// TotalLineCount reflects the loaded content; a scrollable viewport has more
+	// content lines than its own height.
+	if got := m.vp.TotalLineCount(); got <= m.vp.Height() {
+		t.Errorf("viewport content height = %d, want > viewport height %d (content did not reach the persistent viewport)", got, m.vp.Height())
+	}
+}
+
+// TestScrollKeysForwardedToViewport confirms a pager key (PgDown) moves the
+// viewport offset. Content is loaded purely by Update (the WindowSizeMsg refresh
+// in scrollableModel), then GotoTop puts it at the top so PgDown has room to move
+// down.
+func TestScrollKeysForwardedToViewport(t *testing.T) {
+	m := scrollableModel(t)
+	m.vp.GotoTop()
+	startOffset := m.vp.YOffset()
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	m = updated.(Model)
+
+	if m.vp.YOffset() <= startOffset {
+		t.Errorf("PgDown did not scroll the viewport: offset %d, want > %d", m.vp.YOffset(), startOffset)
+	}
+}
+
+// TestMouseWheelMovesOffset confirms a wheel-up event moves the persistent
+// viewport's scroll offset. Driven from the bottom-pinned state the Update path
+// leaves after content load: a wheel up must DECREASE the offset. This fails on
+// the old code path, where the real viewport had no content and the offset was
+// pinned at zero with nowhere to move.
+func TestMouseWheelMovesOffset(t *testing.T) {
+	m := scrollableModel(t)
+
+	// scrollableModel leaves the viewport bottom-pinned (content loaded on resize).
+	startOffset := m.vp.YOffset()
+	if startOffset == 0 {
+		t.Fatalf("expected a non-zero bottom-pinned offset after content load, got 0 (content did not reach the persistent viewport)")
+	}
+
+	updated, _ := m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	m = updated.(Model)
+
+	if m.vp.YOffset() >= startOffset {
+		t.Errorf("wheel up did not scroll up: offset %d, want < %d", m.vp.YOffset(), startOffset)
+	}
 }
 
 func TestRenderOverallProgressFooter(t *testing.T) {

--- a/internal/ui/scrollbar_test.go
+++ b/internal/ui/scrollbar_test.go
@@ -1,0 +1,182 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestBuildScrollbarThumbMaths table-tests the pure scrollbar helper: thumb
+// height tracks the visible fraction and thumb position tracks the scroll
+// percent. A tall content (small visible fraction) yields a short thumb.
+func TestBuildScrollbarThumbMaths(t *testing.T) {
+	const vpHeight = 10
+
+	cases := []struct {
+		name          string
+		totalLines    int
+		visibleLines  int
+		scrollPercent float64
+		wantThumbH    int
+		wantThumbTop  int
+	}{
+		// Half-visible content: thumb is half the strip.
+		{"half top", 20, 10, 0.0, 5, 0},
+		{"half middle", 20, 10, 0.5, 5, 3}, // round((10-5)*0.5)=3
+		{"half bottom", 20, 10, 1.0, 5, 5}, // thumb pinned to the bottom
+		// Tall content: a small visible fraction gives a short (floored) thumb.
+		{"tall short thumb top", 100, 10, 0.0, 1, 0},
+		{"tall short thumb bottom", 100, 10, 1.0, 1, 9}, // (10-1)*1.0
+		// Just-overflowing content keeps the thumb near full height.
+		{"barely over top", 11, 10, 0.0, 9, 0},    // round(10*10/11)=9
+		{"barely over bottom", 11, 10, 1.0, 9, 1}, // (10-9)*1.0
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := buildScrollbar(vpHeight, tc.totalLines, tc.visibleLines, tc.scrollPercent)
+			if len(rows) != vpHeight {
+				t.Fatalf("strip height = %d, want %d", len(rows), vpHeight)
+			}
+
+			// Thumb is the contiguous run of thumb glyphs; locate its top and length.
+			top, height := -1, 0
+			for i, r := range rows {
+				if r == scrollbarThumbGlyph {
+					if top == -1 {
+						top = i
+					}
+					height++
+				}
+			}
+			if height != tc.wantThumbH {
+				t.Errorf("thumb height = %d, want %d (rows %v)", height, tc.wantThumbH, rows)
+			}
+			if top != tc.wantThumbTop {
+				t.Errorf("thumb top = %d, want %d (rows %v)", top, tc.wantThumbTop, rows)
+			}
+
+			// Every non-thumb row is a track glyph; no empty cells.
+			for i, r := range rows {
+				if r != scrollbarThumbGlyph && r != scrollbarTrackGlyph {
+					t.Errorf("row %d = %q, want thumb or track glyph", i, r)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildScrollbarTallContentShortThumb confirms the thumb shrinks as content
+// grows relative to a fixed viewport: more total lines means a shorter thumb.
+func TestBuildScrollbarTallContentShortThumb(t *testing.T) {
+	const vpHeight = 20
+
+	thumbHeight := func(total int) int {
+		rows := buildScrollbar(vpHeight, total, vpHeight, 0.0)
+		h := 0
+		for _, r := range rows {
+			if r == scrollbarThumbGlyph {
+				h++
+			}
+		}
+		return h
+	}
+
+	short := thumbHeight(40)    // half visible -> ~10
+	shorter := thumbHeight(200) // tenth visible -> ~2
+	if short <= shorter {
+		t.Errorf("taller content should yield a shorter thumb: 40-line=%d, 200-line=%d", short, shorter)
+	}
+	if shorter < 1 {
+		t.Errorf("thumb must floor at 1, got %d", shorter)
+	}
+}
+
+// TestScrollbarAndHintAbsentWhenContentFits confirms NEITHER the scrollbar thumb
+// nor the scroll hint render when the file queue fits the viewport (few files,
+// tall terminal).
+func TestScrollbarAndHintAbsentWhenContentFits(t *testing.T) {
+	m := NewModel([]string{"a.wav", "b.wav"})
+	m.Width = 120
+	m.Height = 200 // very tall: two queued files cannot overflow
+	m.sizeViewport()
+	m.refreshViewportContent()
+
+	if m.vp.TotalLineCount() > m.vp.Height() {
+		t.Fatalf("test setup: content overflows (%d > %d); expected it to fit",
+			m.vp.TotalLineCount(), m.vp.Height())
+	}
+
+	plain := ansi.Strip(m.renderScrollingView())
+
+	if strings.Contains(plain, scrollbarThumbGlyph) {
+		t.Errorf("scrollbar thumb present when content fits:\n%s", plain)
+	}
+	if strings.Contains(plain, "to navigate") {
+		t.Errorf("scroll hint present when content fits:\n%s", plain)
+	}
+}
+
+// TestScrollbarAndHintPresentWhenContentOverflows confirms BOTH the scrollbar
+// thumb and the scroll hint render when the file queue overflows the viewport
+// (many files, short terminal).
+func TestScrollbarAndHintPresentWhenContentOverflows(t *testing.T) {
+	files := make([]string, 40)
+	for i := range files {
+		files[i] = "file.wav"
+	}
+	m := NewModel(files)
+	m.Width = 120
+	m.Height = 12 // short terminal: 40 queued files overflow
+	m.sizeViewport()
+	m.refreshViewportContent()
+
+	if m.vp.TotalLineCount() <= m.vp.Height() {
+		t.Fatalf("test setup: content fits (%d <= %d); expected it to overflow",
+			m.vp.TotalLineCount(), m.vp.Height())
+	}
+
+	plain := ansi.Strip(m.renderScrollingView())
+
+	if !strings.Contains(plain, scrollbarThumbGlyph) {
+		t.Errorf("scrollbar thumb absent when content overflows:\n%s", plain)
+	}
+	if !strings.Contains(plain, scrollHintText) {
+		t.Errorf("scroll hint absent when content overflows:\n%s", plain)
+	}
+}
+
+// TestScrollingViewWidthStableAcrossOverflow confirms the rendered width does not
+// change between the fits and overflows cases: the scrollbar column and hint row
+// are reserved unconditionally, so the file boxes never reflow when they toggle.
+func TestScrollingViewWidthStableAcrossOverflow(t *testing.T) {
+	width, height := 120, 14
+
+	fits := NewModel([]string{"a.wav", "b.wav"})
+	fits.Width, fits.Height = width, height
+	fits.sizeViewport()
+	fits.refreshViewportContent()
+	if fits.vp.TotalLineCount() > fits.vp.Height() {
+		t.Fatalf("test setup: fits case overflows")
+	}
+
+	manyFiles := make([]string, 40)
+	for i := range manyFiles {
+		manyFiles[i] = "file.wav"
+	}
+	overflows := NewModel(manyFiles)
+	overflows.Width, overflows.Height = width, height
+	overflows.sizeViewport()
+	overflows.refreshViewportContent()
+	if overflows.vp.TotalLineCount() <= overflows.vp.Height() {
+		t.Fatalf("test setup: overflow case fits")
+	}
+
+	// Both viewports were sized from the same terminal width, so the reserved
+	// scrollbar column gives them identical viewport widths regardless of overflow.
+	if fits.vp.Width() != overflows.vp.Width() {
+		t.Errorf("viewport width differs across overflow: fits=%d overflows=%d",
+			fits.vp.Width(), overflows.vp.Width())
+	}
+}

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -41,6 +41,84 @@ func renderProcessingHeader(m Model) string {
 	return b.String()
 }
 
+// scrollbarThumbGlyph and scrollbarTrackGlyph are the scrollbar cells: a solid
+// block for the thumb (the visible slice) and a thin vertical for the track.
+const (
+	scrollbarThumbGlyph = "█"
+	scrollbarTrackGlyph = "│"
+)
+
+// scrollHintText is the dim one-line footer shown only while the file queue
+// overflows the viewport. It names the scroll inputs in plain British English.
+const scrollHintText = "↑/↓ · PgUp/PgDn · scroll to navigate"
+
+// buildScrollbar builds the vertical scrollbar strip for the file-queue
+// viewport: vpHeight rows tall, one column wide, a thumb sized to the visible
+// fraction of the content and positioned by the scroll percent. It is pure (no
+// viewport handle, no styling) so the thumb maths is table-testable; the caller
+// styles and joins the returned rows. scrollPercent is the viewport's 0..1
+// scroll position. The returned slice always has exactly vpHeight rows (each a
+// single glyph), so it joins cleanly to the right of the viewport view.
+func buildScrollbar(vpHeight, totalLines, visibleLines int, scrollPercent float64) []string {
+	if vpHeight <= 0 {
+		return nil
+	}
+
+	// Visible fraction of the whole content, clamped to (0,1]. A non-positive
+	// total degrades to a full-height thumb so the strip never renders empty.
+	visibleFraction := 1.0
+	if totalLines > 0 {
+		visibleFraction = float64(visibleLines) / float64(totalLines)
+	}
+	visibleFraction = math.Max(0, math.Min(1, visibleFraction))
+
+	thumbHeight := int(math.Round(float64(vpHeight) * visibleFraction))
+	thumbHeight = max(1, min(thumbHeight, vpHeight))
+
+	scrollPercent = math.Max(0, math.Min(1, scrollPercent))
+	thumbTop := int(math.Round(float64(vpHeight-thumbHeight) * scrollPercent))
+	thumbTop = max(0, min(thumbTop, vpHeight-thumbHeight))
+
+	rows := make([]string, vpHeight)
+	for i := range rows {
+		if i >= thumbTop && i < thumbTop+thumbHeight {
+			rows[i] = scrollbarThumbGlyph
+		} else {
+			rows[i] = scrollbarTrackGlyph
+		}
+	}
+	return rows
+}
+
+// renderScrollbar styles the buildScrollbar rows into a single column block: the
+// thumb in the muted fill colour (the same dim tone the empty meter track uses),
+// the track in the dimmer ColorFill so the thumb stands out against it.
+func renderScrollbar(vpHeight, totalLines, visibleLines int, scrollPercent float64) string {
+	rows := buildScrollbar(vpHeight, totalLines, visibleLines, scrollPercent)
+	thumbStyle := lipgloss.NewStyle().Foreground(cli.ColorMuted)
+	trackStyle := lipgloss.NewStyle().Foreground(cli.ColorFill)
+
+	var b strings.Builder
+	for i, row := range rows {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if row == scrollbarThumbGlyph {
+			b.WriteString(thumbStyle.Render(row))
+		} else {
+			b.WriteString(trackStyle.Render(row))
+		}
+	}
+	return b.String()
+}
+
+// renderScrollHint renders the dim scroll-hint footer line. The caller decides
+// whether to fill it (overflow) or leave it blank (fits); this always returns the
+// styled text so the gating lives in one place upstream.
+func renderScrollHint() string {
+	return lipgloss.NewStyle().Foreground(cli.ColorMuted).Render(scrollHintText)
+}
+
 // renderFileQueue renders the list of files with their status
 func renderFileQueue(m Model, prog progress.Model) string {
 	var b strings.Builder

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -15,8 +15,19 @@ import (
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
-// renderProcessingView renders the main processing view
+// renderProcessingView renders the header and file queue as one unscrolled
+// stack. View() drives the live UI through the viewport instead; this is the
+// pre-size fallback (before the first WindowSizeMsg builds the viewport) and the
+// section-order reference the layout tests assert against.
 func renderProcessingView(m Model) string {
+	return renderProcessingHeader(m) + "\n" + renderFileQueue(m, m.progress)
+}
+
+// renderProcessingHeader renders the fixed header above the scrollable file
+// queue: the title and the overall-progress box. View() keeps this outside the
+// viewport so it stays pinned while the file list scrolls. The two trailing
+// blank lines reproduce the prior gap between the box and the first file entry.
+func renderProcessingHeader(m Model) string {
 	var b strings.Builder
 
 	// Header (title only)
@@ -25,10 +36,7 @@ func renderProcessingView(m Model) string {
 
 	// Overall progress box, directly under the title
 	b.WriteString(renderOverallProgress(m))
-	b.WriteString("\n\n")
-
-	// File queue
-	b.WriteString(renderFileQueue(m, m.progress))
+	b.WriteString("\n")
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary

Terminal output is now scrollable during file processing. On macOS Terminal.app with multiple files, users can scroll to review queued files that overflow the viewport height. Added visual feedback with a scrollbar and scroll hints when content overflows.

## Changes

- Move viewport content management from View() to Update() so mutations persist to the model (fixes the throwaway-copy bug that blocked scroll events)
- Add refreshViewportContent() to maintain bottom-follow (active-file tracking) during processing
- Render vertical scrollbar (thumb and track) and dim hint footer (↑/↓ · PgUp/PgDn · scroll to navigate) only on overflow; layout remains stable
- Make View() and renderScrollingView() pure: header + viewport only

## Testing

- Regression tests: viewport content reaches the persistent model, wheel and keyboard scroll events move the offset
- Visual layout stability: scrollbar and hint appear only on overflow; no layout shift when content fits
- Manual test: multi-file run on Terminal.app; scroll works throughout processing

Fixes #133