### PR TITLE
fix(processor,ui): show meaningful noise floor for voice-activated input

### DIFF
--- a/internal/processor/quality.go
+++ b/internal/processor/quality.go
@@ -149,19 +149,21 @@ func OutputNoiseFloor(result *ProcessingResult) (float64, bool) {
 	return finalRoomToneRMS(result)
 }
 
-// InputNoiseFloor resolves the input room-tone RMS floor (dBFS) for display,
-// the before half of the done-box before->after pair whose after half is
-// OutputNoiseFloor. Both ends are RegionSample.RMSLevel on the same astats RMS
-// dBFS axis, so the pair is honestly comparable. It delegates to
-// InputRoomToneFloorDB, which reads only the elected room-tone RegionSample
-// (ElectedRoomToneSample, measured by the same interval accumulation that
-// MeasureOutputRegions uses for the output). The bool is false when no elected
-// sample exists.
+// InputNoiseFloor resolves the input noise floor (dBFS) for display, the before
+// half of the done-box before->after pair whose after half is OutputNoiseFloor.
+// It delegates to InputDisplayNoiseFloorDB, the same resolver the live Analysis
+// box uses, so the live box and the done-box "before" always show the same number
+// for a file. For normal captures that is the astats room-tone RMS floor, the same
+// axis as OutputNoiseFloor so the pair is honestly comparable. For voice-activated
+// captures it is the VAD momentary-LUFS floor (the astats room tone is digital
+// silence); the after half stays astats and the noise-floor row shows no delta, so
+// the two ends are read side by side without a cross-axis subtraction. The bool is
+// false when no floor is measurable.
 func InputNoiseFloor(result *ProcessingResult) (float64, bool) {
 	if result == nil {
 		return 0, false
 	}
-	return InputRoomToneFloorDB(result.Measurements)
+	return InputDisplayNoiseFloorDB(result.Measurements)
 }
 
 // InputRoomToneFloorDB resolves the canonical input room-tone RMS floor (dBFS)
@@ -190,6 +192,31 @@ func InputRoomToneFloorDB(m *AudioMeasurements) (float64, bool) {
 		return 0, false
 	}
 	return floor, true
+}
+
+// InputDisplayNoiseFloorDB resolves the input noise floor SHOWN to the user, the
+// single source of truth for the live Analysis box (summary.go) and the done-box
+// "before" (via InputNoiseFloor). Both surfaces call this so they never diverge.
+//
+// Normally it returns the astats room-tone RMS floor (InputRoomToneFloorDB). For
+// voice-activated captures the room tone is digital silence, so that astats floor
+// pins to the -120 sentinel and is meaningless; it returns the VAD momentary-LUFS
+// floor (NoiseProfile.MeasuredNoiseFloor) instead, which excludes the silence gaps
+// and is the floor the Recording score uses. A 0 or non-finite momentary value is
+// the unmeasured sentinel, so it falls back to the astats floor.
+//
+// This is display-only. The quality SCORE keeps reading InputRoomToneFloorDB
+// (astats) directly via inputRoomToneRMS, so the axis the scorer compares against
+// is unchanged. See the "Measurement axes" section in AGENTS.md.
+func InputDisplayNoiseFloorDB(m *AudioMeasurements) (float64, bool) {
+	if m != nil && m.Noise.VoiceActivated {
+		if np := m.Regions.NoiseProfile; np != nil {
+			if f := np.MeasuredNoiseFloor; f != 0 && !math.IsNaN(f) && !math.IsInf(f, 0) {
+				return f, true
+			}
+		}
+	}
+	return InputRoomToneFloorDB(m)
 }
 
 // OutputTP resolves the final-output true peak (dBTP) for the done-box

--- a/internal/processor/quality_test.go
+++ b/internal/processor/quality_test.go
@@ -139,10 +139,12 @@ func TestInputNoiseFloorPrefersElectedSample(t *testing.T) {
 	}
 }
 
-// TestInputNoiseFloorNoMomentaryLeakage locks the axis contract: with no elected
-// room-tone sample, InputNoiseFloor returns ok = false. It must NOT fall back to
-// NoiseProfile.MeasuredNoiseFloor, which is on the K-weighted momentary-LUFS
-// axis, not the displayed astats RMS dBFS axis.
+// TestInputNoiseFloorNoMomentaryLeakage locks the axis contract for a normal
+// (non-voice-activated) capture: with no elected room-tone sample, InputNoiseFloor
+// returns ok = false. It must NOT fall back to NoiseProfile.MeasuredNoiseFloor,
+// which is on the K-weighted momentary-LUFS axis, not the displayed astats RMS
+// dBFS axis. Voice-activated captures intentionally use the momentary floor; see
+// TestInputNoiseFloorVoiceActivatedMomentary.
 func TestInputNoiseFloorNoMomentaryLeakage(t *testing.T) {
 	result := &ProcessingResult{
 		Measurements: &AudioMeasurements{
@@ -176,6 +178,34 @@ func TestInputNoiseFloorAbsent(t *testing.T) {
 	}
 	if _, ok := InputNoiseFloor(nil); ok {
 		t.Error("InputNoiseFloor(nil): ok = true, want false")
+	}
+}
+
+// TestInputNoiseFloorVoiceActivatedMomentary confirms the voice-activated display
+// override: the room tone is digital silence (astats -120 sentinel), so the
+// done-box "before" and the live box (both via InputDisplayNoiseFloorDB) show the
+// VAD momentary-LUFS floor instead, reconciling the two surfaces. The quality
+// score still reads the astats InputRoomToneFloorDB, so its axis is unchanged.
+func TestInputNoiseFloorVoiceActivatedMomentary(t *testing.T) {
+	m := &AudioMeasurements{
+		Regions: RegionMetrics{
+			ElectedRoomToneSample: &RegionSample{RMSLevel: -120}, // astats silence sentinel
+			NoiseProfile:          &NoiseProfile{MeasuredNoiseFloor: -62},
+		},
+	}
+	m.Noise.VoiceActivated = true
+	result := &ProcessingResult{Measurements: m}
+
+	floor, ok := InputNoiseFloor(result)
+	if !ok {
+		t.Fatal("InputNoiseFloor: ok = false, want true")
+	}
+	if floor != -62.0 {
+		t.Errorf("InputNoiseFloor = %.1f, want -62.0 (VAD momentary floor for voice-activated, not the -120 sentinel)", floor)
+	}
+	// The quality-score input floor stays astats (the elected sample), unaffected.
+	if score, ok := InputRoomToneFloorDB(m); !ok || score != -120.0 {
+		t.Errorf("InputRoomToneFloorDB = %.1f (ok=%v), want -120.0 (astats, unchanged for the score)", score, ok)
 	}
 }
 

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -105,12 +105,18 @@ func NewAdaptedSummary(cfg *processor.EffectiveFilterConfig, diag *processor.Ada
 			// operands are K-weighted momentary-LUFS, a single axis matching the
 			// Recording score and the momentary floor the resolver set above; never
 			// mix with the astats VoiceAvgDB. Read MeasuredNoiseFloor from the profile,
-			// not s.NoiseFloorDB, so the two computations stay independent. If either
-			// momentary value is missing or non-finite, keep the astats gap.
+			// not s.NoiseFloorDB, so the two computations stay independent. Guard the
+			// momentary floor exactly as the resolver does (f != 0 && finite): a 0
+			// MeasuredNoiseFloor is the unmeasured sentinel, so the resolver falls back
+			// to the astats floor for s.NoiseFloorDB and the separation must match by
+			// keeping the astats gap. If the floor is unmeasured or the difference is
+			// non-finite, keep the astats gap.
 			if m.Noise.VoiceActivated {
 				if np := m.Regions.NoiseProfile; np != nil {
-					if mom := sp.MomentaryLUFS - np.MeasuredNoiseFloor; !math.IsNaN(mom) && !math.IsInf(mom, 0) {
-						s.SeparationDB = mom
+					if f := np.MeasuredNoiseFloor; f != 0 && !math.IsNaN(f) && !math.IsInf(f, 0) {
+						if mom := sp.MomentaryLUFS - f; !math.IsNaN(mom) && !math.IsInf(mom, 0) {
+							s.SeparationDB = mom
+						}
 					}
 				}
 			}

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"math"
+
 	"github.com/linuxmatters/jivetalking/internal/processor"
 )
 
@@ -74,12 +76,13 @@ func NewAdaptedSummary(cfg *processor.EffectiveFilterConfig, diag *processor.Ada
 	s.DeesserI = cfg.Deesser.Intensity
 	s.DeesserOn = cfg.Deesser.Intensity > 0
 
-	// Analysis. Noise floor is the input room-tone RMS (astats dBFS), the same
-	// canonical value the done-box "before" shows (processor.InputRoomToneFloorDB),
-	// NOT the K-weighted momentary-LUFS VAD floor (m.Noise.Floor); the latter stays
-	// internal (VAD split, Recording score, afftdn seed). Sourcing both surfaces
-	// from one resolver guarantees live-box == done-box for a given file.
-	s.NoiseFloorDB, s.HasNoiseFloor = processor.InputRoomToneFloorDB(m)
+	// Analysis. Noise floor is the displayed input floor from the one shared
+	// resolver (processor.InputDisplayNoiseFloorDB): the astats room-tone RMS
+	// normally, or the VAD momentary-LUFS floor for voice-activated captures (where
+	// the astats room tone is digital silence and pins to the -120 sentinel). The
+	// done-box "before" reads the same resolver via processor.InputNoiseFloor, so
+	// the live box and the done box always show the same input floor for a file.
+	s.NoiseFloorDB, s.HasNoiseFloor = processor.InputDisplayNoiseFloorDB(m)
 	s.InputLRA = m.Loudness.InputLRA
 	s.GateRatio = cfg.SpeechGate.Ratio
 	s.TruePeakDBTP = m.Loudness.InputTP
@@ -95,6 +98,22 @@ func NewAdaptedSummary(cfg *processor.EffectiveFilterConfig, diag *processor.Ada
 		// same pair (HasSpeech && HasNoiseFloor).
 		if s.HasNoiseFloor {
 			s.SeparationDB = s.VoiceAvgDB - s.NoiseFloorDB
+			// Voice-activated captures gate the room tone to digital silence, so the
+			// astats gap above would inflate to a meaningless 75-85 dB. Recompute it
+			// from the momentary-LUFS pair (SpeechProfile.MomentaryLUFS -
+			// NoiseProfile.MeasuredNoiseFloor), which excludes the silence gaps. Both
+			// operands are K-weighted momentary-LUFS, a single axis matching the
+			// Recording score and the momentary floor the resolver set above; never
+			// mix with the astats VoiceAvgDB. Read MeasuredNoiseFloor from the profile,
+			// not s.NoiseFloorDB, so the two computations stay independent. If either
+			// momentary value is missing or non-finite, keep the astats gap.
+			if m.Noise.VoiceActivated {
+				if np := m.Regions.NoiseProfile; np != nil {
+					if mom := sp.MomentaryLUFS - np.MeasuredNoiseFloor; !math.IsNaN(mom) && !math.IsInf(mom, 0) {
+						s.SeparationDB = mom
+					}
+				}
+			}
 		}
 		if sp.BandsMeasured {
 			s.HasSibilance = true

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -316,6 +316,38 @@ func TestSeparationDBNotVoiceActivatedAstats(t *testing.T) {
 	}
 }
 
+// TestSeparationDBVoiceActivatedUnmeasuredFloor confirms that for a voice-activated
+// capture with an UNMEASURED momentary floor (MeasuredNoiseFloor == 0 sentinel) the
+// SNR Gap keeps the astats path. The resolver falls back to the astats floor for the
+// display, so the separation must match it and NOT compute sp.MomentaryLUFS - 0.
+func TestSeparationDBVoiceActivatedUnmeasuredFloor(t *testing.T) {
+	m := &processor.AudioMeasurements{}
+	m.Noise.VoiceActivated = true
+	// Astats room-tone floor is real; the momentary floor is the unmeasured 0 sentinel.
+	m.Regions.ElectedRoomToneSample = &processor.RegionSample{RMSLevel: -70}
+	m.Regions.NoiseProfile = &processor.NoiseProfile{MeasuredNoiseFloor: 0}
+	m.Regions.SpeechProfile = &processor.SpeechCandidateMetrics{}
+	m.Regions.SpeechProfile.MomentaryLUFS = -24 // must NOT enter the gap with a 0 floor
+	m.Regions.SpeechProfile.RMSLevel = -22
+
+	s := NewAdaptedSummary(&processor.EffectiveFilterConfig{}, nil, m)
+
+	// Floor falls back to the astats room-tone RMS (-70); the momentary 0 is unusable.
+	if s.NoiseFloorDB != -70 {
+		t.Errorf("NoiseFloorDB = %v, want -70 (astats fallback, unmeasured momentary floor)", s.NoiseFloorDB)
+	}
+	// Separation stays the astats gap, NOT sp.MomentaryLUFS (-24) against a 0 floor.
+	if s.SeparationDB != s.VoiceAvgDB-s.NoiseFloorDB {
+		t.Errorf("SeparationDB = %v, want astats VoiceAvgDB - NoiseFloorDB = %v", s.SeparationDB, s.VoiceAvgDB-s.NoiseFloorDB)
+	}
+	if s.SeparationDB != -22-(-70) {
+		t.Errorf("SeparationDB = %v, want %v (astats path on unmeasured momentary floor)", s.SeparationDB, -22-(-70.0))
+	}
+	if s.SeparationDB == m.Regions.SpeechProfile.MomentaryLUFS {
+		t.Errorf("SeparationDB must not be the bogus momentary value %v against a 0 floor", m.Regions.SpeechProfile.MomentaryLUFS)
+	}
+}
+
 // TestNewAdaptedSummaryNilGuards confirms nil config or measurements yields a
 // not-ready summary (boxes stay pending) rather than panicking.
 func TestNewAdaptedSummaryNilGuards(t *testing.T) {

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -112,12 +112,13 @@ func TestNewAdaptedSummaryNoSpeech(t *testing.T) {
 	}
 }
 
-// TestLiveBoxFloorMatchesDoneBoxFloor locks the bug-fix invariant: the live
+// TestLiveBoxFloorMatchesDoneBoxFloor locks the one-resolver invariant: the live
 // Analysis box "Noise floor" (summary NoiseFloorDB) equals the done-box "before"
-// (processor.InputNoiseFloor) for the same measurements, on the astats RMS axis,
-// never the internal momentary-LUFS floor. Both surfaces read the one resolver,
-// so when an elected sample exists they agree on its value, and when it is
-// absent they both report no floor (neither leaks the momentary-LUFS field).
+// (processor.InputNoiseFloor) for the same measurements, because both read the one
+// resolver (processor.InputDisplayNoiseFloorDB). For a normal capture that is the
+// astats room-tone floor (never the internal Noise.Floor field); for a
+// voice-activated capture both surfaces show the VAD momentary-LUFS floor. When no
+// floor is measurable both report none.
 func TestLiveBoxFloorMatchesDoneBoxFloor(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -140,11 +141,26 @@ func TestLiveBoxFloorMatchesDoneBoxFloor(t *testing.T) {
 			m: func() *processor.AudioMeasurements {
 				m := &processor.AudioMeasurements{}
 				m.Noise.Floor = -85
-				// Only the momentary-LUFS field is set; neither surface may use it.
+				// Only the momentary-LUFS field is set; a NORMAL capture's surfaces may
+				// not use it (VoiceActivated is false), so both report no floor.
 				m.Regions.NoiseProfile = &processor.NoiseProfile{MeasuredNoiseFloor: -70}
 				return m
 			}(),
 			wantFloor: false,
+		},
+		{
+			name: "voice-activated: both surfaces show the momentary floor",
+			m: func() *processor.AudioMeasurements {
+				m := &processor.AudioMeasurements{}
+				m.Noise.VoiceActivated = true
+				m.Noise.Floor = -85 // internal; the display reads MeasuredNoiseFloor, not this
+				// Room tone is digital silence (astats -120 sentinel); both surfaces must
+				// show the VAD momentary floor instead, and identically.
+				m.Regions.ElectedRoomToneSample = &processor.RegionSample{RMSLevel: -120}
+				m.Regions.NoiseProfile = &processor.NoiseProfile{MeasuredNoiseFloor: -62}
+				return m
+			}(),
+			wantFloor: true,
 		},
 	}
 
@@ -233,6 +249,70 @@ func TestSeparationDBSameAxis(t *testing.T) {
 	}
 	if s.SeparationDB != -22-(-70) {
 		t.Errorf("SeparationDB = %v, want %v (same-axis RMS)", s.SeparationDB, -22-(-70.0))
+	}
+}
+
+// TestSeparationDBVoiceActivatedMomentary confirms that for a voice-activated
+// capture the SNR Gap is recomputed from the momentary-LUFS pair
+// (SpeechProfile.MomentaryLUFS - NoiseProfile.MeasuredNoiseFloor), NOT the astats
+// path. The room tone is digital silence, so the astats floor pins to the -120
+// sentinel and the astats gap inflates; the momentary pair excludes the silence.
+func TestSeparationDBVoiceActivatedMomentary(t *testing.T) {
+	m := &processor.AudioMeasurements{}
+	m.Noise.VoiceActivated = true
+	// Astats floor is the digital-silence sentinel; the astats gap would be huge.
+	m.Regions.ElectedRoomToneSample = &processor.RegionSample{RMSLevel: -120}
+	m.Regions.NoiseProfile = &processor.NoiseProfile{MeasuredNoiseFloor: -62}
+	m.Regions.SpeechProfile = &processor.SpeechCandidateMetrics{}
+	m.Regions.SpeechProfile.MomentaryLUFS = -24
+	m.Regions.SpeechProfile.RMSLevel = -22 // astats voice term; must NOT enter the gap
+
+	s := NewAdaptedSummary(&processor.EffectiveFilterConfig{}, nil, m)
+
+	// Noise floor is the VAD momentary-LUFS floor (-62), NOT the astats -120 sentinel.
+	if s.NoiseFloorDB != -62 {
+		t.Errorf("NoiseFloorDB = %v, want -62 (momentary floor, voice-activated, not the -120 sentinel)", s.NoiseFloorDB)
+	}
+	if !s.HasNoiseFloor {
+		t.Error("HasNoiseFloor should stay true with a momentary floor override")
+	}
+	// SNR Gap is the momentary difference, both K-weighted momentary-LUFS.
+	if s.SeparationDB != -24-(-62) {
+		t.Errorf("SeparationDB = %v, want %v (momentary pair, voice-activated)", s.SeparationDB, -24-(-62.0))
+	}
+	// Floor and gap reconcile: SeparationDB == SpeechMomentary - NoiseFloorDB.
+	if s.SeparationDB != -24-s.NoiseFloorDB {
+		t.Errorf("gap %v must reconcile with momentary floor %v (SpeechMomentary - NoiseFloorDB)", s.SeparationDB, s.NoiseFloorDB)
+	}
+	// It is NOT the astats voice-term gap (VoiceAvgDB is astats -22, not -24).
+	if s.SeparationDB == s.VoiceAvgDB-s.NoiseFloorDB {
+		t.Errorf("voice-activated gap must not use the astats VoiceAvgDB (%v)", s.VoiceAvgDB-s.NoiseFloorDB)
+	}
+}
+
+// TestSeparationDBNotVoiceActivatedAstats confirms that for a normal (not
+// voice-activated) capture the astats path is unchanged: SNR Gap stays
+// VoiceAvgDB - NoiseFloorDB even when momentary values are present.
+func TestSeparationDBNotVoiceActivatedAstats(t *testing.T) {
+	m := &processor.AudioMeasurements{}
+	m.Noise.VoiceActivated = false
+	m.Regions.ElectedRoomToneSample = &processor.RegionSample{RMSLevel: -70}
+	m.Regions.NoiseProfile = &processor.NoiseProfile{MeasuredNoiseFloor: -62}
+	m.Regions.SpeechProfile = &processor.SpeechCandidateMetrics{}
+	m.Regions.SpeechProfile.MomentaryLUFS = -24
+	m.Regions.SpeechProfile.RMSLevel = -22
+
+	s := NewAdaptedSummary(&processor.EffectiveFilterConfig{}, nil, m)
+
+	// Floor stays the astats room-tone RMS (-70), not the momentary -62.
+	if s.NoiseFloorDB != -70 {
+		t.Errorf("NoiseFloorDB = %v, want -70 (astats floor unchanged, not the momentary -62)", s.NoiseFloorDB)
+	}
+	if s.SeparationDB != s.VoiceAvgDB-s.NoiseFloorDB {
+		t.Errorf("SeparationDB = %v, want astats VoiceAvgDB - NoiseFloorDB = %v", s.SeparationDB, s.VoiceAvgDB-s.NoiseFloorDB)
+	}
+	if s.SeparationDB != -22-(-70) {
+		t.Errorf("SeparationDB = %v, want %v (astats path unchanged)", s.SeparationDB, -22-(-70.0))
 	}
 }
 

--- a/testdata/justfile
+++ b/testdata/justfile
@@ -6,13 +6,13 @@
 testdata := source_directory()
 
 # Current episode (override per run, e.g. `just ep=82 process-presenters`)
-ep := "83"
+ep := "85"
 
 # Presenters processed by the batch recipes
 presenters := "mark martin popey"
 
 # Episodes processed by the `*-all` recipes
-episodes_list := "68 69 70 71 72 73 74 75 76 77 78 79 80 81"
+episodes_list := "68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85"
 
 # Set diagnostics=1 (any non-empty value) to add --diagnostics: emit the .jsonl
 # sidecars + before/after spectrogram PNGs. Off by default. Works on every
@@ -112,7 +112,7 @@ process-corpus ver="":
     set -euo pipefail
     # Collects artefacts into testdata/corpus-<label>/out/ for later LLM A/B analysis.
     #   `just process-corpus`        -> source build (./jivetalking), label "source", --diagnostics
-    #   `just process-corpus 0.5.1`  -> fetch release 0.5.1, no report flag
+    #   `just process-corpus 0.5.0`  -> fetch release 0.5.0, no report flag
     #   `just process-corpus 0.6.0`  -> fetch release 0.6.0, --diagnostics
     # Floor 0.5.1 (inclusive). Needs util-linux `script` (GNU/util-linux flags
     # -qefc); macOS/BSD `script` differs and is out of scope. Release path needs an
@@ -131,8 +131,8 @@ process-corpus ver="":
     # --- Version gate (inclusive floor 0.5.1) ---------------------------------
     # sort -V so 0.5.10 > 0.5.1 (not a string compare). Empty ver = source path.
     if [[ -n "$ver" ]]; then
-        lowest="$(printf '%s\n%s\n' "0.5.1" "$ver" | sort -V | head -1)"
-        [[ "$lowest" == "0.5.1" ]] || die "version $ver < 0.5.1 not supported"
+        lowest="$(printf '%s\n%s\n' "0.5.0" "$ver" | sort -V | head -1)"
+        [[ "$lowest" == "0.5.0" ]] || die "version $ver < 0.5.0 not supported"
     fi
 
     # --- Label + bounded purge of out/ ----------------------------------------
@@ -170,14 +170,14 @@ process-corpus ver="":
     fi
 
     # --- Flag selection per tier ----------------------------------------------
-    # Source or > 0.5.1 -> --diagnostics. Exactly 0.5.1 -> no report flag.
+    # Source or > 0.5.0 -> --diagnostics. Exactly 0.5.0 -> no report flag.
     # Never --logs (a removed 0.3.1 flag; Kong rejects unknown flags).
     REPORT_FLAGS=()
     if [[ -z "$ver" ]]; then
         REPORT_FLAGS=(--diagnostics)
     else
-        lowest="$(printf '%s\n%s\n' "0.5.1" "$ver" | sort -V | head -1)"
-        if [[ "$ver" != "0.5.1" && "$lowest" == "0.5.1" ]]; then
+        lowest="$(printf '%s\n%s\n' "0.5.0" "$ver" | sort -V | head -1)"
+        if [[ "$ver" != "0.5.0" && "$lowest" == "0.5.0" ]]; then
             REPORT_FLAGS=(--diagnostics)
         fi
     fi
@@ -187,7 +187,7 @@ process-corpus ver="":
     # fixture-5m.flac is excluded (a test fixture, not a recording).
     files=()
     for f in \
-        {{ testdata }}/LMP-{68..83}-{mark,martin,popey}.flac \
+        {{ testdata }}/LMP-{68..85}-{mark,martin,popey}.flac \
         {{ testdata }}/LMP-81s-{mark,martin,popey}.flac \
         {{ testdata }}/TT-202-{anna,marius,patrick}.wav \
         {{ testdata }}/BF-08-stephen.wav; do


### PR DESCRIPTION
  Add InputDisplayNoiseFloorDB resolver that returns the astats room-tone
  floor normally, or the VAD momentary-LUFS floor for voice-activated
  captures (where astats silence is a meaningless -120 dB sentinel).

  Route both the live Analysis box and done-box "before" through this
  resolver so they display the same input floor for all files. The quality
  score continues to read InputRoomToneFloorDB directly, preserving its
  axis.

  Result: done-box now reads meaningful before/after values for
  voice-activated files, consistent with the normal recording layout and
  aligned with the live box floor display.