### PR TITLE
 refactor: remove dead code and consolidate config derivation

### DIFF
--- a/cmd/jivetalking/debugsink_test.go
+++ b/cmd/jivetalking/debugsink_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -115,11 +116,14 @@ func TestDebugSinkPrefixAttribution(t *testing.T) {
 		if m == nil {
 			t.Fatalf("line %d malformed: %q", n, line)
 		}
+		id, err := strconv.Atoi(m[2])
+		if err != nil {
+			t.Fatalf("line %d writer id %q: %v", n, m[2], err)
+		}
 		// The marker's writer id must match the payload's writer id.
-		if m[1] != fmt.Sprintf("%02d", mustAtoi(t, m[2])) {
+		if m[1] != fmt.Sprintf("%02d", id) {
 			t.Fatalf("line %d marker/payload writer mismatch: %q", n, line)
 		}
-		id := mustAtoi(t, m[2])
 		if id < 0 || id >= wrappers {
 			t.Fatalf("line %d writer id %d out of range", n, id)
 		}
@@ -155,16 +159,4 @@ func readLines(t *testing.T, path string) []string {
 		t.Fatalf("scan %s: %v", path, err)
 	}
 	return lines
-}
-
-func mustAtoi(t *testing.T, s string) int {
-	t.Helper()
-	n := 0
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			t.Fatalf("non-numeric value %q", s)
-		}
-		n = n*10 + int(r-'0')
-	}
-	return n
 }

--- a/cmd/jivetalking/main.go
+++ b/cmd/jivetalking/main.go
@@ -223,10 +223,10 @@ func openAudioMetadata(inputPath string) (*audio.Metadata, error) {
 // input duration is unknown.
 func (ph *progressHandler) timings(pass2Time time.Duration, fileStart time.Time, result *processor.ProcessingResult) report.Timings {
 	t := report.Timings{
-		Pass1: ph.pass1Time,
+		Pass1: ph.passTime[processor.PassAnalysis-1],
 		Pass2: pass2Time,
-		Pass3: ph.pass3Time,
-		Pass4: ph.pass4Time,
+		Pass3: ph.passTime[processor.PassMeasuring-1],
+		Pass4: ph.passTime[processor.PassNormalising-1],
 	}
 	if result.InputMetadata.DurationSecs > 0 {
 		totalTime := time.Since(fileStart)
@@ -239,17 +239,14 @@ func (ph *progressHandler) timings(pass2Time time.Duration, fileStart time.Time,
 // progressHandler relays processor progress updates to the TUI and records
 // per-pass timings from the start/end progress boundaries.
 type progressHandler struct {
-	p          *tea.Program
-	log        func(string, ...any)
-	fileIndex  int
-	pass1Start time.Time
-	pass1Time  time.Duration
-	pass2Start time.Time
-	pass2Time  time.Duration
-	pass3Start time.Time
-	pass3Time  time.Duration
-	pass4Start time.Time
-	pass4Time  time.Duration
+	p         *tea.Program
+	log       func(string, ...any)
+	fileIndex int
+
+	// passStart/passTime bracket the wall-clock of the four passes, indexed by
+	// PassNumber-1 (PassAnalysis..PassNormalising).
+	passStart [4]time.Time
+	passTime  [4]time.Duration
 
 	// summary is the filter-chain status view-model, built from the Pass-2 start
 	// update (chain + analysis rows). The pool reads it back at completion to merge
@@ -270,34 +267,13 @@ func (ph *progressHandler) callback(update processor.ProgressUpdate) {
 	// for a pass marks its start (start time still zero); progress at or above
 	// passCompleteThreshold marks its end. Keying the start off the first sighting
 	// and the end off a threshold avoids exact float-equality on the progress value.
-	switch update.Pass {
-	case processor.PassAnalysis:
-		if ph.pass1Start.IsZero() {
-			ph.pass1Start = time.Now()
+	if update.Pass >= processor.PassAnalysis && update.Pass <= processor.PassNormalising {
+		idx := int(update.Pass) - 1
+		if ph.passStart[idx].IsZero() {
+			ph.passStart[idx] = time.Now()
 		}
 		if update.Progress >= passCompleteThreshold {
-			ph.pass1Time = time.Since(ph.pass1Start)
-		}
-	case processor.PassProcessing:
-		if ph.pass2Start.IsZero() {
-			ph.pass2Start = time.Now()
-		}
-		if update.Progress >= passCompleteThreshold {
-			ph.pass2Time = time.Since(ph.pass2Start)
-		}
-	case processor.PassMeasuring:
-		if ph.pass3Start.IsZero() {
-			ph.pass3Start = time.Now()
-		}
-		if update.Progress >= passCompleteThreshold {
-			ph.pass3Time = time.Since(ph.pass3Start)
-		}
-	case processor.PassNormalising:
-		if ph.pass4Start.IsZero() {
-			ph.pass4Start = time.Now()
-		}
-		if update.Progress >= passCompleteThreshold {
-			ph.pass4Time = time.Since(ph.pass4Start)
+			ph.passTime[idx] = time.Since(ph.passStart[idx])
 		}
 	}
 

--- a/cmd/jivetalking/pool.go
+++ b/cmd/jivetalking/pool.go
@@ -218,7 +218,7 @@ func runWorkerPool(env poolEnv, diagnostics bool, reportWarnings chan<- string, 
 			// Pass 2 is bracketed directly by the progress handler (the Pass-2
 			// start/end updates), matching passes 1/3/4, so a missed timer cannot
 			// silently land in Pass 2.
-			emitProcessingReport(env, inputPath, result, ph, processingTimings{fileStart: fileStartTime, pass2: ph.pass2Time}, diagnostics, reportWarnings, render)
+			emitProcessingReport(env, inputPath, result, ph, processingTimings{fileStart: fileStartTime, pass2: ph.passTime[processor.PassProcessing-1]}, diagnostics, reportWarnings, render)
 		})
 }
 
@@ -342,7 +342,7 @@ func emitReportArtefacts(a reportArtefacts) {
 // processingTimings is the timing data clump emitProcessingReport needs from the
 // pool worker: fileStart marks when the worker began (feeds both the report's
 // real-time factor and the FileCompleteMsg ProcessingTime), pass2 is the Pass-2
-// wall-clock the progress handler brackets directly (ph.pass2Time). Bundling the
+// wall-clock the progress handler brackets directly (ph.passTime). Bundling the
 // pair keeps the emitProcessingReport signature short.
 type processingTimings struct {
 	fileStart time.Time

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -39,11 +39,13 @@ func StyledHelpPrinter() func(kong.HelpOptions, *kong.Context) error {
 	return func(options kong.HelpOptions, ctx *kong.Context) error {
 		var sb strings.Builder
 
-		// Title and description
+		// Title and description (Kong's Description populates Model.Help)
 		sb.WriteString(RenderTitle())
 		sb.WriteString("\n")
-		sb.WriteString(helpDescStyle.Render("Professional podcast audio preprocessor"))
-		sb.WriteString("\n")
+		if ctx.Model.Help != "" {
+			sb.WriteString(helpDescStyle.Render(ctx.Model.Help))
+			sb.WriteString("\n")
+		}
 
 		// Usage
 		sb.WriteString(helpSectionStyle.Render("Usage:"))

--- a/internal/processor/adaptive_test.go
+++ b/internal/processor/adaptive_test.go
@@ -259,7 +259,6 @@ func assertOrderIndependentAdaptiveDiagnostics(t *testing.T, got, want *Adaptive
 	}{
 		{"BandlimitLPReason", got.BandlimitLPReason, want.BandlimitLPReason},
 		{"SpeechGateDepthDB", got.SpeechGateDepthDB, want.SpeechGateDepthDB},
-		{"SpeechGateDynamicRange", got.SpeechGateDynamicRange, want.SpeechGateDynamicRange},
 		{"SpeechGateQuietSpeechEstimate", got.SpeechGateQuietSpeechEstimate, want.SpeechGateQuietSpeechEstimate},
 		{"SpeechGateSpeechSeparation", got.SpeechGateSpeechSeparation, want.SpeechGateSpeechSeparation},
 		{"SpeechGateSpeechHeadroom", got.SpeechGateSpeechHeadroom, want.SpeechGateSpeechHeadroom},
@@ -943,8 +942,7 @@ func TestTuneSpeechGate(t *testing.T) {
 		if diagnostics.SpeechGateNarrowGap {
 			t.Error("diagnostics SpeechGateNarrowGap = true, want false without a profile")
 		}
-		if diagnostics.SpeechGateDynamicRange != 0 ||
-			diagnostics.SpeechGateQuietSpeechEstimate != 0 ||
+		if diagnostics.SpeechGateQuietSpeechEstimate != 0 ||
 			diagnostics.SpeechGateSpeechSeparation != 0 ||
 			diagnostics.SpeechGateSpeechHeadroom != 0 ||
 			diagnostics.SpeechGateThresholdUnclamped != 0 ||

--- a/internal/processor/analyser.go
+++ b/internal/processor/analyser.go
@@ -69,11 +69,6 @@ type NoiseProfile struct {
 	// only when every band measured successfully.
 	BandNoise     []float64 `json:"band_noise_dbfs,omitempty"`     // Per-band RMS (dBFS) across the afftdn fixed bands
 	BandsMeasured bool      `json:"band_noise_measured,omitempty"` // True only when all afftdn bands measured successfully
-
-	// Golden sub-region refinement info (populated when a long candidate is refined)
-	OriginalStart    time.Duration `json:"original_start,omitempty"`    // Original candidate start before refinement (time.Duration ns)
-	OriginalDuration time.Duration `json:"original_duration,omitempty"` // Original candidate duration before refinement (time.Duration ns)
-	WasRefined       bool          `json:"was_refined,omitempty"`       // True if region was refined from a longer candidate
 }
 
 // RegionSample holds the bare per-region measurement subset shared by the room

--- a/internal/processor/analyser_bands.go
+++ b/internal/processor/analyser_bands.go
@@ -81,10 +81,9 @@ func measureSpeechBandRMS(ctx context.Context, reader *audio.Reader, start, dura
 		return nil
 	}
 
-	lenientHandler := func(error) error { return nil }
 	if err := runFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
-		OnPushError: lenientHandler,
-		OnPullError: lenientHandler,
+		OnPushError: breakOnError,
+		OnPullError: breakOnError,
 		OnFrame:     extract,
 	}); err != nil {
 		return 0, false, err

--- a/internal/processor/analyser_candidates_shared.go
+++ b/internal/processor/analyser_candidates_shared.go
@@ -195,19 +195,22 @@ func scoreSpeechIntervalWindow(intervals []IntervalSample) float64 {
 
 	n := float64(len(intervals))
 
-	// Accumulate metrics
+	// Accumulate metrics, counting voiced intervals (kurtosis above threshold)
+	// in the same pass for the voicing density score below.
 	var kurtosisSum, flatnessSum, centroidSum, rmsSum float64
 	var rolloffSum, fluxSum float64
-	kurtosisValues := make([]float64, len(intervals))
+	voicedCount := 0
 
-	for i, interval := range intervals {
+	for _, interval := range intervals {
 		kurtosisSum += interval.Spectral.Kurtosis
 		flatnessSum += interval.Spectral.Flatness
 		centroidSum += interval.Spectral.Centroid
 		rmsSum += interval.RMSLevel
 		rolloffSum += interval.Spectral.Rolloff
 		fluxSum += interval.Spectral.Flux
-		kurtosisValues[i] = interval.Spectral.Kurtosis
+		if interval.Spectral.Kurtosis > voicedKurtosisThreshold {
+			voicedCount++
+		}
 	}
 
 	avgKurtosis := kurtosisSum / n
@@ -217,10 +220,11 @@ func scoreSpeechIntervalWindow(intervals []IntervalSample) float64 {
 	avgRolloff := rolloffSum / n
 	avgFlux := fluxSum / n
 
-	// Calculate kurtosis variance for consistency score
+	// Calculate kurtosis variance for consistency score (second pass over the
+	// intervals, mean first then variance, mirroring levelVariance)
 	var kurtosisVarianceSum float64
-	for _, k := range kurtosisValues {
-		diff := k - avgKurtosis
+	for _, interval := range intervals {
+		diff := interval.Spectral.Kurtosis - avgKurtosis
 		kurtosisVarianceSum += diff * diff
 	}
 	kurtosisVariance := kurtosisVarianceSum / n
@@ -231,12 +235,6 @@ func scoreSpeechIntervalWindow(intervals []IntervalSample) float64 {
 	// comparison. Rather than using a hard gate that prevents differentiation
 	// among low-density candidates (e.g., whispered speech, heavily accented speech),
 	// we use a weighted score component that allows relative ranking.
-	voicedCount := 0
-	for _, k := range kurtosisValues {
-		if k > voicedKurtosisThreshold {
-			voicedCount++
-		}
-	}
 	voicingDensity := float64(voicedCount) / n
 	voicingScore := calculateVoicingScore(voicingDensity)
 	// voicingScore: 0.0 at 0% density, 1.0 at 60%+ density

--- a/internal/processor/analyser_output.go
+++ b/internal/processor/analyser_output.go
@@ -168,10 +168,9 @@ func measureOutputRegionFromReader(ctx context.Context, reader *audio.Reader, st
 		return nil
 	}
 
-	lenientHandler := func(err error) error { return nil }
 	_ = runFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
-		OnPushError: lenientHandler,
-		OnPullError: lenientHandler,
+		OnPushError: breakOnError,
+		OnPullError: breakOnError,
 		OnFrame:     extractMeasurements,
 	})
 

--- a/internal/processor/filters.go
+++ b/internal/processor/filters.go
@@ -284,7 +284,6 @@ type BaseFilterConfig struct {
 type AdaptiveDiagnostics struct {
 	BandlimitLPReason string `json:"bandlimit_lowpass_reason"`
 
-	SpeechGateDynamicRange        float64 `json:"dynamic_range_db"`
 	SpeechGateQuietSpeechEstimate float64 `json:"quiet_speech_estimate_dbfs"`
 	SpeechGateSpeechSeparation    float64 `json:"separation_db"`
 	SpeechGateSpeechHeadroom      float64 `json:"speech_headroom_db"`
@@ -373,46 +372,18 @@ func (cfg *BaseFilterConfig) CloneForWorker(logger func(format string, args ...a
 }
 
 func defaultFilterConfigDefaults() filterConfigDefaults {
-	return assembleFilterDefaults(
-		defaultDownmixConfig(),
-		defaultAnalysisConfig(),
-		defaultResampleConfig(),
-		defaultRumbleHighPassConfig(),
-		defaultBandlimitLowPassConfig(),
-		defaultNoiseReductionConfig(),
-		defaultSpeechGateConfig(),
-		defaultLevellingCompressorConfig(),
-		defaultDeesserConfig(),
-		defaultAdeclickConfig(),
-		defaultLoudnormConfig(),
-	)
-}
-
-func assembleFilterDefaults(
-	downmix DownmixConfig,
-	analysis AnalysisConfig,
-	resample ResampleConfig,
-	rumbleHighPass RumbleHighPassConfig,
-	bandlimitLowPass BandlimitLowPassConfig,
-	noiseReduction NoiseReductionConfig,
-	speechGate SpeechGateConfig,
-	levellingCompressor LevellingCompressorConfig,
-	deesser DeesserConfig,
-	adeclick AdeclickConfig,
-	loudnorm LoudnormConfig,
-) filterConfigDefaults {
 	return filterConfigDefaults{
-		Downmix:             downmix,
-		Analysis:            analysis,
-		Resample:            resample,
-		RumbleHighPass:      rumbleHighPass,
-		BandlimitLowPass:    bandlimitLowPass,
-		NoiseReduction:      noiseReduction,
-		SpeechGate:          speechGate,
-		LevellingCompressor: levellingCompressor,
-		Deesser:             deesser,
-		Adeclick:            adeclick,
-		Loudnorm:            loudnorm,
+		Downmix:             defaultDownmixConfig(),
+		Analysis:            defaultAnalysisConfig(),
+		Resample:            defaultResampleConfig(),
+		RumbleHighPass:      defaultRumbleHighPassConfig(),
+		BandlimitLowPass:    defaultBandlimitLowPassConfig(),
+		NoiseReduction:      defaultNoiseReductionConfig(),
+		SpeechGate:          defaultSpeechGateConfig(),
+		LevellingCompressor: defaultLevellingCompressorConfig(),
+		Deesser:             defaultDeesserConfig(),
+		Adeclick:            defaultAdeclickConfig(),
+		Loudnorm:            defaultLoudnormConfig(),
 
 		FilterOrder: Pass2FilterOrder,
 	}
@@ -536,31 +507,12 @@ func DefaultEffectiveFilterConfig() *EffectiveFilterConfig {
 }
 
 func deriveEffectiveFilterConfig(base *BaseFilterConfig) *EffectiveFilterConfig {
-	return assembleEffectiveFilterConfig(base, deriveAdaptiveFilterResult(base))
-}
-
-func deriveAdaptiveFilterResult(base *BaseFilterConfig) *filterConfigDefaults {
 	if base == nil {
 		return nil
 	}
 
-	defaults := cloneFilterDefaults(&base.filterConfigDefaults)
-	return &defaults
-}
-
-func assembleEffectiveFilterConfig(base *BaseFilterConfig, adaptive *filterConfigDefaults) *EffectiveFilterConfig {
-	if base == nil {
-		return nil
-	}
-
-	effective := &EffectiveFilterConfig{}
-	copyFilterDefaults(effective, &base.filterConfigDefaults)
-	if adaptive != nil {
-		copyFilterDefaults(effective, adaptive)
-	}
-	effective.FilterOrder = cloneFilterOrder(base.FilterOrder)
-
-	return effective
+	effective := EffectiveFilterConfig(cloneFilterDefaults(&base.filterConfigDefaults))
+	return &effective
 }
 
 func cloneFilterDefaults(src *filterConfigDefaults) filterConfigDefaults {
@@ -577,13 +529,6 @@ func cloneFilterOrder(order []FilterID) []FilterID {
 		return nil
 	}
 	return append([]FilterID(nil), order...)
-}
-
-func copyFilterDefaults(dst *EffectiveFilterConfig, src *filterConfigDefaults) {
-	if dst == nil {
-		return
-	}
-	*dst = EffectiveFilterConfig(cloneFilterDefaults(src))
 }
 
 // DbToLinear converts decibel value to linear amplitude.

--- a/internal/processor/filters_test.go
+++ b/internal/processor/filters_test.go
@@ -12,11 +12,11 @@ import (
 // All filters are disabled by default - enable only what you need for each test.
 // This isolates tests from application default configuration changes.
 func newTestBaseConfig() *BaseFilterConfig {
-	defaults := assembleFilterDefaults(
-		DownmixConfig{Enabled: false},
-		AnalysisConfig{Enabled: false},
-		ResampleConfig{Enabled: false, SampleRate: 44100, Format: "s16", FrameSize: 4096},
-		RumbleHighPassConfig{
+	defaults := filterConfigDefaults{
+		Downmix:  DownmixConfig{Enabled: false},
+		Analysis: AnalysisConfig{Enabled: false},
+		Resample: ResampleConfig{Enabled: false, SampleRate: 44100, Format: "s16", FrameSize: 4096},
+		RumbleHighPass: RumbleHighPassConfig{
 			Enabled:   false,
 			Frequency: 80.0,
 			Poles:     2,
@@ -24,14 +24,14 @@ func newTestBaseConfig() *BaseFilterConfig {
 			Mix:       1.0,
 			Transform: "tdii",
 		},
-		BandlimitLowPassConfig{
+		BandlimitLowPass: BandlimitLowPassConfig{
 			Enabled:   false,
 			Frequency: 16000.0,
 			Poles:     2,
 			Width:     0.707,
 			Mix:       1.0,
 		},
-		NoiseReductionConfig{
+		NoiseReduction: NoiseReductionConfig{
 			Enabled:              false,
 			Strength:             0.00001,
 			PatchSec:             0.006,
@@ -42,7 +42,7 @@ func newTestBaseConfig() *BaseFilterConfig {
 			AfftdnNoiseType:      "w",
 			AfftdnTrackNoise:     true,
 		},
-		SpeechGateConfig{
+		SpeechGate: SpeechGateConfig{
 			Enabled:   false,
 			Threshold: 0.01,
 			Ratio:     2.0,
@@ -53,7 +53,7 @@ func newTestBaseConfig() *BaseFilterConfig {
 			Makeup:    1.0,
 			Detection: "rms",
 		},
-		LevellingCompressorConfig{
+		LevellingCompressor: LevellingCompressorConfig{
 			Enabled:   false,
 			Threshold: -20,
 			Ratio:     2.5,
@@ -63,11 +63,12 @@ func newTestBaseConfig() *BaseFilterConfig {
 			Knee:      2.5,
 			Mix:       1.0,
 		},
-		DeesserConfig{Enabled: false, Intensity: 0.5, Amount: 0.5, Frequency: 0.5},
-		AdeclickConfig{Enabled: true, Threshold: 2.0, Window: 55.0, Overlap: 50.0, Method: "s"},
-		LoudnormConfig{Enabled: true, TargetI: -16.0, TargetTP: -1.5, TargetLRA: 11.0, DualMono: true, Linear: true},
-	)
-	defaults.FilterOrder = Pass2FilterOrder
+		Deesser:  DeesserConfig{Enabled: false, Intensity: 0.5, Amount: 0.5, Frequency: 0.5},
+		Adeclick: AdeclickConfig{Enabled: true, Threshold: 2.0, Window: 55.0, Overlap: 50.0, Method: "s"},
+		Loudnorm: LoudnormConfig{Enabled: true, TargetI: -16.0, TargetTP: -1.5, TargetLRA: 11.0, DualMono: true, Linear: true},
+
+		FilterOrder: Pass2FilterOrder,
+	}
 	return &BaseFilterConfig{filterConfigDefaults: defaults}
 }
 
@@ -456,7 +457,6 @@ func perFileStateFieldNames() []string {
 		"OutputAnalysisEnabled",
 		"BandlimitLPReason",
 		"SpeechGateDepthDB",
-		"SpeechGateDynamicRange",
 		"SpeechGateQuietSpeechEstimate",
 		"SpeechGateSpeechSeparation",
 		"SpeechGateSpeechHeadroom",
@@ -1018,33 +1018,6 @@ func TestFilterOrderRespected(t *testing.T) {
 	}
 }
 
-func TestDeriveAdaptiveFilterResultDeepCopiesFilterOrder(t *testing.T) {
-	base := DefaultFilterConfig()
-	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
-	base.Resample.SampleRate = 48000
-
-	adaptive := deriveAdaptiveFilterResult(base)
-	if adaptive == nil {
-		t.Fatal("deriveAdaptiveFilterResult returned nil")
-	}
-	if !reflect.DeepEqual(adaptive.FilterOrder, base.FilterOrder) {
-		t.Errorf("FilterOrder = %v, want %v", adaptive.FilterOrder, base.FilterOrder)
-	}
-
-	adaptive.FilterOrder[0] = FilterDownmix
-	if base.FilterOrder[0] == FilterDownmix {
-		t.Fatal("adaptive FilterOrder mutation changed base FilterOrder")
-	}
-	if adaptive.Resample.SampleRate != base.Resample.SampleRate {
-		t.Errorf("Resample.SampleRate = %d, want %d",
-			adaptive.Resample.SampleRate, base.Resample.SampleRate)
-	}
-	adaptive.Resample.SampleRate = 32000
-	if base.Resample.SampleRate == 32000 {
-		t.Fatal("adaptive typed Resample mutation changed base Resample")
-	}
-}
-
 func TestCloneFilterDefaultsCopiesTypedFamilies(t *testing.T) {
 	base := DefaultFilterConfig()
 	base.NoiseReduction.AfftdnEnabled = false
@@ -1063,45 +1036,6 @@ func TestCloneFilterDefaultsCopiesTypedFamilies(t *testing.T) {
 	if base.FilterOrder[0] == FilterDownmix {
 		t.Fatal("clone FilterOrder mutation changed base FilterOrder")
 	}
-}
-
-func TestAssembleEffectiveFilterConfig(t *testing.T) {
-	base := DefaultFilterConfig()
-	base.FilterOrder = []FilterID{FilterDeesser, FilterAnalysis}
-	base.Loudnorm.TargetI = -18.0
-
-	adaptive := deriveAdaptiveFilterResult(base)
-	adaptive.RumbleHighPass.Frequency = 65.0
-	adaptive.NoiseReduction.AfftdnEnabled = false
-	adaptive.FilterOrder = []FilterID{FilterDownmix}
-
-	effective := assembleEffectiveFilterConfig(base, adaptive)
-	if effective == nil {
-		t.Fatal("assembleEffectiveFilterConfig returned nil")
-	}
-	if effective.RumbleHighPass.Frequency != adaptive.RumbleHighPass.Frequency {
-		t.Errorf("RumbleHighPass.Frequency = %.1f, want adaptive %.1f",
-			effective.RumbleHighPass.Frequency, adaptive.RumbleHighPass.Frequency)
-	}
-	if effective.NoiseReduction.AfftdnEnabled {
-		t.Error("NoiseReduction.AfftdnEnabled = true, want adaptive false")
-	}
-	if effective.Loudnorm.TargetI != base.Loudnorm.TargetI {
-		t.Errorf("Loudnorm.TargetI = %.1f, want base %.1f", effective.Loudnorm.TargetI, base.Loudnorm.TargetI)
-	}
-	if !reflect.DeepEqual(effective.FilterOrder, base.FilterOrder) {
-		t.Errorf("FilterOrder = %v, want base order %v", effective.FilterOrder, base.FilterOrder)
-	}
-
-	effective.FilterOrder[0] = FilterDownmix
-	if base.FilterOrder[0] == FilterDownmix {
-		t.Fatal("effective FilterOrder mutation changed base FilterOrder")
-	}
-	if adaptive.FilterOrder[0] != FilterDownmix {
-		t.Fatal("effective FilterOrder mutation changed adaptive FilterOrder")
-	}
-
-	assertNoStaleEffectiveConfigFields(t)
 }
 
 func TestDeriveEffectiveFilterConfig(t *testing.T) {

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -259,7 +259,7 @@ func measureWithLoudnorm(ctx context.Context, inputPath string, config *Effectiv
 		loudnorm.TargetI,
 		loudnorm.TargetTP,
 		loudnorm.TargetLRA,
-		boolToString(loudnorm.DualMono),
+		strconv.FormatBool(loudnorm.DualMono),
 		escapeFilterGraphOptionValue(statsPath),
 	)
 
@@ -278,10 +278,9 @@ func measureWithLoudnorm(ctx context.Context, inputPath string, config *Effectiv
 	// Note: We free the filter graph explicitly to trigger loudnorm JSON output
 
 	// Process all frames through loudnorm (no encoding - just measurement)
-	lenientHandler := func(err error) error { return nil }
 	loopErr := deps.runFilterGraph(ctx, reader, bufferSrcCtx, bufferSinkCtx, FrameLoopConfig{
-		OnPushError: lenientHandler,
-		OnPullError: lenientHandler,
+		OnPushError: breakOnError,
+		OnPullError: breakOnError,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
 			// Measure the instantaneous level of the Pass-2 output being read so the
 			// VU meter animates consistently with Passes 1-2.
@@ -1095,10 +1094,9 @@ func newLoudnormApplicationFrameLoop(
 	var currentLevel float64
 	const progressUpdateInterval = 100 // Send progress update every N frames
 
-	lenientHandler := func(err error) error { return nil }
 	return FrameLoopConfig{
-		OnPushError: lenientHandler,
-		OnPullError: lenientHandler,
+		OnPushError: breakOnError,
+		OnPullError: breakOnError,
 		OnInputFrame: func(inputFrame *ffmpeg.AVFrame) {
 			// Drive progress from input-frame consumption so the bar advances
 			// monotonically. samplesProcessed and totalSamples are both at the input rate.
@@ -1279,8 +1277,8 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 		measurement.InputLRA,
 		measurement.InputThresh,
 		offset, // Capped makeup matching the capped I= (binds the gain cap)
-		boolToString(loudnorm.DualMono),
-		boolToString(loudnorm.Linear),
+		strconv.FormatBool(loudnorm.DualMono),
+		strconv.FormatBool(loudnorm.Linear),
 	)
 	// stats_file: loudnorm writes its JSON (including normalization_type) here on
 	// graph free. The caller reads it post-free for the report's Norm Type
@@ -1331,12 +1329,4 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 	filters = append(filters, config.buildRequiredOutputFormatFilter())
 
 	return strings.Join(filters, ",")
-}
-
-// boolToString converts bool to loudnorm's expected string format
-func boolToString(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
 }

--- a/internal/processor/quality.go
+++ b/internal/processor/quality.go
@@ -122,13 +122,8 @@ func scoreNoiseCleanliness(result *ProcessingResult) float64 {
 // outputTruePeak resolves the real Pass 4 output true peak in dBTP. Prefers the
 // normalisation result; falls back to the final output measurements.
 func outputTruePeak(result *ProcessingResult) float64 {
-	if result.NormResult != nil {
-		if !result.NormResult.Skipped {
-			return result.NormResult.OutputTP
-		}
-		if result.NormResult.FinalMeasurements != nil {
-			return result.NormResult.FinalMeasurements.Loudness.OutputTP
-		}
+	if result.NormResult != nil && !result.NormResult.Skipped {
+		return result.NormResult.OutputTP
 	}
 	if result.FilteredMeasurements != nil {
 		return result.FilteredMeasurements.Loudness.OutputTP

--- a/internal/processor/runrecord.go
+++ b/internal/processor/runrecord.go
@@ -512,7 +512,7 @@ func sanitiseValue(v reflect.Value) any {
 		}
 		return out
 
-	case reflect.Float64, reflect.Float32:
+	case reflect.Float64:
 		f := v.Float()
 		if math.IsNaN(f) || math.IsInf(f, 0) {
 			return nil
@@ -587,7 +587,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Int() == 0
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float64:
 		return v.Float() == 0
 	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()

--- a/internal/processor/runrecord_tags_test.go
+++ b/internal/processor/runrecord_tags_test.go
@@ -395,7 +395,6 @@ func TestEffectiveFilterConfigJSON_HasCanonicalKeys(t *testing.T) {
 func TestAdaptiveDiagnosticsJSON_HasCanonicalKeys(t *testing.T) {
 	diag := AdaptiveDiagnostics{
 		BandlimitLPReason:             "20.5 kHz band-limit (always on)",
-		SpeechGateDynamicRange:        14,
 		SpeechGateQuietSpeechEstimate: -52,
 		SpeechGateSpeechSeparation:    8,
 		SpeechGateSpeechHeadroom:      3,
@@ -407,7 +406,7 @@ func TestAdaptiveDiagnosticsJSON_HasCanonicalKeys(t *testing.T) {
 	keys := jsonKeySet(t, diag)
 
 	for _, key := range []string{
-		"bandlimit_lowpass_reason", "dynamic_range_db",
+		"bandlimit_lowpass_reason",
 		"quiet_speech_estimate_dbfs", "separation_db", "speech_headroom_db",
 		"threshold_unclamped_db", "clamp_reason", "speech_gate_depth_db",
 	} {

--- a/internal/processor/runrecord_test.go
+++ b/internal/processor/runrecord_test.go
@@ -44,7 +44,7 @@ func populatedProcessingResult() *ProcessingResult {
 		OutputPath:           "/tmp/episode-LUFS-16-processed.flac",
 		Measurements:         populatedAudioMeasurements(),
 		Config:               &cfg,
-		Diagnostics:          &AdaptiveDiagnostics{SpeechGateDynamicRange: 0.4, SpeechGateClampReason: "none"},
+		Diagnostics:          &AdaptiveDiagnostics{SpeechGateClampReason: "none"},
 		FilteredMeasurements: populatedOutputMeasurements(),
 		NormResult: &NormalisationResult{
 			InputLUFS: -18, OutputLUFS: -16, EffectiveTargetI: -16,

--- a/internal/processor/runrecord_units.go
+++ b/internal/processor/runrecord_units.go
@@ -66,17 +66,14 @@ func durationKeySeconds(m map[string]any, nsKey, secKey string) {
 	m[secKey] = time.Duration(ns).Seconds()
 }
 
-// toInt64 coerces a sanitised JSON-tree value to int64 nanoseconds. sanitiseValue
-// returns a time.Duration via its default case (Kind Int64 is unhandled there, so
-// the concrete time.Duration passes through v.Interface()); the int64/int/float64
-// forms are handled defensively for any other numeric origin.
+// toInt64 coerces a sanitised JSON-tree value to int64 nanoseconds. Two forms
+// occur: sanitiseValue's reflection walk passes a concrete time.Duration through
+// its default case (Kind Int64 is unhandled there), while its custom-marshaler
+// route (e.g. NoiseProfile) re-decodes the marshalled JSON, so the ns value
+// arrives as a float64.
 func toInt64(v any) (int64, bool) {
 	switch n := v.(type) {
 	case time.Duration:
-		return int64(n), true
-	case int64:
-		return n, true
-	case int:
 		return int64(n), true
 	case float64:
 		return int64(n), true
@@ -86,20 +83,12 @@ func toInt64(v any) (int64, bool) {
 }
 
 // recordWrapper holds the single source pointer the three unit-honesty wrappers
-// share, plus the mechanical scaffolding common to all of them: the nil-checked
-// accessor and the null-on-nil sanitise-then-marshal core. The per-type key
-// transforms stay explicit on each wrapper's MarshalJSON; only this boilerplate is
-// shared. The source pointer is unexported so JSON marshalling stays
-// representation-controlled.
+// share, plus the null-on-nil sanitise-then-marshal core common to all of them.
+// The per-type key transforms stay explicit on each wrapper's MarshalJSON; only
+// this boilerplate is shared. The source pointer is unexported so JSON
+// marshalling stays representation-controlled.
 type recordWrapper[T any] struct {
 	src *T
-}
-
-// source returns the wrapped pointer. Callers must nil-check the concrete wrapper
-// before calling, since promotion through a nil embedding pointer would panic
-// (the per-type accessors below own that guard).
-func (w *recordWrapper[T]) source() *T {
-	return w.src
 }
 
 // marshalWithTransform sanitises the source (null on nil), applies the per-type
@@ -128,8 +117,6 @@ func (p noiseProfileRecord) MarshalJSON() ([]byte, error) {
 	return p.marshalWithTransform(func(m map[string]any) {
 		durationKeySeconds(m, "start", "start_s")
 		durationKeySeconds(m, "duration", "duration_s")
-		durationKeySeconds(m, "original_start", "original_start_s")
-		durationKeySeconds(m, "original_duration", "original_duration_s")
 	})
 }
 
@@ -139,7 +126,7 @@ func (p *noiseProfileRecord) Profile() *NoiseProfile {
 	if p == nil {
 		return nil
 	}
-	return p.source()
+	return p.src
 }
 
 // noiseProfileJSON is the flat JSON contract for NoiseProfile: the embedded
@@ -171,10 +158,6 @@ type noiseProfileJSON struct {
 
 	BandNoise     []float64 `json:"band_noise_dbfs,omitempty"`
 	BandsMeasured bool      `json:"band_noise_measured,omitempty"`
-
-	OriginalStart    time.Duration `json:"original_start,omitempty"`
-	OriginalDuration time.Duration `json:"original_duration,omitempty"`
-	WasRefined       bool          `json:"was_refined,omitempty"`
 }
 
 // MarshalJSON preserves the flat spectral_* JSON contract while the Go model
@@ -210,10 +193,6 @@ func (p NoiseProfile) MarshalJSON() ([]byte, error) {
 
 		BandNoise:     p.BandNoise,
 		BandsMeasured: p.BandsMeasured,
-
-		OriginalStart:    p.OriginalStart,
-		OriginalDuration: p.OriginalDuration,
-		WasRefined:       p.WasRefined,
 	}
 	return json.Marshal(sanitiseValue(reflect.ValueOf(flat)))
 }
@@ -246,7 +225,7 @@ func (s *speechProfileRecord) Profile() *SpeechCandidateMetrics {
 	if s == nil {
 		return nil
 	}
-	return s.source()
+	return s.src
 }
 
 // normalisationRecord wraps NormalisationResult for the record. It presents the
@@ -275,7 +254,7 @@ func (n *normalisationRecord) Result() *NormalisationResult {
 	if n == nil {
 		return nil
 	}
-	return n.source()
+	return n.src
 }
 
 // loudnormMeasuredNumeric converts FFmpeg's string-keyed LoudnormStats into the

--- a/internal/report/report_full.md.golden
+++ b/internal/report/report_full.md.golden
@@ -297,7 +297,6 @@ Sibilance reduction. Intensity is adapted from the speech-region sibilant-band e
 | Parameter | Value |
 | --- | --- |
 | Low-pass reason | 20.5 kHz band-limit (always on) |
-| Gate dynamic range (dB) | 29.92 |
 | Quiet-speech estimate (dBFS) | -75.29 |
 | Speech separation (dB) | 9.30 |
 | Speech headroom (dB) | -7.62 |

--- a/internal/report/sections.go
+++ b/internal/report/sections.go
@@ -500,22 +500,17 @@ func renderValueTable(heading string, rows [][]string) string {
 	return b.String()
 }
 
-// valueRow builds a three-cell Metric | Definition | Value row for a single-stage
-// table, looking up the label and gloss from Definitions by key.
-func valueRow(key, value string) []string {
-	return []string{metricLabel(key), metricDefinition(key), value}
-}
-
-// metricValueRow builds a single-stage value row, formatting the float through
-// formatByRule keyed off the key's catalogued Unit so the formatter choice is not
-// re-encoded per call site. It is the single value-row construction path for every
-// dimensioned single-stage cell: dBFS/dBTP (formatMetricDB), LUFS
-// (formatMetricLUFS), dB / Hz / unit-less (formatMetric), and "s" (formatFloat,
-// via fmtRaw). Decimals follow the unit (4 for unit-less spectral ratios, 2
-// otherwise), matching every existing cell.
+// metricValueRow builds a three-cell Metric | Definition | Value row for a
+// single-stage table, looking up the label and gloss from Definitions by key and
+// formatting the float through formatByRule keyed off the key's catalogued Unit
+// so the formatter choice is not re-encoded per call site. It is the single
+// value-row construction path for every dimensioned single-stage cell: dBFS/dBTP
+// (formatMetricDB), LUFS (formatMetricLUFS), dB / Hz / unit-less (formatMetric),
+// and "s" (formatFloat, via fmtRaw). Decimals follow the unit (4 for unit-less
+// spectral ratios, 2 otherwise), matching every existing cell.
 func metricValueRow(key string, value float64) []string {
 	format, decimals := unitMetricFormat(key)
-	return valueRow(key, formatByRule(value, format, decimals))
+	return []string{metricLabel(key), metricDefinition(key), formatByRule(value, format, decimals)}
 }
 
 // unitMetricFormat maps a metric key's catalogued Unit to the formatByRule rule

--- a/internal/report/sections_filters.go
+++ b/internal/report/sections_filters.go
@@ -31,6 +31,18 @@ func renderParamTable(rows []paramRow) string {
 	return mdTable([]string{"Parameter", "Value"}, body)
 }
 
+// renderFilterBlock writes one heading + prose + Parameter/Value table block:
+// the heading line, the prose sentence, the renderParamTable output, and the
+// trailing blank line the blocks share. Callers pass the full heading including
+// its hash level ("### Speech gate", "## Loudnorm"). The Downmix block (no
+// table) and the diagnostics block (no prose) do not conform and stay outside.
+func renderFilterBlock(b *strings.Builder, heading, prose string, rows []paramRow) {
+	b.WriteString(heading + "\n\n")
+	b.WriteString(prose + "\n\n")
+	b.WriteString(renderParamTable(rows))
+	b.WriteString("\n")
+}
+
 // =============================================================================
 // Filter Chain
 // =============================================================================
@@ -56,85 +68,79 @@ func renderFilters(rec *processor.RunRecord) string {
 	b.WriteString("### Downmix\n\n")
 	b.WriteString("Stereo-to-mono downmix using FFmpeg's standard downmix matrix.\n\n")
 
-	b.WriteString("### Rumble high-pass\n\n")
-	b.WriteString("Removes subsonic rumble before the gate. Fixed corner, 2-pole Butterworth (12 dB/oct), non-adaptive.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.RumbleHighPass.Enabled)},
-		{"Frequency (Hz)", formatMetric(f.RumbleHighPass.Frequency, 0)},
-		{"Poles", formatInt(f.RumbleHighPass.Poles)},
-		{"Width (Q)", formatMetric(f.RumbleHighPass.Width, 3)},
-		{"Mix", formatMetric(f.RumbleHighPass.Mix, 2)},
-		{"Transform", stringCell(f.RumbleHighPass.Transform)},
-	}))
-	b.WriteString("\n")
+	renderFilterBlock(&b, "### Rumble high-pass",
+		"Removes subsonic rumble before the gate. Fixed corner, 2-pole Butterworth (12 dB/oct), non-adaptive.",
+		[]paramRow{
+			{"Enabled", boolCell(f.RumbleHighPass.Enabled)},
+			{"Frequency (Hz)", formatMetric(f.RumbleHighPass.Frequency, 0)},
+			{"Poles", formatInt(f.RumbleHighPass.Poles)},
+			{"Width (Q)", formatMetric(f.RumbleHighPass.Width, 3)},
+			{"Mix", formatMetric(f.RumbleHighPass.Mix, 2)},
+			{"Transform", stringCell(f.RumbleHighPass.Transform)},
+		})
 
-	b.WriteString("### Band-limit low-pass\n\n")
-	b.WriteString("Unconditional 20.5 kHz band-limit (2-pole, 12 dB/oct), giving the encoder a consistent bandwidth. Non-adaptive.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.BandlimitLowPass.Enabled)},
-		{"Frequency (Hz)", formatMetric(f.BandlimitLowPass.Frequency, 0)},
-		{"Poles", formatInt(f.BandlimitLowPass.Poles)},
-		{"Width (Q)", formatMetric(f.BandlimitLowPass.Width, 3)},
-		{"Mix", formatMetric(f.BandlimitLowPass.Mix, 2)},
-		{"Transform", stringCell(f.BandlimitLowPass.Transform)},
-	}))
-	b.WriteString("\n")
+	renderFilterBlock(&b, "### Band-limit low-pass",
+		"Unconditional 20.5 kHz band-limit (2-pole, 12 dB/oct), giving the encoder a consistent bandwidth. Non-adaptive.",
+		[]paramRow{
+			{"Enabled", boolCell(f.BandlimitLowPass.Enabled)},
+			{"Frequency (Hz)", formatMetric(f.BandlimitLowPass.Frequency, 0)},
+			{"Poles", formatInt(f.BandlimitLowPass.Poles)},
+			{"Width (Q)", formatMetric(f.BandlimitLowPass.Width, 3)},
+			{"Mix", formatMetric(f.BandlimitLowPass.Mix, 2)},
+			{"Transform", stringCell(f.BandlimitLowPass.Transform)},
+		})
 
-	b.WriteString("### Noise removal\n\n")
-	b.WriteString("anlmdn Non-Local Means denoiser at the source rate, followed by an afftdn FFT spectral denoise tail.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.NoiseReduction.Enabled)},
-		{"Strength (s)", formatMetric(f.NoiseReduction.Strength, 5)},
-		{"Patch (s)", formatMetric(f.NoiseReduction.PatchSec, 4)},
-		{"Research (s)", formatMetric(f.NoiseReduction.ResearchSec, 4)},
-		{"Smooth (m)", formatMetric(f.NoiseReduction.Smooth, 0)},
-		{"afftdn enabled", boolCell(f.NoiseReduction.AfftdnEnabled)},
-		{"afftdn noise reduction (dB)", formatMetric(f.NoiseReduction.AfftdnNoiseReduction, 0)},
-		{"afftdn noise floor (dB)", afftdnNoiseFloorCell(f.NoiseReduction.AfftdnNoiseFloor)},
-		{"afftdn noise type", stringCell(f.NoiseReduction.AfftdnNoiseType)},
-		{"afftdn band noise", stringCell(f.NoiseReduction.AfftdnBandNoise)},
-		{"afftdn track noise", boolCell(f.NoiseReduction.AfftdnTrackNoise)},
-	}))
-	b.WriteString("\n")
+	renderFilterBlock(&b, "### Noise removal",
+		"anlmdn Non-Local Means denoiser at the source rate, followed by an afftdn FFT spectral denoise tail.",
+		[]paramRow{
+			{"Enabled", boolCell(f.NoiseReduction.Enabled)},
+			{"Strength (s)", formatMetric(f.NoiseReduction.Strength, 5)},
+			{"Patch (s)", formatMetric(f.NoiseReduction.PatchSec, 4)},
+			{"Research (s)", formatMetric(f.NoiseReduction.ResearchSec, 4)},
+			{"Smooth (m)", formatMetric(f.NoiseReduction.Smooth, 0)},
+			{"afftdn enabled", boolCell(f.NoiseReduction.AfftdnEnabled)},
+			{"afftdn noise reduction (dB)", formatMetric(f.NoiseReduction.AfftdnNoiseReduction, 0)},
+			{"afftdn noise floor (dB)", afftdnNoiseFloorCell(f.NoiseReduction.AfftdnNoiseFloor)},
+			{"afftdn noise type", stringCell(f.NoiseReduction.AfftdnNoiseType)},
+			{"afftdn band noise", stringCell(f.NoiseReduction.AfftdnBandNoise)},
+			{"afftdn track noise", boolCell(f.NoiseReduction.AfftdnTrackNoise)},
+		})
 
-	b.WriteString("### Speech gate\n\n")
-	b.WriteString("Soft expander for inter-speech cleanup. Threshold and range are adapted per file; the threshold and range values below are in dB.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.SpeechGate.Enabled)},
-		{"Threshold (dB)", formatMetric(f.SpeechGate.Threshold, 2)},
-		{"Ratio", formatMetric(f.SpeechGate.Ratio, 1)},
-		{"Attack (ms)", formatMetric(f.SpeechGate.Attack, 0)},
-		{"Release (ms)", formatMetric(f.SpeechGate.Release, 0)},
-		{"Range (dB)", formatMetric(f.SpeechGate.Range, 2)},
-		{"Knee", formatMetric(f.SpeechGate.Knee, 1)},
-		{"Makeup", formatMetric(f.SpeechGate.Makeup, 1)},
-		{"Detection", stringCell(f.SpeechGate.Detection)},
-	}))
-	b.WriteString("\n")
+	renderFilterBlock(&b, "### Speech gate",
+		"Soft expander for inter-speech cleanup. Threshold and range are adapted per file; the threshold and range values below are in dB.",
+		[]paramRow{
+			{"Enabled", boolCell(f.SpeechGate.Enabled)},
+			{"Threshold (dB)", formatMetric(f.SpeechGate.Threshold, 2)},
+			{"Ratio", formatMetric(f.SpeechGate.Ratio, 1)},
+			{"Attack (ms)", formatMetric(f.SpeechGate.Attack, 0)},
+			{"Release (ms)", formatMetric(f.SpeechGate.Release, 0)},
+			{"Range (dB)", formatMetric(f.SpeechGate.Range, 2)},
+			{"Knee", formatMetric(f.SpeechGate.Knee, 1)},
+			{"Makeup", formatMetric(f.SpeechGate.Makeup, 1)},
+			{"Detection", stringCell(f.SpeechGate.Detection)},
+		})
 
-	b.WriteString("### Levelling compressor\n\n")
-	b.WriteString("Gentle levelling. Threshold is speech-RMS-relative (adapted per file); ratio, attack, release, knee are fixed.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.LevellingCompressor.Enabled)},
-		{"Threshold (dB)", formatMetric(f.LevellingCompressor.Threshold, 2)},
-		{"Ratio", formatMetric(f.LevellingCompressor.Ratio, 1)},
-		{"Attack (ms)", formatMetric(f.LevellingCompressor.Attack, 0)},
-		{"Release (ms)", formatMetric(f.LevellingCompressor.Release, 0)},
-		{"Makeup (dB)", formatMetric(f.LevellingCompressor.Makeup, 1)},
-		{"Knee", formatMetric(f.LevellingCompressor.Knee, 1)},
-		{"Mix", formatMetric(f.LevellingCompressor.Mix, 2)},
-	}))
-	b.WriteString("\n")
+	renderFilterBlock(&b, "### Levelling compressor",
+		"Gentle levelling. Threshold is speech-RMS-relative (adapted per file); ratio, attack, release, knee are fixed.",
+		[]paramRow{
+			{"Enabled", boolCell(f.LevellingCompressor.Enabled)},
+			{"Threshold (dB)", formatMetric(f.LevellingCompressor.Threshold, 2)},
+			{"Ratio", formatMetric(f.LevellingCompressor.Ratio, 1)},
+			{"Attack (ms)", formatMetric(f.LevellingCompressor.Attack, 0)},
+			{"Release (ms)", formatMetric(f.LevellingCompressor.Release, 0)},
+			{"Makeup (dB)", formatMetric(f.LevellingCompressor.Makeup, 1)},
+			{"Knee", formatMetric(f.LevellingCompressor.Knee, 1)},
+			{"Mix", formatMetric(f.LevellingCompressor.Mix, 2)},
+		})
 
-	b.WriteString("### De-esser\n\n")
-	b.WriteString("Sibilance reduction. Intensity is adapted from the speech-region sibilant-band excess; amount and frequency are fixed (FFmpeg deesser 0-1 normalised params).\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(f.Deesser.Enabled)},
-		{"Intensity (i)", formatMetric(f.Deesser.Intensity, 2)},
-		{"Amount (m)", formatMetric(f.Deesser.Amount, 2)},
-		{"Frequency (f)", formatMetric(f.Deesser.Frequency, 2)},
-	}))
-	b.WriteString("\n")
+	renderFilterBlock(&b, "### De-esser",
+		"Sibilance reduction. Intensity is adapted from the speech-region sibilant-band excess; amount and frequency are fixed (FFmpeg deesser 0-1 normalised params).",
+		[]paramRow{
+			{"Enabled", boolCell(f.Deesser.Enabled)},
+			{"Intensity (i)", formatMetric(f.Deesser.Intensity, 2)},
+			{"Amount (m)", formatMetric(f.Deesser.Amount, 2)},
+			{"Frequency (f)", formatMetric(f.Deesser.Frequency, 2)},
+		})
 
 	b.WriteString(renderFilterDiagnostics(f.Diagnostics))
 
@@ -154,7 +160,6 @@ func renderFilterDiagnostics(d *processor.AdaptiveDiagnostics) string {
 	b.WriteString("### Adaptation diagnostics\n\n")
 	b.WriteString(renderParamTable([]paramRow{
 		{"Low-pass reason", stringCell(d.BandlimitLPReason)},
-		{"Gate dynamic range (dB)", formatMetric(d.SpeechGateDynamicRange, 2)},
 		{"Quiet-speech estimate (dBFS)", formatMetricDB(d.SpeechGateQuietSpeechEstimate, 2)},
 		{"Speech separation (dB)", formatMetric(d.SpeechGateSpeechSeparation, 2)},
 		{"Speech headroom (dB)", formatMetric(d.SpeechGateSpeechHeadroom, 2)},
@@ -202,20 +207,17 @@ func renderNormalisation(rec *processor.RunRecord) string {
 	}
 
 	var b strings.Builder
-	b.WriteString("## Peak Limiter\n\n")
-	b.WriteString("Transparent limiter that creates true-peak headroom so loudnorm reaches the target in linear mode. Pre-gain raises very quiet recordings before limiting.\n\n")
-	b.WriteString(renderParamTable([]paramRow{
-		{"Enabled", boolCell(r.LimiterEnabled)},
-		{"Ceiling (dBTP)", formatMetricDB(r.LimiterCeiling, 2)},
-		{"Gain required (dB)", formatMetric(r.LimiterGain, 2)},
-		{"Filtered true peak (dBTP)", formatMetricDB(r.LimiterFilteredTP, 2)},
-		{"Pre-gain (dB)", formatMetric(r.PreGainDB, 2)},
-		{"Ceiling clamped", boolCell(r.LimiterClamped)},
-	}))
-	b.WriteString("\n")
+	renderFilterBlock(&b, "## Peak Limiter",
+		"Transparent limiter that creates true-peak headroom so loudnorm reaches the target in linear mode. Pre-gain raises very quiet recordings before limiting.",
+		[]paramRow{
+			{"Enabled", boolCell(r.LimiterEnabled)},
+			{"Ceiling (dBTP)", formatMetricDB(r.LimiterCeiling, 2)},
+			{"Gain required (dB)", formatMetric(r.LimiterGain, 2)},
+			{"Filtered true peak (dBTP)", formatMetricDB(r.LimiterFilteredTP, 2)},
+			{"Pre-gain (dB)", formatMetric(r.PreGainDB, 2)},
+			{"Ceiling clamped", boolCell(r.LimiterClamped)},
+		})
 
-	b.WriteString("## Loudnorm\n\n")
-	b.WriteString("EBU R128 loudness normalisation in linear mode using the Pass-3 measured input statistics.\n\n")
 	rows := []paramRow{
 		{"Requested target (LUFS)", formatMetricLUFS(r.RequestedTargetI, 2)},
 		{"Effective target (LUFS)", formatMetricLUFS(r.EffectiveTargetI, 2)},
@@ -243,7 +245,9 @@ func renderNormalisation(rec *processor.RunRecord) string {
 	// output integrated loudness minus the effective target. A signed number,
 	// never a boolean or glyph. Precomputed at record assembly (LoudnormParsed).
 	rows = append(rows, paramRow{"Deviation from target (LU)", targetDeviationCell(r)})
-	b.WriteString(renderParamTable(rows))
+	renderFilterBlock(&b, "## Loudnorm",
+		"EBU R128 loudness normalisation in linear mode using the Pass-3 measured input statistics.",
+		rows)
 
 	return b.String()
 }

--- a/internal/report/sections_filters_test.go
+++ b/internal/report/sections_filters_test.go
@@ -31,7 +31,6 @@ func processingRecord() *processor.RunRecord {
 
 	diag := &processor.AdaptiveDiagnostics{
 		BandlimitLPReason:             "20.5 kHz band-limit (always on)",
-		SpeechGateDynamicRange:        29.915058,
 		SpeechGateQuietSpeechEstimate: -75.290897,
 		SpeechGateSpeechSeparation:    9.297741,
 		SpeechGateSpeechHeadroom:      -7.623852,
@@ -126,8 +125,7 @@ func TestRenderFiltersParams(t *testing.T) {
 		"-36.38", // levelling compressor threshold
 		// Diagnostics rendered as objective values.
 		"20.5 kHz band-limit (always on)",
-		"29.92", // gate dynamic range dB
-		"none",  // clamp reason
+		"none", // clamp reason
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("filters output missing %q\n%s", want, got)

--- a/internal/report/sections_spectrograms.go
+++ b/internal/report/sections_spectrograms.go
@@ -23,14 +23,18 @@ var spectrogramKindOrder = []struct {
 	{processor.SpectrogramKindSpeech, "Speech"},
 }
 
+// spectrogramColumn is one stage column: the record stage key and the table
+// header shown for it.
+type spectrogramColumn struct {
+	stage  string
+	header string
+}
+
 // spectrogramStageOrder is the stable stage (column) order. Processing records
 // carry before+after; analysis-only records carry input only. A column is
 // emitted only when at least one image populates it, mirroring the absent-stage
 // convention the metric tables use (renderLoudness etc.).
-var spectrogramStageOrder = []struct {
-	stage  string
-	header string
-}{
+var spectrogramStageOrder = []spectrogramColumn{
 	{processor.SpectrogramStageBefore, "Before"},
 	{processor.SpectrogramStageAfter, "After"},
 	{processor.SpectrogramStageInput, "Input"},
@@ -59,7 +63,7 @@ func renderSpectrograms(rec *processor.RunRecord) string {
 	}
 
 	// Columns: keep only stages that at least one image populates.
-	stages := make([]struct{ stage, header string }, 0, len(spectrogramStageOrder))
+	stages := make([]spectrogramColumn, 0, len(spectrogramStageOrder))
 	for _, s := range spectrogramStageOrder {
 		if present[s.stage] {
 			stages = append(stages, s)

--- a/internal/ui/filledcells_test.go
+++ b/internal/ui/filledcells_test.go
@@ -1,0 +1,49 @@
+package ui
+
+import "testing"
+
+// TestFilledCells covers the three call-site parameterisations: the dot
+// timeline (timelineWidth, minFilled 0), the separation bar
+// (separationBarWidth, minFilled 0), and GainBar (gainBarWidth, minFilled 1,
+// its clipping override lives outside the helper).
+func TestFilledCells(t *testing.T) {
+	tests := []struct {
+		name      string
+		frac      float64
+		width     int
+		minFilled int
+		want      int
+	}{
+		// Dot timeline: width 8, minFilled 0.
+		{"timeline empty", 0, timelineWidth, 0, 0},
+		{"timeline full", 1, timelineWidth, 0, timelineWidth},
+		{"timeline mid rounds up", 0.5, timelineWidth, 0, 4},
+		{"timeline rounds nearest", 0.3, timelineWidth, 0, 2},
+		{"timeline below range clamps", -0.5, timelineWidth, 0, 0},
+		{"timeline above range clamps", 1.5, timelineWidth, 0, timelineWidth},
+
+		// Separation bar: width 3, minFilled 0.
+		{"separation empty", 0, separationBarWidth, 0, 0},
+		{"separation full", 1, separationBarWidth, 0, separationBarWidth},
+		{"separation mid", 0.5, separationBarWidth, 0, 2},
+		{"separation small fraction rounds down", 0.1, separationBarWidth, 0, 0},
+		{"separation above range clamps", 2, separationBarWidth, 0, separationBarWidth},
+
+		// GainBar: width 5, minFilled 1 (one-pip floor).
+		{"gain zero pins one pip", 0, gainBarWidth, 1, 1},
+		{"gain full", 1, gainBarWidth, 1, gainBarWidth},
+		{"gain mid rounds up", 0.5, gainBarWidth, 1, 3},
+		{"gain tiny fraction pins one pip", 0.05, gainBarWidth, 1, 1},
+		{"gain below range pins one pip", -1, gainBarWidth, 1, 1},
+		{"gain above range clamps", 1.2, gainBarWidth, 1, gainBarWidth},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filledCells(tc.frac, tc.width, tc.minFilled)
+			if got != tc.want {
+				t.Fatalf("filledCells(%v, %d, %d) = %d, want %d",
+					tc.frac, tc.width, tc.minFilled, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -42,14 +42,7 @@ const analysisBarOverhead = 13
 // progressWidthFor clamps the bar width derived from a terminal width and its
 // surrounding chrome into the supported range.
 func progressWidthFor(termWidth, overhead int) int {
-	w := termWidth - overhead
-	if w < minProgressWidth {
-		return minProgressWidth
-	}
-	if w > maxProgressWidth {
-		return maxProgressWidth
-	}
-	return w
+	return max(minProgressWidth, min(termWidth-overhead, maxProgressWidth))
 }
 
 // handleCommonMsg processes the messages both Update methods treat identically:

--- a/internal/ui/statusboxes.go
+++ b/internal/ui/statusboxes.go
@@ -384,10 +384,7 @@ func renderAnalysisBox(s AdaptedSummary, height int) string {
 // wider separation reads greener (cleaner). Reuses the meter's colour grammar.
 func separationBar(separationDB float64) string {
 	const span = 60.0
-	frac := separationDB / span
-	frac = max(0, min(frac, 1))
-	filled := int(frac*float64(separationBarWidth) + 0.5)
-	filled = max(0, min(filled, separationBarWidth))
+	filled := filledCells(separationDB/span, separationBarWidth, 0)
 
 	ramp := lipgloss.Blend1D(separationBarWidth, cli.ColorRed, cli.ColorYellow, cli.ColorGreen)
 	return renderFilledBar(separationBarWidth, filled, ramp)

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -70,12 +70,12 @@ func buildScrollbar(vpHeight, totalLines, visibleLines int, scrollPercent float6
 	if totalLines > 0 {
 		visibleFraction = float64(visibleLines) / float64(totalLines)
 	}
-	visibleFraction = math.Max(0, math.Min(1, visibleFraction))
+	visibleFraction = max(0, min(1, visibleFraction))
 
 	thumbHeight := int(math.Round(float64(vpHeight) * visibleFraction))
 	thumbHeight = max(1, min(thumbHeight, vpHeight))
 
-	scrollPercent = math.Max(0, math.Min(1, scrollPercent))
+	scrollPercent = max(0, min(1, scrollPercent))
 	thumbTop := int(math.Round(float64(vpHeight-thumbHeight) * scrollPercent))
 	thumbTop = max(0, min(thumbTop, vpHeight-thumbHeight))
 
@@ -245,8 +245,7 @@ func renderTimeline(file FileProgress) string {
 	// Mini dot timeline filled to progress. Filled dots muted, empty dots use the
 	// meter empty-track colour, so the timeline reads as secondary to the main
 	// gradient bar above.
-	filled := int(file.Progress*float64(timelineWidth) + 0.5)
-	filled = max(0, min(filled, timelineWidth))
+	filled := filledCells(file.Progress, timelineWidth, 0)
 	filledStyle := lipgloss.NewStyle().Foreground(cli.ColorMuted)
 	emptyStyle := lipgloss.NewStyle().Foreground(cli.ColorFill)
 	timeline := filledStyle.Render(strings.Repeat("▰", filled)) +
@@ -554,11 +553,10 @@ const gainBarWidth = 5
 // of truth.
 func GainBar(inputTP float64) string {
 	position := gainGlyphPosition(inputTP)
-	filled := int(math.Round(position * float64(gainBarWidth)))
 	// Floor at one cell so the cold/blue end always shows a pip, an empty bar
 	// would lose the under-recorded signal. A clipping input (>= 0 dBTP) maxes
 	// the bar so the worst case reads as a full, red-tipped run.
-	filled = max(1, min(filled, gainBarWidth))
+	filled := filledCells(position, gainBarWidth, 1)
 	if inputTP >= 0 {
 		filled = gainBarWidth
 	}
@@ -569,6 +567,15 @@ func GainBar(inputTP float64) string {
 	// (clipping).
 	ramp := lipgloss.Blend1D(gainBarWidth, cli.ColorCyanBright, cli.ColorBlue, cli.ColorGreen, cli.ColorOrange, cli.ColorRed)
 	return renderFilledBar(gainBarWidth, filled, ramp)
+}
+
+// filledCells converts a fill fraction into a filled-cell count for a
+// width-cell bar: frac is clamped to [0,1], rounded to the nearest cell, and the
+// count clamped to [minFilled, width]. minFilled lets a bar pin a minimum
+// visible fill (GainBar's one-pip floor); the plain bars pass 0.
+func filledCells(frac float64, width, minFilled int) int {
+	frac = max(0, min(frac, 1))
+	return max(minFilled, min(int(math.Round(frac*float64(width))), width))
 }
 
 // renderFilledBar draws a width-cell coloured bar: the first filled cells use the


### PR DESCRIPTION
  Simplify the effective-config derivation from a two-step
  assembleEffectiveFilterConfig/deriveAdaptiveFilterResult pair to a single
  cloneFilterDefaults call. Replace one-caller indirections
  (assembleFilterDefaults, valueRow, copyFilterDefaults) with direct
  construction. Swap custom atoi and lenientHandler implementations for stdlib
  (strconv.Atoi) and standard filter-loop error handling (breakOnError).
  Consolidate pass-timing tracking from eight fields to an indexed four-element
  array.

  Remove the always-zero SpeechGateDynamicRange diagnostic field from
  AdaptiveDiagnostics and its report row in sections_filters.go. Remove dead
  NoiseProfile refinement fields (OriginalStart, OriginalDuration, WasRefined)
  and dead reflect.Float32 cases. In scoreSpeechIntervalWindow, fold the voiced
  count into the first accumulation loop and drop the kurtosisValues slice.

  Update Kong help rendering to source from ctx.Model.Help (Kong's Description)
  instead of a hard-coded string. Add TestFilledCells unit test covering all
  three call-site parameterisations (timeline, separation bar, GainBar).

  User-visible effects: the report and JSON lose the always-zero "Gate dynamic
  range (dB)" row and dynamic_range_db key; styled --help now sources from Kong's
  Description field. No DSP changes; all tests and lint pass.