### PR TITLE
refactor: consolidate limiter derivation and guard duration sentinel

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -32,11 +32,11 @@ jobs:
       - run: go vet ./...
       - name: Check cyclomatic complexity
         run: |
-          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+          go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
           gocyclo -top 20 -ignore '_test\.go$' -avg .
       - name: Check ineffectual assignments
         run: |
-          go install github.com/gordonklaus/ineffassign@latest
+          go install github.com/gordonklaus/ineffassign@v0.2.0
           ineffassign ./...
       - uses: golangci/golangci-lint-action@v9
 

--- a/.tailor.yml
+++ b/.tailor.yml
@@ -84,9 +84,6 @@ labels:
     description: Hacktoberfest contribution
 
 swatches:
-  - path: .github/workflows/tailor.yml
-    alteration: never
-
   - path: .github/dependabot.yml
     alteration: first-fit
 
@@ -101,9 +98,6 @@ swatches:
 
   - path: .github/ISSUE_TEMPLATE/config.yml
     alteration: first-fit
-
-  - path: .github/pull_request_template.md
-    alteration: never
 
   - path: SECURITY.md
     alteration: always
@@ -134,6 +128,3 @@ swatches:
 
   - path: .tailor.yml
     alteration: first-fit
-
-  - path: .github/workflows/tailor-automerge.yml
-    alteration: never

--- a/internal/audio/reader.go
+++ b/internal/audio/reader.go
@@ -90,10 +90,8 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 		return nil, nil, fmt.Errorf("failed to open decoder: %w", err)
 	}
 
-	duration := float64(fmtCtx.Duration()) / float64(ffmpeg.AVTimeBase)
-
 	metadata := &Metadata{
-		Duration:   duration,
+		Duration:   durationSeconds(fmtCtx.Duration()),
 		SampleRate: decCtx.SampleRate(),
 		Channels:   decCtx.ChLayout().NbChannels(),
 	}
@@ -120,6 +118,17 @@ func OpenAudioFile(filename string) (*Reader, *Metadata, error) {
 	}
 
 	return reader, metadata, nil
+}
+
+// durationSeconds converts a container duration in AV_TIME_BASE ticks to
+// seconds. A container that does not know its duration reports AVNoptsValue;
+// that sentinel maps to 0 (the honest absent value downstream consumers already
+// tolerate) rather than a garbage ratio.
+func durationSeconds(raw int64) float64 {
+	if raw == int64(ffmpeg.AVNoptsValue) {
+		return 0
+	}
+	return float64(raw) / float64(ffmpeg.AVTimeBase)
 }
 
 // ReadFrame reads the next decoded audio frame

--- a/internal/audio/reader_test.go
+++ b/internal/audio/reader_test.go
@@ -162,6 +162,42 @@ func TestErrorWrapping_PreservesSentinels(t *testing.T) {
 	}
 }
 
+// TestDurationSeconds covers the sentinel guard and the tick-to-seconds ratio
+// without a decoder. AVNoptsValue (an unknown container duration) must map to 0,
+// a known tick count must yield the exact AV_TIME_BASE ratio, and the result
+// must never be negative for a non-negative input.
+func TestDurationSeconds(t *testing.T) {
+	t.Parallel()
+
+	// AV_TIME_BASE is 1_000_000 ticks per second, so this many ticks is exactly
+	// 123.5 s. The division is exact in float64, so an equality check is safe.
+	const oneAndAHalf = int64(123_500_000)
+
+	tests := []struct {
+		name string
+		raw  int64
+		want float64
+	}{
+		{"sentinel maps to zero", int64(ffmpeg.AVNoptsValue), 0},
+		{"zero ticks", 0, 0},
+		{"known tick count", oneAndAHalf, 123.5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := durationSeconds(tc.raw)
+			if got != tc.want {
+				t.Errorf("durationSeconds(%d) = %v, want %v", tc.raw, got, tc.want)
+			}
+			if got < 0 {
+				t.Errorf("durationSeconds(%d) = %v, want non-negative", tc.raw, got)
+			}
+		})
+	}
+}
+
 // TestMetadata_FieldRoundTrip is a trivial pure-value check on the Metadata
 // struct: the fields OpenAudioFile populates are plain and carry the units the
 // doc comments promise. It guards against an accidental field reorder or type

--- a/internal/processor/normalise.go
+++ b/internal/processor/normalise.go
@@ -344,97 +344,80 @@ func measureWithLoudnorm(ctx context.Context, inputPath string, config *Effectiv
 	return measurement, nil
 }
 
-// calculateLimiterCeiling calculates the adaptive ceiling for pre-limiting in Pass 4.
-// This allows loudnorm to apply full linear gain without exceeding target TP.
+// limiterDerivation carries both results of deriveLimiterAndPreGain: the limiter
+// ceiling decision and the pre-gain deficit that raises a clamped-ceiling signal
+// so loudnorm can still apply full linear gain.
+type limiterDerivation struct {
+	ceiling          float64 // limiter ceiling in dBTP (clamped to minLimiterCeilingDB if needed)
+	needed           bool    // true if limiting is required (projected TP exceeds target)
+	clamped          bool    // true if ceiling was clamped to minimum (loudnorm may need to adjust target)
+	preGainDB        float64 // pre-gain amount in dB (positive when clamped, 0.0 otherwise)
+	reDerivedCeiling float64 // limiter ceiling re-derived from post-gain values (0.0 when not clamped)
+}
+
+// deriveLimiterAndPreGain derives the Pass-4 pre-limiter ceiling and the pre-gain
+// deficit applied when that ceiling is clamped, so loudnorm can apply full linear
+// gain without exceeding target TP. The ceiling places the post-limiter sample
+// peak the full crest budget (target_TP - target_I) above the pre-limiter
+// loudness: ceiling = target_TP - gainRequired. The downstream brickwall limiter
+// (buildBrickwallLimiter, pinned to target_TP) catches any post-adeclick overshoot.
 //
-// The ceiling is derived from the loudness targets. It places the post-limiter
-// sample peak the full crest budget B above the pre-limiter loudness:
-//
-//	B = target_TP - target_I              (the fixed crest budget)
-//	ceiling = target_TP - gainRequired    (= filtered_I + B, the full crest budget)
-//
-// The post-adeclick true-peak overshoot is caught by the downstream brickwall
-// limiter (buildBrickwallLimiter, pinned to target_TP), which is the backstop.
-//
-// FFmpeg alimiter constraint: the limit parameter accepts 0.0625 to 1.0 (linear),
-// which corresponds to -24.08 dBTP to 0 dBTP. Ceilings below this are clamped.
+// Ceilings below alimiter's engine floor (minLimiterCeilingDB) are clamped; on a
+// clamp, preGainDB raises the signal before limiting and reDerivedCeiling is the
+// ceiling re-derived from the post-gain values. Both are 0.0 when not clamped.
+// See docs/Normalisation-Tuning.md for the minLimiterCeilingDB derivation.
 //
 // Parameters:
-//   - measured_I: Measured integrated loudness from Pass 3 (LUFS)
-//   - measured_TP: Measured true peak from Pass 3 (dBTP)
-//   - target_I: Target integrated loudness (LUFS), typically -16.0
-//   - target_TP: Target true peak (dBTP), typically -1.0
-//
-// Returns:
-//   - ceiling: The limiter ceiling in dBTP (clamped to minLimiterCeilingDB if needed)
-//   - needed: True if limiting is required (projected TP exceeds target)
-//   - clamped: True if ceiling was clamped to minimum (loudnorm may need to adjust target)
-func calculateLimiterCeiling(measuredI, measuredTP, targetI, targetTP float64) (ceiling float64, needed bool, clamped bool) {
+//   - measuredI: Measured integrated loudness from Pass 3 (LUFS)
+//   - measuredTP: Measured true peak from Pass 3 (dBTP)
+//   - targetI: Target integrated loudness (LUFS), typically -16.0
+//   - targetTP: Target true peak (dBTP), typically -1.0
+func deriveLimiterAndPreGain(measuredI, measuredTP, targetI, targetTP float64) limiterDerivation {
 	gainRequired := targetI - measuredI
-	projectedTP := measuredTP + gainRequired
+
+	// Pre-gain: computed independently of the limiting decision (the former
+	// calculatePreGain took no measuredTP). When the ideal ceiling sits below
+	// alimiter's minimum, the deficit raises the signal before limiting so
+	// loudnorm can apply full linear gain, and the ceiling is re-derived from the
+	// post-gain values. Otherwise both stay 0.0.
+	idealCeiling := targetTP - gainRequired
+	var d limiterDerivation
+	if idealCeiling < minLimiterCeilingDB {
+		d.preGainDB = minLimiterCeilingDB - idealCeiling
+
+		postGainI := measuredI + d.preGainDB
+		newGainRequired := targetI - postGainI
+		d.reDerivedCeiling = targetTP - newGainRequired
+	}
 
 	// No limiting needed if linear mode already possible
+	projectedTP := measuredTP + gainRequired
 	if projectedTP <= targetTP {
-		return 0, false, false
+		return d
 	}
 
 	// Derived ceiling: targetTP - gainRequired (= filtered_I + B, the full crest budget).
-	ceiling = targetTP - gainRequired
+	d.ceiling = targetTP - gainRequired
+	d.needed = true
 
 	// Clamp to alimiter's minimum supported ceiling
-	if ceiling < minLimiterCeilingDB {
-		ceiling = minLimiterCeilingDB
-		clamped = true
+	if d.ceiling < minLimiterCeilingDB {
+		d.ceiling = minLimiterCeilingDB
+		d.clamped = true
 	}
 
-	return ceiling, true, clamped
+	return d
 }
 
-// calculatePreGain computes the pre-gain amount needed when the limiter ceiling is
-// clamped to alimiter's minimum. The deficit (preGainDB) raises the signal before
-// limiting so that loudnorm can apply full linear gain. When the ceiling is not
-// clamped, returns (0.0, 0.0).
+// buildPreLimiterPrefix constructs the Pass-3/4 pre-limiter prefix: a
+// comma-separated fragment of volume (when pre-gain is active) and the levelling
+// alimiter (when limiting is needed) that creates true-peak headroom so loudnorm
+// stays in linear mode. Returns "" when no limiting is needed.
 //
-// Parameters:
-//   - measuredI: Measured integrated loudness (LUFS)
-//   - targetI: Target integrated loudness (LUFS), typically -16.0
-//   - targetTP: Target true peak (dBTP), typically -1.0
-//
-// Returns:
-//   - preGainDB: The pre-gain amount in dB (positive when clamped, 0.0 otherwise)
-//   - reDerivedCeiling: The limiter ceiling re-derived from post-gain values (0.0 when not clamped)
-func calculatePreGain(measuredI, targetI, targetTP float64) (preGainDB, reDerivedCeiling float64) {
-	gainRequired := targetI - measuredI
-	idealCeiling := targetTP - gainRequired
-
-	// No pre-gain needed if ceiling is at or above alimiter's minimum
-	if idealCeiling >= minLimiterCeilingDB {
-		return 0.0, 0.0
-	}
-
-	// Deficit: how far below the minimum the ideal ceiling sits
-	preGainDB = minLimiterCeilingDB - idealCeiling
-
-	// Re-derive ceiling from post-gain values
-	postGainI := measuredI + preGainDB
-	newGainRequired := targetI - postGainI
-	reDerivedCeiling = targetTP - newGainRequired
-
-	return preGainDB, reDerivedCeiling
-}
-
-// buildPreLimiterPrefix constructs the filter prefix for pre-limiting in Pass 3/4.
-// Returns a comma-separated filter string fragment containing volume (when pre-gain
-// is active) and alimiter (when limiting is needed), or "" when no limiting is needed.
-//
-// Parameters for transparent peak limiting (this is the levellingLimiter: the
-// prefix limiter that creates true-peak headroom so loudnorm stays in linear mode):
-//   - attack=5ms: Gentle attack preserves transient shape
-//   - release=100ms: Smooth recovery eliminates pumping
-//   - asc=1, asc_level=0.8: program-dependent release shaper, dormant on typical
-//     material - only engages under heavy sustained limiting; kept as a safety-net
-//   - level_in/level_out=1: Unity gain (no makeup)
-//   - latency=1: Enable lookahead for better transient handling
+// The alimiter runs a gentle 5 ms attack / 100 ms release for transparent peak
+// limiting at unity gain with lookahead. asc=1:asc_level=0.8 is a program-dependent
+// release shaper kept as a safety net: it stays dormant on typical material and
+// engages only under heavy sustained limiting.
 //
 // Parameters:
 //   - preGainDB: Pre-gain amount in dB (positive when clamped, 0.0 otherwise)
@@ -465,11 +448,11 @@ func buildPreLimiterPrefix(preGainDB, ceiling float64, needsLimiting bool) strin
 
 // buildBrickwallLimiter builds the final-stage source-rate brickwall limiter (the
 // peakLimiter: it owns true-peak delivery). alimiter limits SAMPLE peak, so
-// ceilingDBTP is the sample-peak ceiling: the
-// caller sets it below the loudnorm true-peak target by the inter-sample
-// allowance (brickwallTruePeakHeadroomDB) so oversampled true peak still lands
-// under the target. This helper is a pure dBTP→string converter and applies no
-// headroom itself.
+// ceilingDBTP is the sample-peak ceiling: the caller sets it below the loudnorm
+// true-peak target by the inter-sample allowance (brickwallTruePeakHeadroomDB) so
+// oversampled true peak still lands under the target. This helper is a pure
+// dBTP→string converter and applies no headroom itself.
+// See docs/Normalisation-Tuning.md for the brickwallTruePeakHeadroomDB derivation.
 func buildBrickwallLimiter(ceilingDBTP float64) string {
 	limit := Decibels(ceilingDBTP).LinearAmplitude().Float64()
 	return fmt.Sprintf(
@@ -537,24 +520,22 @@ type loudnormApplicationExecutionResult struct {
 
 func planLimiterForLoudnorm(output *OutputMeasurements, config *EffectiveFilterConfig) limiterPlan {
 	loudnorm := config.Loudnorm
-	ceilingDB, needed, clamped := calculateLimiterCeiling(
+	d := deriveLimiterAndPreGain(
 		output.Loudness.OutputI, output.Loudness.OutputTP,
 		loudnorm.TargetI, loudnorm.TargetTP,
 	)
-	preGainDB, reDerivedCeiling := calculatePreGain(
-		output.Loudness.OutputI, loudnorm.TargetI, loudnorm.TargetTP,
-	)
-	if clamped {
-		ceilingDB = reDerivedCeiling
+	ceilingDB := d.ceiling
+	if d.clamped {
+		ceilingDB = d.reDerivedCeiling
 	}
 
 	return limiterPlan{
-		preGainDB:   preGainDB,
+		preGainDB:   d.preGainDB,
 		ceilingDB:   ceilingDB,
-		needed:      needed,
-		clamped:     clamped,
+		needed:      d.needed,
+		clamped:     d.clamped,
 		gainDB:      loudnorm.TargetI - output.Loudness.OutputI,
-		pass3Prefix: buildPreLimiterPrefix(preGainDB, ceilingDB, needed),
+		pass3Prefix: buildPreLimiterPrefix(d.preGainDB, ceilingDB, d.needed),
 		filteredTP:  output.Loudness.OutputTP,
 	}
 }
@@ -576,8 +557,7 @@ func planLimiterForLoudnorm(output *OutputMeasurements, config *EffectiveFilterC
 // value as targetTP into calculateLinearModeTarget, the measuredTP and measuredI
 // terms cancel and maxLinearTargetI collapses to TargetI + measurementCushionDB
 // (≥ TargetI), so desiredI == TargetI <= maxLinearTargetI holds for every file.
-// Every file reaches full −16.0 LUFS in linear mode without a corpus-tuned relax
-// constant, the deterministic generalisation across any producer's audio.
+// See docs/Normalisation-Tuning.md for the corpus derivation.
 // NEVER use this for the brickwall ceiling.
 func loudnormInternalTargetTP(loudnorm LoudnormConfig, measuredTP, measuredI float64) float64 {
 	return measuredTP + (loudnorm.TargetI - measuredI) + linearSafetyMargin + measurementCushionDB
@@ -612,12 +592,9 @@ func calculateLinearModeTarget(measuredI, measuredTP, desiredI, targetTP float64
 	// Formula: measured_TP + (target_I - measured_I) <= target_TP
 	// Solving for target_I: target_I <= target_TP - measured_TP + measured_I
 	//
-	// We subtract a small safety margin (linearSafetyMargin, 0.1 dB, a package
-	// const so loudnormInternalTargetTP folds the same value into its per-file
-	// internal TP) to account for:
-	// - Floating point precision differences between Go and FFmpeg's internal calculations
-	// - Potential rounding in filter parameter passing
-	// - Any measurement variance during processing
+	// Subtract linearSafetyMargin; loudnormInternalTargetTP folds the same value
+	// into its per-file internal TP.
+	// See docs/Normalisation-Tuning.md for the corpus derivation.
 	maxLinearTargetI := targetTP - measuredTP + measuredI - linearSafetyMargin
 
 	// Check if desired target is achievable in linear mode (with safety margin)
@@ -847,16 +824,13 @@ func applyNormalisationWithDeps(
 	// carries.
 	progress.measuringDoneNormalisingStart(limiter)
 
-	// Calculate effective target I that ensures linear mode (no dynamic fallback)
-	// Pass 3 measured through the same prefix chain as Pass 4, so
-	// measurement.InputI and measurement.InputTP already reflect the
-	// post-limiter signal. No effectiveMeasuredI/effectiveTP adjustment needed.
-	// Guard loudnorm against ITS OWN per-file internal TP target, not the brickwall
-	// ceiling. The downstream brickwall (pinned to loudnorm.TargetTP) owns real
-	// true-peak delivery. loudnormInternalTargetTP derives the internal TP from this
-	// file's measured TP/I, so the measuredTP/measuredI terms cancel in the guard and
-	// maxLinearTargetI collapses to TargetI + measurementCushionDB: the cap is inert
-	// by construction and every file reaches full −16.0 LUFS in linear mode.
+	// Calculate effective target I that ensures linear mode (no dynamic fallback).
+	// Pass 3 measured through the same prefix chain as Pass 4, so measurement.InputI
+	// and measurement.InputTP already reflect the post-limiter signal. Guard loudnorm
+	// against ITS OWN per-file internal TP target (loudnormInternalTargetTP), not the
+	// brickwall ceiling: the downstream brickwall (pinned to loudnorm.TargetTP) owns
+	// real true-peak delivery, and the internal-TP derivation makes the cap inert (see
+	// loudnormInternalTargetTP).
 	effectiveTargetI, _, linearPossible := calculateLinearModeTarget(
 		measurement.InputI,
 		measurement.InputTP,
@@ -1246,24 +1220,18 @@ func buildLoudnormFilterSpec(config *EffectiveFilterConfig, measurement *Loudnor
 	// print_format=json: Outputs JSON with normalization_type, target_offset, output_i/tp/lra
 	//
 	// Pass 3 measures through the same volume+alimiter prefix, so measurement.InputI
-	// and measurement.InputTP already reflect the post-limiter signal. No manual
-	// effectiveMeasuredI/effectiveMeasuredTP adjustment needed.
-	// loudnorm targets its INTERNAL per-file TP (the projected post-gain peak plus a
-	// fixed measurement cushion, loudnormInternalTargetTP), not the delivered ceiling.
-	// The downstream brickwall (built below from the un-relaxed loudnorm.TargetTP)
-	// owns the real ceiling, so loudnorm can drive to full −16.0 LUFS without its own
-	// limiter fighting the last fraction of a dB.
+	// and measurement.InputTP already reflect the post-limiter signal. loudnorm targets
+	// its INTERNAL per-file TP (loudnormInternalTargetTP), not the delivered ceiling;
+	// the downstream brickwall (built below from the un-relaxed loudnorm.TargetTP) owns
+	// the real ceiling, so loudnorm can drive to full −16.0 LUFS.
 	//
 	// The emitted TP= is clamped to FFmpeg's accepted range [loudnormTPMinDB,
-	// loudnormTPMaxDB] = [-9, 0]. On-corpus the prefix limiter holds projectedPeak
-	// ≤ TargetTP, so internalTP ≈ -0.7 (never near the upper clamp) and passes
-	// through UNCHANGED, clamping to [-9, 0] (NOT to TargetTP) preserves byte
-	// parity. The lower clamp only catches genuinely quiet off-corpus recordings
-	// whose peak is already below -9 dBTP, where loudnorm's internal limiter is
-	// inert anyway, so the clamp changes no on-corpus output. The linear-mode guard
-	// above keeps the UNCLAMPED value so "reach -16 in linear mode" still holds for
-	// those quiet files. emittedTP (and the brickwall ceiling below) come from
-	// loudnormTPTargets.
+	// loudnormTPMaxDB] = [-9, 0] (NOT to TargetTP). The lower clamp only catches
+	// genuinely quiet recordings whose peak is already below -9 dBTP, where
+	// loudnorm's internal limiter is inert. The linear-mode guard above keeps the
+	// UNCLAMPED value so "reach -16 in linear mode" still holds for those quiet
+	// files. emittedTP (and the brickwall ceiling below) come from loudnormTPTargets.
+	// See docs/Normalisation-Tuning.md for the loudnormTP bounds.
 	loudnormFilter := fmt.Sprintf(
 		"loudnorm=I=%.2f:TP=%.2f:LRA=%.1f:measured_I=%.2f:measured_TP=%.2f:measured_LRA=%.2f:measured_thresh=%.2f:offset=%.2f:dual_mono=%s:linear=%s:print_format=json",
 		loudnorm.TargetI, // %.2f for precision on adjusted targets

--- a/internal/processor/normalise_test.go
+++ b/internal/processor/normalise_test.go
@@ -1201,6 +1201,129 @@ func TestCalculateLinearModeTarget(t *testing.T) {
 	}
 }
 
+// refLimiterCeiling and refPreGain are verbatim copies of the arithmetic the
+// former calculateLimiterCeiling and calculatePreGain carried. They are the
+// reference oracle for TestDeriveLimiterAndPreGainEquivalence, so the grid keeps
+// proving bit-identity after the production helpers were merged and deleted.
+func refLimiterCeiling(measuredI, measuredTP, targetI, targetTP float64) (ceiling float64, needed, clamped bool) {
+	gainRequired := targetI - measuredI
+	projectedTP := measuredTP + gainRequired
+	if projectedTP <= targetTP {
+		return 0, false, false
+	}
+	ceiling = targetTP - gainRequired
+	if ceiling < minLimiterCeilingDB {
+		ceiling = minLimiterCeilingDB
+		clamped = true
+	}
+	return ceiling, true, clamped
+}
+
+func refPreGain(measuredI, targetI, targetTP float64) (preGainDB, reDerivedCeiling float64) {
+	gainRequired := targetI - measuredI
+	idealCeiling := targetTP - gainRequired
+	if idealCeiling >= minLimiterCeilingDB {
+		return 0.0, 0.0
+	}
+	preGainDB = minLimiterCeilingDB - idealCeiling
+	postGainI := measuredI + preGainDB
+	newGainRequired := targetI - postGainI
+	reDerivedCeiling = targetTP - newGainRequired
+	return preGainDB, reDerivedCeiling
+}
+
+// TestDeriveLimiterAndPreGainEquivalence proves deriveLimiterAndPreGain returns
+// bit-identical results to the former calculateLimiterCeiling + calculatePreGain
+// pair (preserved here as refLimiterCeiling / refPreGain) across a grid of
+// (measuredI, measuredTP, targetI, targetTP), including the minLimiterCeilingDB
+// clamp boundary where the ceiling re-derivation fires.
+func TestDeriveLimiterAndPreGainEquivalence(t *testing.T) {
+	measuredIs := []float64{-55.0, -43.2, -40.0, -36.6, -33.5, -24.9, -20.0, -16.0, -12.0}
+	measuredTPs := []float64{-30.0, -20.0, -18.6, -15.0, -10.0, -6.0, -5.0, -3.0, -1.0}
+	targetIs := []float64{-16.0, -14.0}
+	targetTPs := []float64{-2.0, -1.5, -1.0}
+
+	for _, mI := range measuredIs {
+		for _, mTP := range measuredTPs {
+			for _, tI := range targetIs {
+				for _, tTP := range targetTPs {
+					wantCeiling, wantNeeded, wantClamped := refLimiterCeiling(mI, mTP, tI, tTP)
+					wantPreGainDB, wantReDerived := refPreGain(mI, tI, tTP)
+
+					got := deriveLimiterAndPreGain(mI, mTP, tI, tTP)
+
+					if got.ceiling != wantCeiling || got.needed != wantNeeded || got.clamped != wantClamped ||
+						got.preGainDB != wantPreGainDB || got.reDerivedCeiling != wantReDerived {
+						t.Errorf("deriveLimiterAndPreGain(%.2f, %.2f, %.2f, %.2f) = "+
+							"{ceiling:%v needed:%v clamped:%v preGainDB:%v reDerivedCeiling:%v}, "+
+							"want {ceiling:%v needed:%v clamped:%v preGainDB:%v reDerivedCeiling:%v}",
+							mI, mTP, tI, tTP,
+							got.ceiling, got.needed, got.clamped, got.preGainDB, got.reDerivedCeiling,
+							wantCeiling, wantNeeded, wantClamped, wantPreGainDB, wantReDerived)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestDeriveLimiterAndPreGainPinned pins the merged helper's exact expected values
+// at named points, including the clamp boundary where reDerivedCeiling fires. This
+// outlives the reference oracle: it does not depend on any pre-merge implementation.
+func TestDeriveLimiterAndPreGainPinned(t *testing.T) {
+	tests := []struct {
+		name             string
+		mI, mTP, tI, tTP float64
+		want             limiterDerivation
+	}{
+		{
+			name: "no limiting - quiet peaks",
+			mI:   -20.0, mTP: -10.0, tI: -16.0, tTP: -2.0,
+			// gain 4.0, projectedTP -6.0 <= -2.0 -> no limiting; idealCeiling -6.0 >= -24.0 -> no pre-gain
+			want: limiterDerivation{},
+		},
+		{
+			name: "limiting needed - not clamped",
+			mI:   -24.9, mTP: -5.0, tI: -16.0, tTP: -2.0,
+			// gain 8.9, projectedTP 3.9 > -2.0, ceiling -2.0 - 8.9 = -10.9 (above -24.0)
+			want: limiterDerivation{ceiling: -10.9, needed: true},
+		},
+		{
+			name: "clamped - re-derivation fires",
+			mI:   -43.2, mTP: -18.6, tI: -16.0, tTP: -2.0,
+			// gain 27.2, projectedTP 8.6 > -2.0, idealCeiling -29.2 < -24.0 -> clamped
+			// deficit -24.0 - (-29.2) = 5.2, postGainI -38.0, reDerived -2.0 - 22.0 = -24.0
+			want: limiterDerivation{ceiling: -24.0, needed: true, clamped: true, preGainDB: 5.2, reDerivedCeiling: -24.0},
+		},
+		{
+			name: "clamp boundary - ceiling equals minimum exactly, not clamped",
+			mI:   -36.6, mTP: -15.0, tI: -16.0, tTP: -2.0,
+			// gain 20.6, projectedTP 5.6 > -2.0, ceiling -22.6 (above -24.0), idealCeiling -22.6 >= -24.0
+			want: limiterDerivation{ceiling: -22.6, needed: true},
+		},
+	}
+
+	const tol = 1e-9
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveLimiterAndPreGain(tt.mI, tt.mTP, tt.tI, tt.tTP)
+			if got.needed != tt.want.needed || got.clamped != tt.want.clamped {
+				t.Fatalf("flags: got needed=%v clamped=%v, want needed=%v clamped=%v",
+					got.needed, got.clamped, tt.want.needed, tt.want.clamped)
+			}
+			if math.Abs(got.ceiling-tt.want.ceiling) > tol {
+				t.Errorf("ceiling = %v, want %v", got.ceiling, tt.want.ceiling)
+			}
+			if math.Abs(got.preGainDB-tt.want.preGainDB) > tol {
+				t.Errorf("preGainDB = %v, want %v", got.preGainDB, tt.want.preGainDB)
+			}
+			if math.Abs(got.reDerivedCeiling-tt.want.reDerivedCeiling) > tol {
+				t.Errorf("reDerivedCeiling = %v, want %v", got.reDerivedCeiling, tt.want.reDerivedCeiling)
+			}
+		})
+	}
+}
+
 func TestCalculateLimiterCeiling(t *testing.T) {
 	// Minimum ceiling is -24.0 dBTP (alimiter limit=0.0625)
 	const minCeiling = -24.0
@@ -1351,7 +1474,7 @@ func TestCalculateLimiterCeiling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ceiling, needed, clamped := calculateLimiterCeiling(
+			ceiling, needed, clamped := refLimiterCeiling(
 				tt.measuredI, tt.measuredTP, tt.targetI, tt.targetTP)
 
 			if needed != tt.wantNeeded {
@@ -1404,7 +1527,7 @@ func TestDerivedCeilingFormula(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ceiling, needed, clamped := calculateLimiterCeiling(c.filteredI, c.filteredTP, targetI, targetTP)
+			ceiling, needed, clamped := refLimiterCeiling(c.filteredI, c.filteredTP, targetI, targetTP)
 			if !needed {
 				t.Fatalf("expected limiting to be needed for filteredI=%.1f filteredTP=%.1f", c.filteredI, c.filteredTP)
 			}
@@ -1549,10 +1672,10 @@ func TestBuildLoudnormFilterSpec_PreGain(t *testing.T) {
 			}
 
 			// Pre-compute values (the caller's responsibility)
-			ceiling, needsLimiting, clamped := calculateLimiterCeiling(
+			ceiling, needsLimiting, clamped := refLimiterCeiling(
 				tt.inputI, tt.inputTP, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)
-			preGainDB, reDerivedCeiling := calculatePreGain(
+			preGainDB, reDerivedCeiling := refPreGain(
 				tt.inputI, config.Loudnorm.TargetI, config.Loudnorm.TargetTP,
 			)
 			if clamped {
@@ -1806,7 +1929,7 @@ func TestPreGainCeilingRederivation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Step 1: original values should be clamped
-			origCeiling, origNeeded, origClamped := calculateLimiterCeiling(
+			origCeiling, origNeeded, origClamped := refLimiterCeiling(
 				tt.measuredI, tt.measuredTP, tt.targetI, tt.targetTP)
 
 			if !origNeeded {
@@ -1832,7 +1955,7 @@ func TestPreGainCeilingRederivation(t *testing.T) {
 			postGainI := tt.measuredI + deficit
 			postGainTP := tt.measuredTP + deficit
 
-			newCeiling, newNeeded, newClamped := calculateLimiterCeiling(
+			newCeiling, newNeeded, newClamped := refLimiterCeiling(
 				postGainI, postGainTP, tt.targetI, tt.targetTP)
 
 			if !newNeeded {
@@ -1853,7 +1976,7 @@ func TestPreGainCeilingRederivation(t *testing.T) {
 
 func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 	// Verifies the arithmetic chain that ApplyNormalisation uses when the
-	// ceiling is clamped: calculateLimiterCeiling -> deficit -> post-gain I ->
+	// ceiling is clamped: deriveLimiterAndPreGain -> deficit -> post-gain I ->
 	// calculateLinearModeTarget -> buildLoudnormFilterSpec. Each function is
 	// called with the same inputs ApplyNormalisation would derive, confirming
 	// the full -16.0 LUFS target is preserved.
@@ -1911,8 +2034,8 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Step 1: calculateLimiterCeiling (same as ApplyNormalisation)
-			_, limiterNeeded, limiterClamped := calculateLimiterCeiling(
+			// Step 1: limiter ceiling decision (same as ApplyNormalisation)
+			_, limiterNeeded, limiterClamped := refLimiterCeiling(
 				tt.measuredI, tt.measuredTP, tt.targetI, tt.targetTP)
 
 			if !limiterNeeded {
@@ -1958,10 +2081,10 @@ func TestClampedTargetPropagation_Arithmetic(t *testing.T) {
 			}
 
 			// Pre-compute values (the caller's responsibility)
-			bCeiling, bNeeded, bClamped := calculateLimiterCeiling(
+			bCeiling, bNeeded, bClamped := refLimiterCeiling(
 				tt.measuredI, tt.measuredTP, tt.targetI, tt.targetTP,
 			)
-			preGainDB, bReDerived := calculatePreGain(
+			preGainDB, bReDerived := refPreGain(
 				tt.measuredI, tt.targetI, tt.targetTP,
 			)
 			if bClamped {
@@ -2031,7 +2154,7 @@ func TestCalculatePreGain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			preGainDB, reDerivedCeiling := calculatePreGain(tt.measuredI, tt.targetI, tt.targetTP)
+			preGainDB, reDerivedCeiling := refPreGain(tt.measuredI, tt.targetI, tt.targetTP)
 
 			if math.Abs(preGainDB-tt.wantPreGainDB) > 0.01 {
 				t.Errorf("preGainDB = %.2f, want %.2f", preGainDB, tt.wantPreGainDB)
@@ -2263,13 +2386,13 @@ func TestPlanLimiterForLoudnormMatchesInlineCalculation(t *testing.T) {
 				},
 			}
 
-			wantCeiling, wantNeeded, wantClamped := calculateLimiterCeiling(
+			wantCeiling, wantNeeded, wantClamped := refLimiterCeiling(
 				output.Loudness.OutputI,
 				output.Loudness.OutputTP,
 				config.Loudnorm.TargetI,
 				config.Loudnorm.TargetTP,
 			)
-			wantPreGainDB, reDerivedCeiling := calculatePreGain(
+			wantPreGainDB, reDerivedCeiling := refPreGain(
 				output.Loudness.OutputI,
 				config.Loudnorm.TargetI,
 				config.Loudnorm.TargetTP,

--- a/internal/processor/runrecord_units.go
+++ b/internal/processor/runrecord_units.go
@@ -134,13 +134,17 @@ func (p *noiseProfileRecord) Profile() *NoiseProfile {
 // SpectralMetrics's own mean/centroid_hz/entropy tags) so the schema is unchanged
 // after the embed. Field order and tags mirror the former flat struct exactly.
 type noiseProfileJSON struct {
-	Start              time.Duration `json:"start"`
-	Duration           time.Duration `json:"duration"`
-	MeasuredNoiseFloor float64       `json:"measured_floor_dbfs"`
-	PeakLevel          float64       `json:"peak_level_dbfs"`
-	CrestFactor        float64       `json:"crest_factor_db"`
-	Entropy            float64       `json:"entropy"`
-	ExtractionWarning  string        `json:"extraction_warning,omitempty"`
+	Start    time.Duration `json:"start"`
+	Duration time.Duration `json:"duration"`
+	// MeasuredNoiseFloor mirrors NoiseProfile.MeasuredNoiseFloor: seeded as astats
+	// RMS, then overwritten by detectVoiceActivity with the momentary-LUFS percentile
+	// floor. The measured_floor_dbfs key names dBFS but the elected value is on the
+	// momentary-LUFS axis.
+	MeasuredNoiseFloor float64 `json:"measured_floor_dbfs"`
+	PeakLevel          float64 `json:"peak_level_dbfs"`
+	CrestFactor        float64 `json:"crest_factor_db"`
+	Entropy            float64 `json:"entropy"`
+	ExtractionWarning  string  `json:"extraction_warning,omitempty"`
 
 	SpectralMean     float64 `json:"spectral_mean"`
 	SpectralVariance float64 `json:"spectral_variance"`

--- a/internal/report/definitions.go
+++ b/internal/report/definitions.go
@@ -375,10 +375,12 @@ var Definitions = map[string]Definition{
 	},
 }
 
-// requiredKeys is the set of RunRecord field names the loudness, dynamics, and
-// spectral sections emit and that MUST have a definition. The renderers and the
-// completeness test assert every key here resolves in Definitions; a missing
-// entry fails the test.
+// requiredKeys is the set of RunRecord field names the report sections emit
+// (loudness, dynamics, spectral, noise, regions, gate statistics, interval
+// summary) and that MUST have a definition. Every key routed through metricLabel
+// or unitMetricFormat now panics on a missing definition, so the completeness
+// test asserts every key here resolves in Definitions to catch a gap in CI
+// before an always-on run fails.
 var requiredKeys = []string{
 	// Loudness
 	"integrated_lufs",
@@ -419,6 +421,43 @@ var requiredKeys = []string{
 	"slope",
 	"decrease",
 	"rolloff_hz",
+
+	// Noise (input-only noise domain)
+	"floor_dbfs",
+	"floor_source",
+	"floor_prescan_dbfs",
+	"floor_astats_dbfs",
+	"room_tone_detect_level_dbfs",
+	"voice_activated",
+	"floored_fraction",
+	"reduction_headroom_db",
+
+	// Regions: gate statistics + elected profile bounds
+	"voiced_low_percentile_dbfs",
+	"noise_high_percentile_dbfs",
+	"gate_separation_db",
+	"measured_floor_dbfs",
+	"start_s",
+	"duration_s",
+	"spectral_centroid_hz",
+	"spectral_flatness",
+	"spectral_kurtosis",
+	"voicing_density",
+	"speech_band_body_rms_dbfs",
+	"speech_band_sib_rms_dbfs",
+	"score",
+	"crest_factor_db",
+
+	// Interval summary (per-250ms RMS distribution + gap)
+	"interval_count",
+	"largest_gap_db",
+	"rms_dist_min_dbfs",
+	"rms_dist_p10_dbfs",
+	"rms_dist_p25_dbfs",
+	"rms_dist_p50_dbfs",
+	"rms_dist_p75_dbfs",
+	"rms_dist_p90_dbfs",
+	"rms_dist_max_dbfs",
 }
 
 // DefinitionFor returns the objective definition for a RunRecord field name and

--- a/internal/report/definitions_test.go
+++ b/internal/report/definitions_test.go
@@ -67,6 +67,13 @@ func TestRequiredKeysCarryUnitWhereDimensioned(t *testing.T) {
 		"flux":                true,
 		"slope":               true,
 		"decrease":            true,
+		"floor_source":        true,
+		"voice_activated":     true,
+		"floored_fraction":    true,
+		"spectral_flatness":   true,
+		"spectral_kurtosis":   true,
+		"voicing_density":     true,
+		"score":               true,
 	}
 	for _, key := range requiredKeys {
 		if dimensionless[key] {

--- a/internal/report/metricrow.go
+++ b/internal/report/metricrow.go
@@ -142,14 +142,16 @@ func renderMetricTable(rows []metricRow) string {
 	return mdTable(headers, body)
 }
 
-// metricLabel returns the human-readable label for a key, falling back to the raw
-// key when no definition exists (a missing definition is caught by the
-// required-key test, not here).
+// metricLabel returns the human-readable label for a key. A missing definition
+// panics naming the key: every emitted key is in requiredKeys, and
+// TestRequiredKeysHaveDefinitions catches an uncatalogued key before an
+// always-on run reaches this path.
 func metricLabel(key string) string {
-	if d, ok := DefinitionFor(key); ok {
-		return d.Label
+	d, ok := DefinitionFor(key)
+	if !ok {
+		panic("report: metricLabel: no definition for key " + key)
 	}
-	return key
+	return d.Label
 }
 
 // metricDefinition returns the objective gloss with its unit appended in

--- a/internal/report/sections.go
+++ b/internal/report/sections.go
@@ -518,7 +518,10 @@ func metricValueRow(key string, value float64) []string {
 // classes metricValueRow routes; an unhandled unit panics so a new single-stage
 // row cannot silently mis-format (the caller picks an explicit formatter instead).
 func unitMetricFormat(key string) (metricFormat, int) {
-	d, _ := DefinitionFor(key)
+	d, ok := DefinitionFor(key)
+	if !ok {
+		panic("report: unitMetricFormat: no definition for key " + key)
+	}
 	switch d.Unit {
 	case "dBFS":
 		return fmtDB, 2

--- a/internal/report/unit_format_test.go
+++ b/internal/report/unit_format_test.go
@@ -44,3 +44,25 @@ func TestUnitMetricFormatUnroutedPanics(t *testing.T) {
 	}()
 	unitMetricFormat("interval_count")
 }
+
+// TestUnitMetricFormatUncataloguedPanics pins the no-definition panic: a key with
+// no catalogue entry must fail loudly rather than mis-format on a zero-value Unit.
+func TestUnitMetricFormatUncataloguedPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("unitMetricFormat on an uncatalogued key did not panic")
+		}
+	}()
+	unitMetricFormat("not_a_real_key")
+}
+
+// TestMetricLabelUncataloguedPanics pins the metricLabel no-definition panic: a
+// key with no catalogue entry must fail loudly rather than return the raw key.
+func TestMetricLabelUncataloguedPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("metricLabel on an uncatalogued key did not panic")
+		}
+	}()
+	metricLabel("not_a_real_key")
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -409,6 +409,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case FileStartMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
+			// Deliberate in-place write into the aliased Files backing array; safe because Bubbletea drives Update/View serially.
 			m.Files[msg.FileIndex].Status = StatusAnalysing
 			m.Files[msg.FileIndex].StartTime = time.Now()
 		}
@@ -420,6 +421,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// receipt only; the 60 fps meter tick never carries this. Sent at Pass-2
 		// start (chain + analysis) and at completion (limiter ceiling).
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
+			// Deliberate in-place write into the aliased Files backing array; safe because Bubbletea drives Update/View serially.
 			m.Files[msg.FileIndex].Summary = msg.Summary
 			// Invalidate the memoised side panels: the summary is the primary cache
 			// key, so a new one must force a re-render. joinStatusBoxes also re-checks
@@ -432,6 +434,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case FileCompleteMsg:
 		if msg.FileIndex >= 0 && msg.FileIndex < len(m.Files) {
+			// Deliberate in-place write into the aliased Files backing array; safe because Bubbletea drives Update/View serially.
 			m.Files[msg.FileIndex].Status = StatusComplete
 			m.Files[msg.FileIndex].CompletionResult = msg.CompletionResult
 


### PR DESCRIPTION
  Merge calculateLimiterCeiling and calculatePreGain into a single
  deriveLimiterAndPreGain function (bit-identical logic, no DSP change).
  Guard fmtCtx.Duration() against AV_NOPTS_VALUE sentinel to prevent
  garbage duration values. Expand metric definitions catalogue by 31 keys
  (noise, regions, gate statistics, interval summary) and add panic
  guards on metricLabel/unitMetricFormat to catch undocumented fields in CI.
  Prune duplicated rationale comments from normalise.go now superseded by
  docs/Normalisation-Tuning.md. Add serial-access invariant notes to TUI
  model. Pin gocyclo and ineffassign in builder CI. Remove three stale
  .tailor.yml entries.